### PR TITLE
:ghost: Refactor Label Manipulation

### DIFF
--- a/engine/labels/labels.go
+++ b/engine/labels/labels.go
@@ -22,6 +22,14 @@ type LabelSelector[T Labeled] struct {
 	language gval.Language
 }
 
+//  Helper function to refactor key value label manipulation
+func AsString(key,value string) string{
+	if value == ""{
+		return fmt.Sprintf("%s",key)
+	}
+	return fmt.Sprintf("%s=%s",key,value)
+}
+
 func (l *LabelSelector[T]) Matches(v T) (bool, error) {
 	ruleLabels, _ := ParseLabels(v.GetLabels())
 	expr := getBooleanExpression(l.expr, ruleLabels)
@@ -192,7 +200,7 @@ func getBooleanExpression(expr string, compareLabels map[string][]string) string
 		for _, exprLabelVal := range exprLabelVals {
 			toReplace := exprLabelKey
 			if exprLabelVal != "" {
-				toReplace = fmt.Sprintf("%s=%s", toReplace, exprLabelVal)
+				toReplace = AsString(toReplace,exprLabelVal)
 			}
 			if labelVals, ok := compareLabels[exprLabelKey]; !ok {
 				replaceMap[toReplace] = "false"

--- a/engine/labels/labels.go
+++ b/engine/labels/labels.go
@@ -22,12 +22,12 @@ type LabelSelector[T Labeled] struct {
 	language gval.Language
 }
 
-//  Helper function to refactor key value label manipulation
-func AsString(key,value string) string{
-	if value == ""{
-		return fmt.Sprintf("%s",key)
+// Helper function to refactor key value label manipulation
+func AsString(key, value string) string {
+	if value == "" {
+		return fmt.Sprintf("%s", key)
 	}
-	return fmt.Sprintf("%s=%s",key,value)
+	return fmt.Sprintf("%s=%s", key, value)
 }
 
 func (l *LabelSelector[T]) Matches(v T) (bool, error) {
@@ -200,7 +200,7 @@ func getBooleanExpression(expr string, compareLabels map[string][]string) string
 		for _, exprLabelVal := range exprLabelVals {
 			toReplace := exprLabelKey
 			if exprLabelVal != "" {
-				toReplace = AsString(toReplace,exprLabelVal)
+				toReplace = AsString(toReplace, exprLabelVal)
 			}
 			if labelVals, ok := compareLabels[exprLabelKey]; !ok {
 				replaceMap[toReplace] = "false"

--- a/external-providers/golang-external-provider/pkg/golang/dependency.go
+++ b/external-providers/golang-external-provider/pkg/golang/dependency.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/konveyor/analyzer-lsp/engine/labels"
 	"github.com/konveyor/analyzer-lsp/provider"
 	"go.lsp.dev/uri"
 )
@@ -92,8 +93,8 @@ func parseGoDepString(dep string) (provider.Dep, error) {
 	d.Name = strings.TrimSpace(v[0])
 	d.Version = strings.TrimSpace(strings.ReplaceAll(v[1], "@", ""))
 	d.Labels = []string{
-		fmt.Sprintf("%v=%v", provider.DepSourceLabel, golangDownloadableDepSourceLabel),
-		fmt.Sprintf("%s=go", provider.DepLanguageLabel),
+		labels.AsString(provider.DepSourceLabel,golangDownloadableDepSourceLabel),
+		labels.AsString(provider.DepLanguageLabel,"go"),
 	}
 	return d, nil
 }

--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -282,11 +282,11 @@ func (p *javaServiceClient) addDepLabels(depName string) []string {
 	}
 	// if open source label is not found, qualify the dep as being internal by default
 	if _, openSourceLabelFound :=
-		m[ labels.AsString(provider.DepSourceLabel,javaDepSourceOpenSource)]; !openSourceLabelFound {
+		m[labels.AsString(provider.DepSourceLabel, javaDepSourceOpenSource)]; !openSourceLabelFound {
 		s = append(s,
-			labels.AsString(provider.DepSourceLabel,javaDepSourceInternal))
+			labels.AsString(provider.DepSourceLabel, javaDepSourceInternal))
 	}
-	s = append(s, labels.AsString(provider.DepLanguageLabel,"java"))
+	s = append(s, labels.AsString(provider.DepLanguageLabel, "java"))
 	return s
 }
 

--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/antchfx/xmlquery"
+	"github.com/konveyor/analyzer-lsp/engine/labels"
 	"github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/analyzer-lsp/provider"
 	"go.lsp.dev/uri"
@@ -281,11 +282,11 @@ func (p *javaServiceClient) addDepLabels(depName string) []string {
 	}
 	// if open source label is not found, qualify the dep as being internal by default
 	if _, openSourceLabelFound :=
-		m[fmt.Sprintf("%s=%s", provider.DepSourceLabel, javaDepSourceOpenSource)]; !openSourceLabelFound {
+		m[ labels.AsString(provider.DepSourceLabel,javaDepSourceOpenSource)]; !openSourceLabelFound {
 		s = append(s,
-			fmt.Sprintf("%s=%s", provider.DepSourceLabel, javaDepSourceInternal))
+			labels.AsString(provider.DepSourceLabel,javaDepSourceInternal))
 	}
-	s = append(s, fmt.Sprintf("%s=java", provider.DepLanguageLabel))
+	s = append(s, labels.AsString(provider.DepLanguageLabel,"java"))
 	return s
 }
 
@@ -368,7 +369,7 @@ func (p *javaServiceClient) initOpenSourceDepLabels() error {
 		return err
 	}
 	return loadDepLabelItems(file, p.depToLabels,
-		fmt.Sprintf("%s=%s", provider.DepSourceLabel, javaDepSourceOpenSource))
+		labels.AsString(provider.DepSourceLabel, javaDepSourceOpenSource))
 }
 
 // initExcludeDepLabels reads user provided list of excluded packages

--- a/provider/internal/java/dependency_test.go
+++ b/provider/internal/java/dependency_test.go
@@ -56,7 +56,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 						ResolvedIdentifier: "4e031bb61df09069aeb2bffb4019e7a5034a4ee0",
 						Labels: []string{
 							labels.AsString(provider.DepSourceLabel, "internal"),
-							labels.AsString(provider.DepLanguageLabel,"java"),
+							labels.AsString(provider.DepLanguageLabel, "java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/junit/junit/4.11",
 					},
@@ -70,7 +70,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "42a25dc3219429f0e5d060061f71acb49bf010a0",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/org/hamcrest/hamcrest-core/1.3",
 							},
@@ -86,7 +86,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 						ResolvedIdentifier: "d0831d44e12313df8989fc1d4a9c90452f08858e",
 						Labels: []string{
 							labels.AsString(provider.DepSourceLabel, "internal"),
-							labels.AsString(provider.DepLanguageLabel,"java"),
+							labels.AsString(provider.DepLanguageLabel, "java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-client/6.0.0",
 					},
@@ -100,7 +100,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "70690b98acb07a809c55d15d7cf45f53ec1026e1",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-httpclient-okhttp/6.0.0",
 							},
@@ -114,7 +114,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "d3e1ce1d2b3119adf270b2d00d947beb03fe3321",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/okhttp/3.12.12",
 							},
@@ -128,7 +128,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "bc28b5a964c8f5721eb58ee3f3c47a9bcbf4f4d8",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okio/okio/1.15.0",
 							},
@@ -142,7 +142,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "d952189f6abb148ff72aab246aa8c28cf99b469f",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/logging-interceptor/3.12.12",
 							},
