### PR TITLE
Produce hierarchical dependency output

### DIFF
--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -40,7 +40,15 @@
     message: all go files
     externallinks: []
     extras: {}
+  - uri: dependency/provider/golang/provider_test.go
+    message: all go files
+    externallinks: []
+    extras: {}
   - uri: dependency/provider/java/provider.go
+    message: all go files
+    externallinks: []
+    extras: {}
+  - uri: dependency/provider/java/provider_test.go
     message: all go files
     externallinks: []
     extras: {}

--- a/dependency/main.go
+++ b/dependency/main.go
@@ -1,16 +1,33 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"os"
 
 	"github.com/konveyor/analyzer-lsp/dependency/provider/java"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	outputFile = flag.String("output", "output.yaml", "path to output file")
 )
 
 func main() {
+	flag.Parse()
+
 	p := java.GetDepProvider()
-	deps, err := p.GetDependencies("/home/shurley/repos/analyzer-lsp/examples/java/pom.xml")
+	deps, err := p.GetDependencies("../examples/java/pom.xml")
+
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("%#v", deps)
+
+	// Write results out to CLI
+	b, _ := yaml.Marshal(deps)
+	if len(deps) > 0 && err == nil {
+		fmt.Printf("%s", string(b))
+	}
+
+	os.WriteFile(*outputFile, b, 0644)
 }

--- a/dependency/provider/golang/provider.go
+++ b/dependency/provider/golang/provider.go
@@ -18,7 +18,7 @@ func GetDepProvider() provider.DependencyProvider {
 	return &depProvider{}
 }
 
