### PR TITLE
:sparkles: Refactors code that deals with condition response and violations

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -405,15 +405,6 @@ func (r *ruleEngine) createViolation(conditionResponse ConditionResponse, rule R
 			lineNumber := *m.LineNumber
 			incident.LineNumber = &lineNumber
 		}
-		links := []konveyor.Link{}
-		if len(m.Links) > 0 {
-			for _, l := range m.Links {
-				links = append(links, konveyor.Link{
-					URL:   l.URL,
-					Title: l.Title,
-				})
-			}
-		}
 		// Some violations may not have a location in code.
 		limitSnip := (r.codeSnipLimit != 0 && fileCodeSnipCount[string(m.FileURI)] == r.codeSnipLimit)
 		if !limitSnip {


### PR DESCRIPTION
This pull request addresses issue #235 .
Removes unused code that was redundant as it's functionality was handled by other elements. Actually, the `links` field in `IncidentContext` draws it's value from `rule`, and as `rule` is also passed to `createViolations` function, we can derive the `links` in the function itself. So, the `links` field within `IncidentContext` is currently unused throughout the source code; its primary role was to transfer this value to `violations`, which is handled by `rule`. With your approval, we can safely remove this field to enhance code clarity.