### PR TITLE
:sparkles: Deduplicating Labels

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -491,6 +491,8 @@ func (r *ruleEngine) createViolation(conditionResponse ConditionResponse, rule R
 		}
 	}
 
+	deduplicateLabels(&rule.Labels)
+
 	return konveyor.Violation{
 		Description: rule.Description,
 		Labels:      rule.Labels,
@@ -556,4 +558,19 @@ func matchesAllSelectors(m RuleMeta, selectors ...RuleSelector) bool {
 		}
 	}
 	return true
+}
+
+func deduplicateLabels(labels *[]string) {
+	present := map[string]bool{}
+	i := 0
+
+	for _, label := range *labels {
+		if !present[label] {
+			present[label] = true
+			(*labels)[i] = label
+			i++
+		}
+	}
+
+	*labels = (*labels)[:i]
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -491,7 +491,7 @@ func (r *ruleEngine) createViolation(conditionResponse ConditionResponse, rule R
 		}
 	}
 
-	deduplicateLabels(&rule.Labels)
+	rule.Labels = deduplicateLabels(rule.Labels)
 
 	return konveyor.Violation{
 		Description: rule.Description,
@@ -560,17 +560,17 @@ func matchesAllSelectors(m RuleMeta, selectors ...RuleSelector) bool {
 	return true
 }
 
-func deduplicateLabels(labels *[]string) {
+func deduplicateLabels(labels []string) []string {
 	present := map[string]bool{}
-	i := 0
+	uniquelabels := []string{}
 
-	for _, label := range *labels {
+	for _, label := range labels {
 		if !present[label] {
 			present[label] = true
-			(*labels)[i] = label
-			i++
+			uniquelabels = append(uniquelabels, label)
 		}
 	}
 
-	*labels = (*labels)[:i]
+	return uniquelabels
+
 }


### PR DESCRIPTION
This pull request addresses issue #295.  I resolved the problem, of duplicate labels appearing both in violations and rules after adding labels from the ruleset, by introducing a function that flags all duplicate values within the labels array.
@pranavgaikwad please check.