### PR TITLE
:sparkles:Replacing fmt.Println with logger

### DIFF
--- a/jsonrpc2/backoff_handler.go
+++ b/jsonrpc2/backoff_handler.go
@@ -2,7 +2,6 @@ package jsonrpc2
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -129,7 +128,7 @@ func (b *BackoffHandler) Done(ctx context.Context, err error) {
 	b.failedRequestsMu.Lock()
 	// handle clean up in back off if we need to .
 	if err == nil {
-		fmt.Printf("deleting request key")
+		b.logger.V(7).Info("deleting request key")
 		delete(b.failedRequests, requestKey)
 	}
 	b.failedRequestsMu.Unlock()


### PR DESCRIPTION
This pull request corrects the typo error in backoff_handler.go by replacing ```fmt.Println("deleting request key")``` by ```b.logger.V(7).Info("deleting request key")```