### PR TITLE
:bug: Handle grep exit with 1, when it does not find matches

### DIFF
--- a/provider/builtin/provider.go
+++ b/provider/builtin/provider.go
@@ -138,6 +138,9 @@ func (p *builtinProvider) Evaluate(cap string, conditionInfo []byte) (lib.Provid
 		grep := exec.Command("grep", "-o", "-n", "-R", "-E", pattern, p.config.Location)
 		outputBytes, err := grep.Output()
 		if err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 1 {
+				return response, nil
+			}
 			return response, fmt.Errorf("could not run grep with provided pattern %+v", err)
 		}
 		matches := strings.Split(strings.TrimSpace(string(outputBytes)), "\n")


### PR DESCRIPTION
Simple fix to make rule execution continue if a grep condition does not find matches