### PR TITLE
:sparkles: remove chain keyword order conditions

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cbroglie/mustache"
 	"github.com/go-logr/logr"
 	"github.com/konveyor/analyzer-lsp/hubapi"
+	"github.com/konveyor/analyzer-lsp/provider/lib"
 )
 
 type RuleEngine interface {
@@ -70,7 +71,7 @@ func processRuleWorker(ctx context.Context, ruleMessages chan ruleMessage, logge
 		select {
 		case m := <-ruleMessages:
 			logger.V(5).Info("taking rule")
-			m.ctx.Template = make(map[string]interface{})
+			m.ctx.Template = make(map[string]lib.ChainTemplate)
 			bo, err := processRule(m.rule, m.ctx, logger)
 			m.returnChan <- response{
 				ConditionResponse: bo,
@@ -175,7 +176,7 @@ func (r *ruleEngine) RunRules(ctx context.Context, rules []Rule) []hubapi.Violat
 func (r *ruleEngine) runMetaRules(infoRules []Rule) ConditionContext {
 	context := ConditionContext{
 		Tags:     make(map[string]interface{}),
-		Template: make(map[string]interface{}),
+		Template: make(map[string]lib.ChainTemplate),
 	}
 	for _, rule := range infoRules {
 		response, err := processRule(rule, context, r.logger)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/go-logr/logr"
+	"github.com/konveyor/analyzer-lsp/provider/lib"
 	"github.com/sirupsen/logrus"
 )
 
@@ -69,13 +70,11 @@ func (t testChainableConditionalFrom) Ignorable() bool {
 func (t testChainableConditionalFrom) Evaluate(log logr.Logger, ctx ConditionContext) (ConditionResponse, error) {
 
 	if v, ok := ctx.Template[t.FromName]; ok {
-		if m, ok := v.(map[string]interface{}); ok {
-			if reflect.DeepEqual(m[t.DocumentedKey], t.FromValue) {
-				return ConditionResponse{
-					Matched:         true,
-					TemplateContext: map[string]interface{}{},
-				}, nil
-			}
+		if reflect.DeepEqual(v.Extras[t.DocumentedKey], t.FromValue) {
+			return ConditionResponse{
+				Matched:         true,
+				TemplateContext: map[string]interface{}{},
+			}, nil
 		}
 	}
 	return ConditionResponse{}, fmt.Errorf("unable to find from in context")
@@ -178,7 +177,7 @@ func TestEvaluateAndConditions(t *testing.T) {
 			}
 
 			ret, err := processRule(rule, ConditionContext{
-				Template: make(map[string]interface{}),
+				Template: make(map[string]lib.ChainTemplate),
 			}, log)
 			if err != nil && !tc.IsError {
 				t.Errorf("got err: %v, expected no error", err)
@@ -297,7 +296,7 @@ func TestEvaluateOrConditions(t *testing.T) {
 				When: OrCondition{tc.Conditions},
 			}
 			ret, err := processRule(rule, ConditionContext{
-				Template: make(map[string]interface{}),
+				Template: make(map[string]lib.ChainTemplate),
 			}, log)
 			if err != nil && !tc.IsError {
 				t.Errorf("got err: %v, expected no error", err)
@@ -448,7 +447,7 @@ func TestChainConditions(t *testing.T) {
 				When: OrCondition{tc.Conditions},
 			}
 			ret, err := processRule(rule, ConditionContext{
-				Template: make(map[string]interface{}),
+				Template: make(map[string]lib.ChainTemplate),
 			}, log)
 			if err != nil && !tc.IsError {
 				t.Errorf("got err: %v, expected no error", err)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -406,7 +406,7 @@ func TestChainConditions(t *testing.T) {
 						Conditions: []ConditionEntry{
 							{
 								As: "testing",
-								ProviderSpecificConfig: ChainCondition{
+								ProviderSpecificConfig: OrCondition{
 									Conditions: []ConditionEntry{
 										{
 											As: "testing",
@@ -445,7 +445,7 @@ func TestChainConditions(t *testing.T) {
 				Perform: Perform{
 					Message: &testString,
 				},
-				When: ChainCondition{tc.Conditions},
+				When: OrCondition{tc.Conditions},
 			}
 			ret, err := processRule(rule, ConditionContext{
 				Template: make(map[string]interface{}),

--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -175,19 +175,6 @@ func (r *RuleParser) LoadRule(filepath string) ([]engine.Rule, map[string]provid
 				for k, prov := range provs {
 					providers[k] = prov
 				}
-			case "chain":
-				m, ok := value.([]interface{})
-				if !ok {
-					return nil, nil, fmt.Errorf("invalid type for chain clause, must be an array")
-				}
-				conditions, provs, err := r.getConditions(m)
-				if err != nil {
-					return nil, nil, err
-				}
-				rule.When = engine.ChainCondition{Conditions: conditions}
-				for k, prov := range provs {
-					providers[k] = prov
-				}
 			case "":
 				return nil, nil, fmt.Errorf("must have at least one condition")
 			default:
@@ -312,27 +299,6 @@ func (r *RuleParser) getConditions(conditionsInterface []interface{}) ([]engine.
 					Ignorable: ignorable,
 					Not:       not,
 					ProviderSpecificConfig: engine.OrCondition{
-						Conditions: conds,
-					},
-				})
-				for k, prov := range provs {
-					providers[k] = prov
-				}
-			case "chain":
-				iConditions, ok := v.([]interface{})
-				if !ok {
-					return nil, nil, fmt.Errorf("inner condition for and is not array")
-				}
-				conds, provs, err := r.getConditions(iConditions)
-				if err != nil {
-					return nil, nil, err
-				}
-				conditions = append(conditions, engine.ConditionEntry{
-					From:      from,
-					As:        as,
-					Ignorable: ignorable,
-					Not:       not,
-					ProviderSpecificConfig: engine.ChainCondition{
 						Conditions: conds,
 					},
 				})

--- a/parser/testdata/or-and-chain-layer.yaml
+++ b/parser/testdata/or-and-chain-layer.yaml
@@ -6,7 +6,7 @@
     - and:
       - builtin.file: "*.go"
       - builtin.file: "*.json"
-    - chain:
+    - or:
       - builtin.file: "*.go"
       - builtin.file: "*.json"
     - or:

--- a/parser/testdata/rule-chain.yaml
+++ b/parser/testdata/rule-chain.yaml
@@ -2,7 +2,7 @@
 - message: all go or json files
   ruleID: file-001
   when:
-    chain:
+    or:
     - builtin.file: "*.go"
       as: go-files
       from: test-files

--- a/provider/lib/lib.go
+++ b/provider/lib/lib.go
@@ -72,9 +72,14 @@ type ExternalLinks struct {
 	Title string `yaml:"title"`
 }
 
+type ChainTemplate struct {
+	Filepaths []string               `yaml:"filepaths"`
+	Extras    map[string]interface{} `yaml:"extras"`
+}
+
 type ProviderContext struct {
-	Tags     map[string]interface{} `yaml:"tags"`
-	Template map[string]interface{} `yaml:"template"`
+	Tags     map[string]interface{}   `yaml:"tags"`
+	Template map[string]ChainTemplate `yaml:"template"`
 }
 
 func HasCapability(caps []Capability, name string) bool {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -101,7 +101,7 @@ func (p *ProviderCondition) Evaluate(log logr.Logger, ctx engine.ConditionContex
 
 }
 
-func templateCondition(condition []byte, ctx map[string]interface{}) ([]byte, error) {
+func templateCondition(condition []byte, ctx map[string]lib.ChainTemplate) ([]byte, error) {
 	//TODO(shanw-hurley):
 	// this is needed because for the initial yaml read, we convert this to a string,
 	// then when it is used here, we need the value to be whatever is in the context and not

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -17,13 +17,13 @@
   ruleID: chain-pom-001
   when:
     or:
-    - builtin.file: pom.xml
-      as: poms
-      ignore: true
     - builtin.xml:
         xpath: "//dependencies/dependency"
         filepaths: "{{poms.filepaths}}"
       from: poms
+    - builtin.file: pom.xml
+      as: poms
+      ignore: true
 - message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
   ruleID: lang-ref-001
   when:

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -16,7 +16,7 @@
 - message: '{{{matchingXML}}}'
   ruleID: chain-pom-001
   when:
-    chain:
+    or:
     - builtin.file: pom.xml
       as: poms
       ignore: true


### PR DESCRIPTION
First steps to making chaining of conditions more intuitive

1. Remove the chain keyword, Or and And do this now.
2. Ordering of from and as does not matter.


TODO: 
Adding a known struct for the output of a condition based on the incidents.
We will continue to have "extras" that will be unstructured.