### PR TITLE
:sparkles: improve CLI for dependency generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 DOCKER_IMAGE = test
 
-build:
+build: analyzer deps
+
+analyzer:
 	go build -o konveyor-analyzer main.go
+
+deps:
+	go build -o konveyor-analyzer-dep ./dependency/main.go
 
 image-build:
 	docker build -f Dockerfile . -t $(DOCKER_IMAGE)

--- a/dependency/main.go
+++ b/dependency/main.go
@@ -5,34 +5,119 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/konveyor/analyzer-lsp/provider/java"
+	"github.com/bombsimon/logrusr/v3"
+	"github.com/konveyor/analyzer-lsp/dependency/dependency"
+	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/konveyor/analyzer-lsp/provider/lib"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
 var (
-	outputFile = flag.String("output", "output.yaml", "path to output file")
+	providerSettings = flag.String("provider-settings", "provider_settings.json", "path to provider settings file")
+	treeOutput       = flag.Bool("tree", false, "output dependencies as a tree")
+	outputFile       = flag.String("output-file", "output.yaml", "path to output file")
 )
 
 func main() {
+	logrusLog := logrus.New()
+	logrusLog.SetOutput(os.Stdout)
+	logrusLog.SetFormatter(&logrus.TextFormatter{})
+	log := logrusr.New(logrusLog)
+
 	flag.Parse()
 
-	p := java.NewJavaProvider(lib.Config{Location: "../examples/java"})
-	if !p.HasCapability("dependency") {
-		fmt.Println("Provider does not have dependency capability")
-		return
-	}
-	deps, err := p.GetDependencies()
-
+	err := validateFlags()
 	if err != nil {
-		panic(err)
+		log.Error(err, "failed to validate input flags")
+		os.Exit(1)
 	}
 
-	// Write results out to CLI
-	b, _ := yaml.Marshal(deps)
-	if len(deps) > 0 && err == nil {
-		fmt.Printf("%s", string(b))
+	providers := map[string]provider.Client{}
+
+	// Get the configs
+	configs, err := lib.GetConfig(*providerSettings)
+	if err != nil {
+		log.Error(err, "unable to get configuration")
+		os.Exit(1)
 	}
 
-	os.WriteFile(*outputFile, b, 0644)
+	for _, config := range configs {
+		provider, err := provider.GetProviderClient(config)
+		if err != nil {
+			log.Error(err, "unable to create provider client")
+			os.Exit(1)
+		}
+		providers[config.Name] = provider
+	}
+
+	var depsFlat []dependency.Dep
+	var depsTree map[dependency.Dep][]dependency.Dep
+	for name, provider := range providers {
+		if !provider.HasCapability("dependency") {
+			log.Info("provider does not have dependency capability", "provider", name)
+			continue
+		}
+
+		if *treeOutput {
+			deps, err := provider.GetDependenciesLinkedList()
+			if err != nil {
+				log.Error(err, "failed to get list of dependencies for provider", "provider", name)
+				continue
+			}
+			if depsTree == nil {
+				depsTree = make(map[dependency.Dep][]dependency.Dep)
+			}
+			for parentDep, transitiveDeps := range deps {
+				depsTree[parentDep] = transitiveDeps
+			}
+		} else {
+			deps, err := provider.GetDependencies()
+			if err != nil {
+				log.Error(err, "failed to get list of dependencies for provider", "provider", name)
+				continue
+			}
+			if depsFlat == nil {
+				depsFlat = make([]dependency.Dep, 0)
+			}
+			depsFlat = append(depsFlat, deps...)
+		}
+	}
+
+	if depsFlat == nil && depsTree == nil {
+		log.Info("failed to get dependencies from all given providers")
+		os.Exit(1)
+	}
+
+	var b []byte
+	if *treeOutput {
+		b, err = yaml.Marshal(depsTree)
+		if err != nil {
+			log.Error(err, "failed to marshal dependency data as yaml")
+			os.Exit(1)
+		}
+	} else {
+		b, err = yaml.Marshal(depsFlat)
+		if err != nil {
+			log.Error(err, "failed to marshal dependency data as yaml")
+			os.Exit(1)
+		}
+	}
+
+	fmt.Printf("%s", string(b))
+
+	err = os.WriteFile(*outputFile, b, 0644)
+	if err != nil {
+		log.Error(err, "failed to write dependencies to output file", "file", *outputFile)
+		os.Exit(1)
+	}
+}
+
+func validateFlags() error {
+	_, err := os.Stat(*providerSettings)
+	if err != nil {
+		return fmt.Errorf("unable to find provider settings file")
+	}
+
+	return nil
 }


### PR DESCRIPTION
This iterates over all providers in the config and generates dependencies using the ones that provide dep cap