### PR TITLE
:sparkles: Search for all files matching the pattern in the xml filepath

### DIFF
--- a/provider/builtin/provider.go
+++ b/provider/builtin/provider.go
@@ -185,6 +185,10 @@ func (p *builtinProvider) Evaluate(cap string, conditionInfo []byte) (lib.Provid
 			for _, pattern := range patterns {
 				files, err := findFilesMatchingPattern(p.config.Location, pattern)
 				if err != nil {
+					// Something went wrong dealing with the pattern, so we'll assume the user input
+					// is good and pass it on
+					// TODO(fabianvf): if we're ever hitting this for real we should investigate
+					fmt.Printf("Unable to resolve pattern '%s': %v", pattern, err)
 					xmlFiles = append(xmlFiles, pattern)
 				} else {
 					xmlFiles = append(xmlFiles, files...)


### PR DESCRIPTION
This means if you look for `ejb-jar.xml` for example, it would also find `/config/ejb-jar.xml`, and allows you to put wildcards etc in the filepaths. 