### PR TITLE
:sparkles: when an invalid category, or no category is set, default it

### DIFF
--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -6,6 +6,7 @@
   violations:
     chain-pom-001:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
@@ -203,6 +204,7 @@
       effort: 3
     go-lang-ref-001:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/golang/main.go
         message: golang apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/golang/main.go:9
@@ -212,6 +214,7 @@
       extras: []
     golang-gomod-dependencies:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: dependency golang.org/x/text with v0.3.7 is bad and you should feel
@@ -234,6 +237,7 @@
       extras: []
     java-pomxml-dependencies:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency junit.junit with 4.11 is bad and you should feel bad for
@@ -250,6 +254,7 @@
       extras: []
     lang-ref-001:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
         message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions
@@ -317,6 +322,7 @@
       extras: []
     lang-ref-003:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
         message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java:2
@@ -353,6 +359,7 @@
       extras: []
     lang-ref-004:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
         message: found generic call
@@ -366,6 +373,7 @@
       extras: []
     tech-tag-001:
       description: ""
+      category: potential
       incidents:
       - uri: ""
         message: Tags [Golang Kubernetes] found
@@ -381,6 +389,7 @@
       extras: []
     xml-pom-001:
       description: ""
+      category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies

--- a/hubapi/violations.go
+++ b/hubapi/violations.go
@@ -24,9 +24,18 @@ type RuleSetTechnology struct {
 type Category string
 
 var (
-	Potential   Category = "potential"
-	Information Category = "information"
-	Mandatory   Category = "mandatory"
+	// Potential - rule states that there may be issue, but the rule author is unsure.
+	// This is used when you are trying to communicate that something may be wrong/incorrect
+	// But individual situations may require more context.
+	Potential Category = "potential"
+	// Optional - rule states that there is an issue, but that this issue can be fixed later.
+	// Primary use case is when migrating frameworks, and something has a deprecated notice,
+	// You should fix this but it wont break the migration/upgrade.
+	Optional Category = "optional"
+	// Mandatory - rule states that there is an issue that must be fixed.
+	// This is used, based on the ruleset, to tell the user that this is a real issue.
+	// For migrations, this means it must be fixed or the upgrade with fail.
+	Mandatory Category = "mandatory"
 )
 
 type Violation struct {

--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -353,16 +353,18 @@ func (r *RuleParser) addRuleFields(rule *engine.Rule, ruleMap map[string]interfa
 	}
 	rule.Description = description
 
-	category, ok := ruleMap["category"].(string)
-	if !ok {
-		r.Log.V(8).WithValues("ruleID", rule.RuleID).Info("unable to find category")
-	}
-	c := hubapi.Category(strings.ToLower(category))
-	if c != hubapi.Potential && c != hubapi.Mandatory && c != hubapi.Information {
-		r.Log.V(8).WithValues("ruleID", rule.RuleID).Info("unable to find category")
-		rule.Category = nil
-	} else {
-		rule.Category = &c
+	if rule.Perform.Message != nil {
+		category, ok := ruleMap["category"].(string)
+		if !ok {
+			r.Log.V(8).WithValues("ruleID", rule.RuleID).Info("unable to find category")
+		}
+		c := hubapi.Category(strings.ToLower(category))
+		if c != hubapi.Potential && c != hubapi.Mandatory && c != hubapi.Optional {
+			r.Log.V(8).WithValues("ruleID", rule.RuleID).Info(fmt.Sprintf("unable to find category: %v, defaulting to %v", c, hubapi.Potential))
+			rule.Category = &hubapi.Potential
+		} else {
+			rule.Category = &c
+		}
 	}
 
 	effort, ok := ruleMap["effort"].(int)

--- a/parser/rule_parser_test.go
+++ b/parser/rule_parser_test.go
@@ -128,6 +128,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoFiles},
 						},
 					},
@@ -198,6 +199,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoAndJsonFiles},
 						},
 					},
@@ -232,6 +234,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoOrJsonFiles},
 						},
 					},
@@ -266,6 +269,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoOrJsonFiles},
 						},
 					},
@@ -339,6 +343,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoOrJsonFiles},
 						},
 					},
@@ -390,6 +395,7 @@ func TestLoadRules(t *testing.T) {
 					Rules: []engine.Rule{
 						{
 							RuleID:      "file-001",
+							Category:    &hubapi.Potential,
 							Description: "",
 							Perform:     engine.Perform{Message: &allGoOrJsonFiles},
 						},
@@ -491,6 +497,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoFiles},
 						},
 					},
@@ -500,6 +507,7 @@ func TestLoadRules(t *testing.T) {
 						{
 							RuleID:      "file-001",
 							Description: "",
+							Category:    &hubapi.Potential,
 							Perform:     engine.Perform{Message: &allGoFiles},
 						},
 					},
@@ -531,6 +539,52 @@ func TestLoadRules(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "handle not-valid category",
+			testFileName: "invalid-category.yaml",
+			providerNameClient: map[string]provider.Client{
+				"builtin": testProvider{
+					caps: []lib.Capability{{
+						Name: "file",
+					}},
+				},
+				"notadded": testProvider{
+					caps: []lib.Capability{{
+						Name: "fake",
+					}},
+				},
+			},
+			ExpectedRuleSet: map[string]engine.RuleSet{
+				"konveyor-analysis": {
+					Rules: []engine.Rule{
+						{
+							RuleID: "file-001",
+							Links: []hubapi.Link{
+								{
+									URL:   "https://go.dev",
+									Title: "Golang",
+								},
+							},
+							Labels: []string{
+								"testing",
+								"test",
+							},
+							Effort:      &effort,
+							Description: "",
+							Category:    &hubapi.Potential,
+							Perform:     engine.Perform{Message: &allGoFiles},
+						},
+					},
+				},
+			},
+			ExpectedProvider: map[string]provider.Client{
+				"builtin": testProvider{
+					caps: []lib.Capability{{
+						Name: "file",
+					}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -547,15 +601,19 @@ func TestLoadRules(t *testing.T) {
 					return
 				}
 				t.Errorf("Got err: %v expected: should have error: %v or message: %v", err, tc.ShouldErr, tc.ErrorMessage)
+				return
 			}
 			if err == nil && tc.ShouldErr {
 				t.Errorf("expected error but not none")
+				return
 			}
 			if len(tc.ExpectedProvider) != 0 && len(clients) == 0 {
 				t.Errorf("unable to get correct clients")
+				return
 			}
 			if len(tc.ExpectedRuleSet) != 0 && len(ruleSets) == 0 {
 				t.Errorf("unable to get correct ruleSets")
+				return
 			}
 
 			for k, c := range clients {

--- a/parser/testdata/invalid-category.yaml
+++ b/parser/testdata/invalid-category.yaml
@@ -1,0 +1,13 @@
+---
+- message: all go files
+  ruleID: file-001
+  links:
+  - title: "Golang"
+    url: "https://go.dev"
+  labels:
+  - "testing"
+  - "test"
+  category: this-is-invalid
+  effort: 3
+  when:
+    builtin.file: "*.go"


### PR DESCRIPTION
Currently choosing to default to potential, as it has the least impact on the end user and captures the uncertainity of the default.

fixes #88 

