### PR TITLE
:sparkles: Making CodeSnips Pretty

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -462,6 +462,8 @@ func (r *ruleEngine) createViolation(conditionResponse ConditionResponse, rule R
 			}
 		}
 
+		makeCodeSnipsBlockConvertible(&incident.CodeSnip)
+
 		if rule.Perform.Message.Text != nil {
 			variables := make(map[string]interface{})
 			for key, value := range m.Variables {
@@ -556,4 +558,10 @@ func matchesAllSelectors(m RuleMeta, selectors ...RuleSelector) bool {
 		}
 	}
 	return true
+}
+
+func makeCodeSnipsBlockConvertible(codeSnip *string) {
+	// remove spaces and tabs from the beginning of each new line of codesnippet strings
+	re := regexp.MustCompile(`\n\s+`)
+	*codeSnip = re.ReplaceAllString(*codeSnip, "\n")
 }


### PR DESCRIPTION
This pull request addresses issue #241 . It aims to improve the readability of the `codeSnip` script in the output YAML. I had previously submitted a pull request (#293 ) for the same issue, but that approach was quite lengthy and unconventional. Upon further investigation into why the `codesnip` wasn't being marshaled into the desired '|' block scalar style literal, I discovered that any `\s` (whitespace) character following a `\n` (newline) caused the string to be treated as a regular string. To resolve this, I removed any spaces that appeared after the `\n` in the `incident.CodeSnip`. 
@pranavgaikwad Sir, can you please check this. 