-func (d *depProvider) GetDependencies(path string) ([]dependency.Dep, error) {
+func (d *depProvider) GetDependencies(path string) (map[dependency.Dep][]dependency.Dep, error) {
 	// We are going to run the graph command, and write a parser for this.
 	// This is so that we can get the tree of deps.
 
@@ -38,31 +38,84 @@ func (d *depProvider) GetDependencies(path string) ([]dependency.Dep, error) {
 	data := buf.String()
 	lines := strings.Split(data, "\n")
 
-	depsListed := []string{}
+	deps, err := parseGoDepLines(lines)
+	if err != nil {
+		return nil, err
+	}
+
+	return deps, nil
+}
+
+// parseGoDepString parses a golang dependency string
+// assumes format <dependency_name>@<version>
+func parseGoDepString(dep string) (dependency.Dep, error) {
+	d := dependency.Dep{}
+	v := strings.Split(dep, "@")
+	if len(v) != 2 {
+		return d, fmt.Errorf("failed to parse dependency string %s", dep)
+	}
+	d.Name = strings.TrimSpace(v[0])
+	d.Version = strings.TrimSpace(strings.ReplaceAll(v[1], "@", ""))
+	return d, nil
+}
+
+// parseGoDepLines parses go mod graph output
+func parseGoDepLines(lines []string) (map[dependency.Dep][]dependency.Dep, error) {
+	depsListed := map[string][]string{}
+	var root *string
+	deps := map[dependency.Dep][]dependency.Dep{}
+
 	for _, l := range lines {
 		// get all base mod deps.
 		if len(l) == 0 {
 			continue
 		}
 		values := strings.Split(l, " ")
-		if len(values) != 2 {
-			fmt.Printf("\nthis is odd and deal with it: %v", l)
+		if len(values) < 2 {
+			return deps, fmt.Errorf("failed to split dependency line '%s'", l)
 		}
-		depsListed = append(depsListed, values[1])
+
+		baseDep, nestedDep := values[0], values[1]
+		if _, ok := depsListed[baseDep]; !ok {
+			depsListed[baseDep] = make([]string, 0)
+		}
+		if _, ok := depsListed[nestedDep]; !ok {
+			depsListed[nestedDep] = make([]string, 0)
+		}
+		depsListed[baseDep] = append(depsListed[baseDep], nestedDep)
+		if root == nil {
+			root = &baseDep
+		}
 	}
 
-	deps := []dependency.Dep{}
-	for _, k := range depsListed {
-		v := strings.Split(k, "@")
-		if len(v) != 2 {
-			fmt.Printf("something went wrong")
+	if root == nil {
+		if len(lines) > 1 {
+			return deps, fmt.Errorf("failed to parse dependencies %s", strings.Join(lines, ""))
+		}
+		return deps, nil
+	}
 
+	for _, directDepString := range depsListed[*root] {
+		directDep, err := parseGoDepString(directDepString)
+		if err != nil {
+			// TODO: handle error better
+			fmt.Println(err.Error())
+			return deps, err
 		}
-		d := dependency.Dep{
-			Name:    strings.TrimSpace(v[0]),
-			Version: strings.ReplaceAll(v[1], "@", ""),
+		if _, ok := deps[directDep]; !ok {
+			deps[directDep] = make([]dependency.Dep, 0)
 		}
-		deps = append(deps, d)
+
+		// traverse the list to find all indirect deps for current dep
+		for _, indirectDepString := range depsListed[directDepString] {
+			indirectDep, err := parseGoDepString(indirectDepString)
+			if err != nil {
+				// TODO: handle error better
+				fmt.Println(err.Error())
+				return deps, err
+			}
+			deps[directDep] = append(deps[directDep], indirectDep)
+		}
 	}
 	return deps, nil
 }

--- a/dependency/provider/golang/provider_test.go
+++ b/dependency/provider/golang/provider_test.go
@@ -1,0 +1,75 @@
+package golang
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/konveyor/analyzer-lsp/dependency/dependency"
+)
+
+func Test_parseGoDepLines(t *testing.T) {
+	tests := []struct {
+		name        string
+		goDepOutput string
+		want        map[dependency.Dep][]dependency.Dep
+		wantErr     bool
+	}{
+		{
+			name:        "an empty go dep output shouldn't produce anything",
+			goDepOutput: "",
+			want:        map[dependency.Dep][]dependency.Dep{},
+			wantErr:     false,
+		},
+		{
+			name: "an invalid go dep output should produce an error",
+			goDepOutput: `invalid-dep invalid-dep
+github.com/konveyor/analyzer-lsp github.com/antchfx/xmlquery@v1.3.12
+github.com/konveyor/analyzer-lsp gopkg.in/yaml.v3@v3.0.1`,
+			want:    map[dependency.Dep][]dependency.Dep{},
+			wantErr: true,
+		},
+		{
+			name: "an invalid go dep output should produce an error",
+			goDepOutput: `github.com/konveyor/analyzer-lsp github.com/antchfx/jsonquery@v1.3.0
+github.com/konveyor/analyzer-lsp github.com/antchfx/xmlquery@v1.3.12
+github.com/konveyor/analyzer-lsp gopkg.in/yaml.v3@v3.0.1
+github.com/antchfx/jsonquery@v1.3.0 github.com/antchfx/xpath@v1.2.1
+github.com/antchfx/jsonquery@v1.3.0 github.com/golang/groupcache@v0.0.0-20200121045136-8c9f03a8e57e
+github.com/antchfx/xmlquery@v1.3.12 github.com/antchfx/xpath@v1.2.1
+github.com/antchfx/xmlquery@v1.3.12 github.com/golang/groupcache@v0.0.0-20200121045136-8c9f03a8e57e`,
+			want: map[dependency.Dep][]dependency.Dep{
+				{
+					Name:    "gopkg.in/yaml.v3",
+					Version: "v3.0.1"}: {},
+				{
+					Name:    "github.com/antchfx/jsonquery",
+					Version: "v1.3.0",
+				}: {
+					{Name: "github.com/antchfx/xpath", Version: "v1.2.1"},
+					{Name: "github.com/golang/groupcache", Version: "v0.0.0-20200121045136-8c9f03a8e57e"},
+				},
+				{
+					Name:    "github.com/antchfx/xmlquery",
+					Version: "v1.3.12",
+				}: {
+					{Name: "github.com/antchfx/xpath", Version: "v1.2.1"},
+					{Name: "github.com/golang/groupcache", Version: "v0.0.0-20200121045136-8c9f03a8e57e"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGoDepLines(strings.Split(tt.goDepOutput, "\n"))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseGoDepLines() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseGoDepLines() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/dependency/provider/java/provider_test.go
+++ b/dependency/provider/java/provider_test.go
@@ -1,0 +1,104 @@
+package java
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/konveyor/analyzer-lsp/dependency/dependency"
+)
+
+func Test_parseMavenDepLines(t *testing.T) {
+	tests := []struct {
+		name        string
+		mavenOutput string
+		wantDeps    map[dependency.Dep][]dependency.Dep
+		wantErr     bool
+	}{
+		{
+			name:        "an empty maven output should not return any dependencies",
+			mavenOutput: "",
+			wantDeps:    map[dependency.Dep][]dependency.Dep{},
+			wantErr:     false,
+		},
+		{
+			name: "an invalid maven output should return an error",
+			mavenOutput: `com.example.apps:java:jar:1.0-SNAPSHOT
++- invalid maven output
+|  \- invalid dep
++- invalid dep
+|  +- invalid dep`,
+			wantDeps: map[dependency.Dep][]dependency.Dep{},
+			wantErr:  true,
+		},
+		{
+			name: "a valid maven dependency graph must be parsed without errors",
+			mavenOutput: `com.example.apps:java:jar:1.0-SNAPSHOT
++- junit:junit:jar:4.11:test
+|  \- org.hamcrest:hamcrest-core:jar:1.3:test
++- io.fabric8:kubernetes-client:jar:6.0.0:compile
+|  +- io.fabric8:kubernetes-httpclient-okhttp:jar:6.0.0:runtime
+|  |  +- com.squareup.okhttp3:okhttp:jar:3.12.12:runtime
+|  |  |  \- com.squareup.okio:okio:jar:1.15.0:runtime
+|  |  \- com.squareup.okhttp3:logging-interceptor:jar:3.12.12:runtime
+|  \- io.fabric8:zjsonpatch:jar:0.3.0:compile`,
+			wantDeps: map[dependency.Dep][]dependency.Dep{
+				{
+					Name:     "junit.junit",
+					Version:  "4.11",
+					Location: "test",
+				}: {
+					{
+						Name:     "org.hamcrest.hamcrest-core",
+						Version:  "1.3",
+						Location: "test",
+					},
+				},
+				{
+					Name:     "io.fabric8.kubernetes-client",
+					Version:  "6.0.0",
+					Location: "compile",
+				}: {
+					{
+						Name:     "io.fabric8.kubernetes-httpclient-okhttp",
+						Version:  "6.0.0",
+						Location: "runtime",
+					},
+					{
+						Name:     "com.squareup.okhttp3.okhttp",
+						Version:  "3.12.12",
+						Location: "runtime",
+					},
+					{
+						Name:     "com.squareup.okio.okio",
+						Version:  "1.15.0",
+						Location: "runtime",
+					},
+					{
+						Name:     "com.squareup.okhttp3.logging-interceptor",
+						Version:  "3.12.12",
+						Location: "runtime",
+					},
+					{
+						Name:     "io.fabric8.zjsonpatch",
+						Version:  "0.3.0",
+						Location: "compile",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.mavenOutput, "\n")
+			deps := map[dependency.Dep][]dependency.Dep{}
+			if err := parseMavenDepLines(lines[1:], deps); (err != nil) != tt.wantErr {
+				t.Errorf("parseMavenDepLines() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.wantDeps, deps) {
+				t.Errorf("parseMavenDepLines() want %v got %v", tt.wantDeps, deps)
+			}
+		})
+	}
+}

--- a/dependency/provider/provider.go
+++ b/dependency/provider/provider.go
@@ -6,5 +6,5 @@ type DependencyProvider interface {
 	// GetDependencies will get the depdencies
 	// Path is the absolute path to the file to determine deps.
 	// In golang this is go.mod, in java pom.xml
-	GetDependencies(path string) ([]dependency.Dep, error)
+	GetDependencies(path string) (map[dependency.Dep][]dependency.Dep, error)
 }


### PR DESCRIPTION
fixes #59 

- Changes dependency provider interface to return a map of list of dependencies where each key is the direct dependency of the application and indirect dependencies form the list of values for that key. Note that transitive / indirect dependencies are flattened into a list.
- Updates golang / java dep providers to parse dependency in the expected format

In future, the same map can be used to return an adjacency list instead of an absolute list to further maintain the hierarchy within transitive / indirect deps.