### PR TITLE
:bug: Strip line numbers from code snips before applying substring matches :bell: 

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -412,8 +412,15 @@ func (r *ruleEngine) createViolation(conditionResponse ConditionResponse, rule R
 		}
 
 		if len(rule.CustomVariables) > 0 {
+			var originalCodeSnip string
+			re := regexp.MustCompile(`^(\s*[0-9]+  )?(.*)`)
+			scanner := bufio.NewScanner(strings.NewReader(incident.CodeSnip))
+			for scanner.Scan() {
+				originalCodeSnip = originalCodeSnip + re.ReplaceAllString(scanner.Text(), "$2")
+			}
+
 			for _, cv := range rule.CustomVariables {
-				match := cv.Pattern.FindStringSubmatch(incident.CodeSnip)
+				match := cv.Pattern.FindStringSubmatch(originalCodeSnip)
 				switch len(match) {
 				case 0:
 					m.Variables[cv.Name] = cv.DefaultValue


### PR DESCRIPTION
This allows the substrings to successfully match instead of breaking them completely. Janky solution though, may be better to expand the CodeSnip interface to allow this more easily?