### PR TITLE
:bug: Decompile files into a java-project for provider to init correctly

### DIFF
--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -19,6 +19,7 @@ const (
 	JavaArchive       = ".jar"
 	WebArchive        = ".war"
 	EnterpriseArchive = ".ear"
+	ClassFile         = ".class"
 )
 
 // Rule Location to location that the bundle understands

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -161,7 +161,6 @@ func symbolKindToString(symbolKind protocol.SymbolKind) string {
 }
 
 func (p *javaProvider) ProviderInit(ctx context.Context) error {
-
 	for _, c := range p.config.InitConfig {
 		client, err := p.Init(ctx, p.Log, c)
 		if err != nil {
@@ -188,12 +187,14 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	extension := strings.ToLower(path.Ext(config.Location))
 	switch extension {
 	case JavaArchive, WebArchive, EnterpriseArchive:
-		newLocation, err := decompileJava(ctx, log, config.Location)
+		depLocation, sourceLocation, err := decompileJava(ctx, log, config.Location)
 		if err != nil {
 			cancelFunc()
 			return nil, err
 		}
-		config.Location = newLocation
+		config.Location = sourceLocation
+		// for binaries, we fallback to looking at .jar files only for deps
+		config.DependencyPath = depLocation
 	}
 	bundlesString, ok := config.ProviderSpecificConfig[BUNDLES_INIT_OPTION].(string)
 	if !ok {

--- a/provider/internal/java/util.go
+++ b/provider/internal/java/util.go
@@ -66,7 +66,7 @@ func decompile(ctx context.Context, log logr.Logger, archivePath, projectPath st
 	// Create the destDir directory using the same permissions as the Java archive file
 	// java.jar should become java-jar-decompiled
 	destDir := filepath.Join(path.Dir(archivePath), strings.Replace(path.Base(archivePath), ".", "-", -1)+"-decompiled")
-	err := os.MkdirAll(destDir, 0755)
+	err := os.MkdirAll(destDir, fileInfo.Mode()|0111)
 	if err != nil {
 		return "", err
 	}

--- a/provider/internal/java/util.go
+++ b/provider/internal/java/util.go
@@ -47,9 +47,8 @@ func decompileJava(ctx context.Context, log logr.Logger, archivePath string) (ex
 	if err != nil {
 		log.Error(err, "failed to create java project", "path", projectPath)
 		return
-	} else {
-		log.V(5).Info("created java project", "path", projectPath)
 	}
+	log.V(5).Info("created java project", "path", projectPath)
 
 	explodedPath, err = decompile(ctx, log, archivePath, projectPath)
 	if err != nil {

--- a/provider/internal/java/util.go
+++ b/provider/internal/java/util.go
@@ -13,25 +13,66 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// decompileJava is a function that extracts the contents ofa Java archive (.jar|.war|.ear) and
-// decompiles any .class files found using the fernflower decompiler and returns the path to
-// the destition directory on success, error otherwise.
-func decompileJava(ctx context.Context, log logr.Logger, location string) (string, error) {
-	// Get the permissions of the Java archive file
-	fileInfo, err := os.Stat(location)
+const javaProjectPom = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.konveyor</groupId>
+  <artifactId>java-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>java-project</name>
+  <url>http://www.konveyor.io</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+  </dependencies>
+
+  <build>
+  </build>
+</project>
+`
+
+// decompileJava unpacks archive at archivePath, decompiles all .class files in it
+// creates new java project and puts the java files in the tree of the project
+// returns path to exploded archive, path to java project, and an error when encountered
+func decompileJava(ctx context.Context, log logr.Logger, archivePath string) (explodedPath, projectPath string, err error) {
+	projectPath = filepath.Join(filepath.Dir(archivePath), "java-project")
+
+	err = createJavaProject(ctx, projectPath)
 	if err != nil {
-		return "", err
+		log.Error(err, "failed to create java project", "path", projectPath)
+		return
+	} else {
+		log.V(5).Info("created java project", "path", projectPath)
 	}
 
+	explodedPath, err = decompile(ctx, log, archivePath, projectPath)
+	if err != nil {
+		log.Error(err, "failed to decompile archive", "path", archivePath)
+		return
+	}
+
+	return
+}
+
+// decompile is a function that extracts the contents of a Java archive (.jar|.war|.ear) and
+// decompiles any .class files found using the fernflower decompiler into java project location
+// maintaining the tree. swallows decomp and copy errors, returns others
+func decompile(ctx context.Context, log logr.Logger, archivePath, projectPath string) (string, error) {
 	// Create the destDir directory using the same permissions as the Java archive file
 	// java.jar should become java-jar-decompiled
-	destDir := filepath.Join(path.Dir(location), strings.Replace(path.Base(location), ".", "-", -1) + "-decompiled")
-	err = os.MkdirAll(destDir, fileInfo.Mode())
+	destDir := filepath.Join(path.Dir(archivePath), strings.Replace(path.Base(archivePath), ".", "-", -1)+"-decompiled")
+	err := os.MkdirAll(destDir, 0755)
 	if err != nil {
 		return "", err
 	}
 
-	archive, err := zip.OpenReader(location)
+	archive, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return "", err
 	}
@@ -43,6 +84,11 @@ func decompileJava(ctx context.Context, log logr.Logger, location string) (strin
 		case <-ctx.Done():
 			return "", ctx.Err()
 		default:
+		}
+
+		// fernflower already deemed this unparsable, skip...
+		if strings.Contains(f.Name, "unparsable") || strings.Contains(f.Name, "NonParsable") {
+			continue
 		}
 
 		filePath := filepath.Join(destDir, f.Name)
@@ -72,17 +118,44 @@ func decompileJava(ctx context.Context, log logr.Logger, location string) (strin
 			return "", err
 		}
 
-		// If we found a class file, decompile it
+		// If we found a class file, decompile it to java project path
 		if strings.HasSuffix(f.Name, ".class") {
-			cmd := exec.CommandContext(ctx, "java", "-jar", "/bin/fernflower.jar", filePath, path.Dir(filePath))
+			// full path in the java project for the decompd file
+			destPath := filepath.Join(
+				projectPath, "src", "main", "java",
+				strings.Replace(filePath, destDir, "", -1))
+			destPath = strings.ReplaceAll(destPath, "WEB-INF/classes", "")
+			destPath = strings.ReplaceAll(destPath, "META-INF/classes", "")
+			if err = os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+				log.V(8).Error(err, "failed to create directories for decompiled file", "path", filepath.Dir(destPath))
+				continue
+			}
+			cmd := exec.CommandContext(
+				ctx, "java", "-jar", "/bin/fernflower.jar", filePath, path.Dir(destPath))
 			err := cmd.Run()
 			if err != nil {
-				log.Error(err, "Failed to decompile file", filePath)
+				log.Error(err, "failed to decompile file", "file", filePath)
 			} else {
-				log.Info("Decompiled file", filePath)
+				log.V(8).Info("decompiled file", "file", filePath)
+			}
+		} else if strings.HasSuffix(f.Name, ".jar") || strings.HasSuffix(f.Name, ".war") {
+			if _, err := decompile(ctx, log, filePath, projectPath); err != nil {
+				log.Error(err, "failed to decompile file", "file", filePath)
 			}
 		}
 	}
 
 	return destDir, nil
+}
+
+func createJavaProject(ctx context.Context, dir string) error {
+	err := os.MkdirAll(filepath.Join(dir, "src", "main", "java"), 0755)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filepath.Join(dir, "pom.xml"), []byte(javaProjectPom), 0755)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/provider/internal/java/util.go
+++ b/provider/internal/java/util.go
@@ -86,12 +86,13 @@ func decompile(ctx context.Context, log logr.Logger, archivePath, projectPath st
 		default:
 		}
 
+		filePath := filepath.Join(destDir, f.Name)
+
 		// fernflower already deemed this unparsable, skip...
 		if strings.Contains(f.Name, "unparsable") || strings.Contains(f.Name, "NonParsable") {
+			log.V(8).Info("unable to parse file", "file", filePath)
 			continue
 		}
-
-		filePath := filepath.Join(destDir, f.Name)
 
 		if f.FileInfo().IsDir() {
 			os.MkdirAll(filePath, f.Mode())


### PR DESCRIPTION
- Place decompiled java files in a dummy java project maintaining the directory structure for packages
- Walk and decompile all JARs/ WARs within
- Update the dependency path to point to the base of exploded app for us to get .jar names only. 