### PR TITLE
:sparkles: add fallbacks for when workspace/symbol isn't giving us what we need

### DIFF
--- a/external-providers/generic-external-provider/main.go
+++ b/external-providers/generic-external-provider/main.go
@@ -35,4 +35,22 @@ func main() {
 	s := provider.NewServer(client, *port, log)
 	ctx := context.TODO()
 	s.Start(ctx)
+	// serviceClient, err := client.Init(ctx, log, provider.InitConfig{
+	// 	Location:     "/home/fabian/projects/github.com/konveyor/analyzer-lsp/examples/golang",
+	// 	AnalysisMode: "full",
+	// 	ProviderSpecificConfig: map[string]interface{}{
+	// 		"name":          "go",
+	// 		"lspServerPath": "gopls",
+	// 		"lspArgs":       []interface{}{"-vv", "-logfile", "go-debug.log", "-rpc.trace"},
+	// 	},
+	// })
+	// if err != nil {
+	// 	panic(err)
+	// }
+
+	// response, err := serviceClient.Evaluate("referenced", []byte(`{"referenced":{pattern: ".*v1beta1.CustomResourceDefinition"}}`))
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// fmt.Println(response)
 }

--- a/external-providers/generic-external-provider/pkg/generic/service_client.go
+++ b/external-providers/generic-external-provider/pkg/generic/service_client.go
@@ -141,9 +141,13 @@ func (p *genericServiceClient) GetAllSymbols(query string) []protocol.WorkspaceS
 						logger.WriteString(fmt.Sprintf("Locations: %+v\n", matchLocations))
 						for _, loc := range matchLocations {
 							logger.WriteString(fmt.Sprintf("%s, %d, %+v\n", path, lineNumber, loc))
+							absPath, err := filepath.Abs(path)
+							if err != nil {
+								logger.WriteString(err.Error() + "\n")
+							}
 							positions = append(positions, protocol.TextDocumentPositionParams{
 								TextDocument: protocol.TextDocumentIdentifier{
-									URI: fmt.Sprintf("file://%s", path),
+									URI: fmt.Sprintf("file://%s", absPath),
 								},
 								Position: protocol.Position{
 									Line:      float64(lineNumber),

--- a/external-providers/generic-external-provider/pkg/generic/service_client.go
+++ b/external-providers/generic-external-provider/pkg/generic/service_client.go
@@ -1,10 +1,14 @@
 package generic
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -45,7 +49,7 @@ func (p *genericServiceClient) Evaluate(cap string, conditionInfo []byte) (provi
 
 	incidents := []provider.IncidentContext{}
 	for _, s := range symbols {
-		references := p.GetAllReferences(s)
+		references := p.GetAllReferences(s.Location)
 		for _, ref := range references {
 			// Look for things that are in the location loaded, //Note may need to filter out vendor at some point
 			if strings.Contains(ref.URI, p.config.Location) {
@@ -75,29 +79,115 @@ func (p *genericServiceClient) Evaluate(cap string, conditionInfo []byte) (provi
 }
 
 func (p *genericServiceClient) GetAllSymbols(query string) []protocol.WorkspaceSymbol {
+	logger, err := os.OpenFile("golang-provider.log",
+		os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Println(err)
+	}
+	defer logger.Close()
 
 	wsp := &protocol.WorkspaceSymbolParams{
 		Query: query,
 	}
 
-	var refs []protocol.WorkspaceSymbol
+	var symbols []protocol.WorkspaceSymbol
 	fmt.Printf("\nrpc call\n")
-	err := p.rpc.Call(context.TODO(), "workspace/symbol", wsp, &refs)
+	logger.WriteString("\nrpc call\n")
+	err = p.rpc.Call(context.TODO(), "workspace/symbol", wsp, &symbols)
 	fmt.Printf("\nrpc called\n")
 	if err != nil {
 		fmt.Printf("\n\nerror: %v\n", err)
+		logger.WriteString(err.Error() + "\n")
 	}
-
-	return refs
+	logger.WriteString(fmt.Sprintf("First try: %+v\n", symbols))
+	regex, err := regexp.Compile(query)
+	if err != nil {
+		logger.WriteString(err.Error())
+		// Not a valid regex, can't do anything more
+		return symbols
+	}
+	if len(symbols) == 0 {
+		// Run empty string query and manually search using the query as a regex
+		var allSymbols []protocol.WorkspaceSymbol
+		err = p.rpc.Call(context.TODO(), "workspace/symbol", &protocol.WorkspaceSymbolParams{Query: ""}, &allSymbols)
+		if err != nil {
+			fmt.Printf("\n\nerror: %v\n", err)
+		}
+		for _, s := range allSymbols {
+			if regex.MatchString(s.Name) {
+				symbols = append(symbols, s)
+			}
+		}
+	}
+	logger.WriteString(fmt.Sprintf("Second try: %+v\n", symbols))
+	if len(symbols) == 0 {
+		var positions []protocol.TextDocumentPositionParams
+		// Fallback to manually searching for an occurrence and performing a GotoDefinition call
+		visit := func(path string, f os.FileInfo, err error) error {
+			logger.WriteString(fmt.Sprintf("Visiting %s\n", path))
+			if f.Mode().IsRegular() {
+				content, err := os.ReadFile(path)
+				if err != nil {
+					logger.WriteString(err.Error() + "\n")
+					return err
+				}
+				if regex.Match(content) {
+					logger.WriteString("Found a match\n")
+					// Find the exact location
+					scanner := bufio.NewScanner(strings.NewReader(string(content)))
+					lineNumber := 0
+					for scanner.Scan() {
+						matchLocations := regex.FindAllStringIndex(scanner.Text(), -1)
+						logger.WriteString(fmt.Sprintf("Locations: %+v\n", matchLocations))
+						for _, loc := range matchLocations {
+							logger.WriteString(fmt.Sprintf("%s, %d, %+v\n", path, lineNumber, loc))
+							positions = append(positions, protocol.TextDocumentPositionParams{
+								TextDocument: protocol.TextDocumentIdentifier{
+									URI: fmt.Sprintf("file://%s", path),
+								},
+								Position: protocol.Position{
+									Line:      float64(lineNumber),
+									Character: float64(loc[1]),
+								},
+							})
+						}
+						lineNumber++
+					}
+				}
+			}
+			return nil
+		}
+		err = filepath.Walk(p.config.Location, visit)
+		if err != nil {
+			logger.WriteString(err.Error() + "\n")
+			// return err
+		}
+		for _, position := range positions {
+			fmt.Println(position)
+			logger.WriteString(fmt.Sprintf("%+v\n", position))
+			res := []protocol.Location{}
+			err := p.rpc.Call(p.ctx, "textDocument/definition", position, &res)
+			if err != nil {
+				fmt.Printf("Error rpc: %v", err)
+				logger.WriteString(err.Error() + "\n")
+			}
+			logger.WriteString(fmt.Sprintf("%+v\n", res))
+			for _, r := range res {
+				symbols = append(symbols, protocol.WorkspaceSymbol{Location: r})
+			}
+			logger.WriteString(fmt.Sprintf("%+v\n", symbols))
+		}
+	}
+	return symbols
 }
 
-func (p *genericServiceClient) GetAllReferences(symbol protocol.WorkspaceSymbol) []protocol.Location {
+func (p *genericServiceClient) GetAllReferences(location protocol.Location) []protocol.Location {
 	params := &protocol.ReferenceParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{
-				URI: symbol.Location.URI,
+				URI: location.URI,
 			},
-			Position: symbol.Location.Range.Start,
+			Position: location.Range.Start,
 		},
 	}
 

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -43,12 +43,12 @@
         pattern: "*apiextensions.v1beta1.CustomResourceDefinition*"
         location: TYPE
     - go.referenced: 
-        pattern: "v1beta1.CustomResourceDefinition"
+        pattern: ".*v1beta1.CustomResourceDefinition"
 - message: 'golang apiextensions/v1/customresourcedefinitions found {{file}}:{{lineNumber}}'
   ruleID: go-lang-ref-001
   when:
     go.referenced: 
-        pattern: "v1beta1.CustomResourceDefinition"
+        pattern: ".*v1beta1.CustomResourceDefinition"
 - message: testing nested conditions
   ruleID: lang-ref-002
   when:


### PR DESCRIPTION
- ~~This is currently failing with Go for... some reason. It can't load packages anymore?~~
- ~~This is probably going to be hideously slow on large projects, the directory tree search will need to be parallelized before this is a feasible approach~~
- I haven't verified that this works with other providers. We should give the experimental python one another try