### PR TITLE
:bug: Not to fail when dependency SHA cannot be read from file.

### DIFF
--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -258,9 +258,14 @@ func (p *javaServiceClient) parseDepString(dep, localRepoPath string) (provider.
 	fp := filepath.Join(localRepoPath, strings.Replace(parts[0], ".", "/", -1), parts[1], d.Version, fmt.Sprintf("%v-%v.jar.sha1", parts[1], d.Version))
 	b, err := os.ReadFile(fp)
 	if err != nil {
-		return d, err
+		// Log the error and continue with the next dependency.
+		fmt.Printf("Error reading SHA-1 hash file for dependency %s: %s\n", dep, err)
+		// Set some default or empty resolved identifier for the dependency.
+		d.ResolvedIdentifier = ""
+	} else {
+		d.ResolvedIdentifier = string(b)
 	}
-	d.ResolvedIdentifier = string(b)
+
 	d.Labels = p.addDepLabels(d.Name)
 	d.FileURIPrefix = fmt.Sprintf("%v://contents%v", FILE_URI_PREFIX, filepath.Dir(fp))
 

--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -259,7 +259,7 @@ func (p *javaServiceClient) parseDepString(dep, localRepoPath string) (provider.
 	b, err := os.ReadFile(fp)
 	if err != nil {
 		// Log the error and continue with the next dependency.
-		fmt.Printf("Error reading SHA hash file for dependency %s: %s\n", dep, err)
+		p.log.V(7).Info("Error reading SHA hash file for dependency %s: %s\n", dep, err)
 		// Set some default or empty resolved identifier for the dependency.
 		d.ResolvedIdentifier = ""
 	} else {

--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -259,7 +259,7 @@ func (p *javaServiceClient) parseDepString(dep, localRepoPath string) (provider.
 	b, err := os.ReadFile(fp)
 	if err != nil {
 		// Log the error and continue with the next dependency.
-		p.log.V(7).Info("Error reading SHA hash file for dependency %s: %s\n", dep, err)
+		p.log.V(5).Error(err, "error reading SHA hash file for dependency", "dep", d.Name)
 		// Set some default or empty resolved identifier for the dependency.
 		d.ResolvedIdentifier = ""
 	} else {

--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -259,7 +259,7 @@ func (p *javaServiceClient) parseDepString(dep, localRepoPath string) (provider.
 	b, err := os.ReadFile(fp)
 	if err != nil {
 		// Log the error and continue with the next dependency.
-		fmt.Printf("Error reading SHA-1 hash file for dependency %s: %s\n", dep, err)
+		fmt.Printf("Error reading SHA hash file for dependency %s: %s\n", dep, err)
 		// Set some default or empty resolved identifier for the dependency.
 		d.ResolvedIdentifier = ""
 	} else {


### PR DESCRIPTION
Hey in failure scenario I set `d.ResolvedIdentifier` as an empty string (d.ResolvedIdentifier = "").
Let me know if I need to set it to any other value.
I think this is the only function that need to update maybe have to update also `parseMavenDepLines` function .. let me know if I am wrong.

Issue: #175