@@ -156,7 +156,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "d3ebf0f291297649b4c8dc3ecc81d2eddedc100d",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/zjsonpatch/0.3.0",
 							},
@@ -191,7 +191,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 						ResolvedIdentifier: "4e031bb61df09069aeb2bffb4019e7a5034a4ee0",
 						Labels: []string{
 							labels.AsString(provider.DepSourceLabel, "open-source"),
-							labels.AsString(provider.DepLanguageLabel,"java"),
+							labels.AsString(provider.DepLanguageLabel, "java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/junit/junit/4.11",
 					},
@@ -204,9 +204,9 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "42a25dc3219429f0e5d060061f71acb49bf010a0",
 								Labels: []string{
-									labels.AsString(provider.DepExcludeLabel,""),
+									labels.AsString(provider.DepExcludeLabel, ""),
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/org/hamcrest/hamcrest-core/1.3",
 							},
@@ -222,7 +222,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 						ResolvedIdentifier: "d0831d44e12313df8989fc1d4a9c90452f08858e",
 						Labels: []string{
 							labels.AsString(provider.DepSourceLabel, "internal"),
-							labels.AsString(provider.DepLanguageLabel,"java"),
+							labels.AsString(provider.DepLanguageLabel, "java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-client/6.0.0",
 					},
@@ -236,7 +236,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "70690b98acb07a809c55d15d7cf45f53ec1026e1",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-httpclient-okhttp/6.0.0",
 							},
@@ -250,7 +250,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "d3e1ce1d2b3119adf270b2d00d947beb03fe3321",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/okhttp/3.12.12",
 							},
@@ -264,7 +264,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "bc28b5a964c8f5721eb58ee3f3c47a9bcbf4f4d8",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okio/okio/1.15.0",
 							},
@@ -278,7 +278,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "d952189f6abb148ff72aab246aa8c28cf99b469f",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/logging-interceptor/3.12.12",
 							},
@@ -292,7 +292,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 								ResolvedIdentifier: "d3ebf0f291297649b4c8dc3ecc81d2eddedc100d",
 								Labels: []string{
 									labels.AsString(provider.DepSourceLabel, "internal"),
-									labels.AsString(provider.DepLanguageLabel,"java"),
+									labels.AsString(provider.DepLanguageLabel, "java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/zjsonpatch/0.3.0",
 							},

--- a/provider/internal/java/dependency_test.go
+++ b/provider/internal/java/dependency_test.go
@@ -1,7 +1,6 @@
 package java
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"

--- a/provider/internal/java/dependency_test.go
+++ b/provider/internal/java/dependency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr/testr"
+	"github.com/konveyor/analyzer-lsp/engine/labels"
 	"github.com/konveyor/analyzer-lsp/provider"
 )
 
@@ -55,8 +56,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 						Indirect:           false,
 						ResolvedIdentifier: "4e031bb61df09069aeb2bffb4019e7a5034a4ee0",
 						Labels: []string{
-							fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-							fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+							labels.AsString(provider.DepSourceLabel, "internal"),
+							labels.AsString(provider.DepLanguageLabel,"java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/junit/junit/4.11",
 					},
@@ -69,8 +70,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "42a25dc3219429f0e5d060061f71acb49bf010a0",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/org/hamcrest/hamcrest-core/1.3",
 							},
@@ -85,8 +86,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 						Indirect:           false,
 						ResolvedIdentifier: "d0831d44e12313df8989fc1d4a9c90452f08858e",
 						Labels: []string{
-							fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-							fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+							labels.AsString(provider.DepSourceLabel, "internal"),
+							labels.AsString(provider.DepLanguageLabel,"java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-client/6.0.0",
 					},
@@ -99,8 +100,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "70690b98acb07a809c55d15d7cf45f53ec1026e1",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-httpclient-okhttp/6.0.0",
 							},
@@ -113,8 +114,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "d3e1ce1d2b3119adf270b2d00d947beb03fe3321",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/okhttp/3.12.12",
 							},
@@ -127,8 +128,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "bc28b5a964c8f5721eb58ee3f3c47a9bcbf4f4d8",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okio/okio/1.15.0",
 							},
@@ -141,8 +142,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "d952189f6abb148ff72aab246aa8c28cf99b469f",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/logging-interceptor/3.12.12",
 							},
@@ -155,8 +156,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "d3ebf0f291297649b4c8dc3ecc81d2eddedc100d",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/zjsonpatch/0.3.0",
 							},
@@ -190,8 +191,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 						Indirect:           false,
 						ResolvedIdentifier: "4e031bb61df09069aeb2bffb4019e7a5034a4ee0",
 						Labels: []string{
-							fmt.Sprintf("%v=open-source", provider.DepSourceLabel),
-							fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+							labels.AsString(provider.DepSourceLabel, "open-source"),
+							labels.AsString(provider.DepLanguageLabel,"java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/junit/junit/4.11",
 					},
@@ -204,9 +205,9 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "42a25dc3219429f0e5d060061f71acb49bf010a0",
 								Labels: []string{
-									fmt.Sprintf(provider.DepExcludeLabel),
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepExcludeLabel,""),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/org/hamcrest/hamcrest-core/1.3",
 							},
@@ -221,8 +222,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 						Indirect:           false,
 						ResolvedIdentifier: "d0831d44e12313df8989fc1d4a9c90452f08858e",
 						Labels: []string{
-							fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-							fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+							labels.AsString(provider.DepSourceLabel, "internal"),
+							labels.AsString(provider.DepLanguageLabel,"java"),
 						},
 						FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-client/6.0.0",
 					},
@@ -235,8 +236,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "70690b98acb07a809c55d15d7cf45f53ec1026e1",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/kubernetes-httpclient-okhttp/6.0.0",
 							},
@@ -249,8 +250,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "d3e1ce1d2b3119adf270b2d00d947beb03fe3321",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/okhttp/3.12.12",
 							},
@@ -263,8 +264,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "bc28b5a964c8f5721eb58ee3f3c47a9bcbf4f4d8",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okio/okio/1.15.0",
 							},
@@ -277,8 +278,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "d952189f6abb148ff72aab246aa8c28cf99b469f",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/com/squareup/okhttp3/logging-interceptor/3.12.12",
 							},
@@ -291,8 +292,8 @@ func Test_parseMavenDepLines(t *testing.T) {
 								Indirect:           true,
 								ResolvedIdentifier: "d3ebf0f291297649b4c8dc3ecc81d2eddedc100d",
 								Labels: []string{
-									fmt.Sprintf("%v=internal", provider.DepSourceLabel),
-									fmt.Sprintf("%s=%s", provider.DepLanguageLabel, "java"),
+									labels.AsString(provider.DepSourceLabel, "internal"),
+									labels.AsString(provider.DepLanguageLabel,"java"),
 								},
 								FileURIPrefix: "konveyor-jdt://contentstestdata/io/fabric8/zjsonpatch/0.3.0",
 							},


### PR DESCRIPTION
Pull Request: Refactor Label Manipulation

Description:
Introducing the 'formatLabel' helper function to refactor and centralize key-value label manipulation throughout the codebase. This change addresses the issue of repeated label string manipulation, enhancing code organization and maintainability.

Changes Made:

Added 'formatLabel' function to handle label key-value formatting.
Replaced instances of label construction with calls to 'formatLabel'.
Ensured consistent usage of 'formatLabel' for label manipulation.
Closes #262 