### PR TITLE
:warning: always use up-to-date context

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -8,6 +8,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: replace analyzer-lsp upstream dep from external providers
+        run: |
+          for dir in ./external-providers/*; do
+            pushd $dir &> /dev/null
+            go mod edit -replace=github.com/konveyor/analyzer-lsp=../../
+            popd &> /dev/null
+          done
+
       - name: build image
         run: podman build -t quay.io/konveyor/analyzer-lsp:latest .
 

--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -103,7 +103,7 @@ func main() {
 		}
 
 		if treeOutput {
-			deps, err := prov.GetDependenciesDAG()
+			deps, err := prov.GetDependenciesDAG(ctx)
 			if err != nil {
 				log.Error(err, "failed to get list of dependencies for provider", "provider", name)
 				continue
@@ -116,7 +116,7 @@ func main() {
 				})
 			}
 		} else {
-			deps, err := prov.GetDependencies()
+			deps, err := prov.GetDependencies(ctx)
 			if err != nil {
 				log.Error(err, "failed to get list of dependencies for provider", "provider", name)
 				continue

--- a/external-providers/generic-external-provider/go.mod
+++ b/external-providers/generic-external-provider/go.mod
@@ -38,3 +38,5 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/konveyor/analyzer-lsp => ../../

--- a/external-providers/generic-external-provider/go.mod
+++ b/external-providers/generic-external-provider/go.mod
@@ -38,5 +38,3 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/konveyor/analyzer-lsp => ../../

--- a/external-providers/generic-external-provider/pkg/generic/dependency.go
+++ b/external-providers/generic-external-provider/pkg/generic/dependency.go
@@ -1,6 +1,7 @@
 package generic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -9,7 +10,7 @@ import (
 	"go.lsp.dev/uri"
 )
 
-func (g *genericServiceClient) GetDependencies() (map[uri.URI][]*provider.Dep, error) {
+func (g *genericServiceClient) GetDependencies(ctx context.Context) (map[uri.URI][]*provider.Dep, error) {
 	cmdStr, isString := g.config.ProviderSpecificConfig["dependencyProviderPath"].(string)
 	if !isString {
 		return nil, fmt.Errorf("dependency provider path is not a string")
@@ -33,6 +34,6 @@ func (g *genericServiceClient) GetDependencies() (map[uri.URI][]*provider.Dep, e
 	return m, err
 }
 
-func (p *genericServiceClient) GetDependenciesDAG() (map[uri.URI][]provider.DepDAGItem, error) {
+func (p *genericServiceClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
 	return nil, nil
 }

--- a/external-providers/generic-external-provider/pkg/generic/provider.go
+++ b/external-providers/generic-external-provider/pkg/generic/provider.go
@@ -110,7 +110,6 @@ func (p *genericProvider) Init(ctx context.Context, log logr.Logger, c provider.
 
 	svcClient := genericServiceClient{
 		rpc:        rpc,
-		ctx:        ctx,
 		cancelFunc: cancelFunc,
 		cmd:        cmd,
 		config:     c,

--- a/parser/rule_parser_test.go
+++ b/parser/rule_parser_test.go
@@ -28,15 +28,15 @@ func (t testProvider) Init(ctx context.Context, log logr.Logger, config provider
 	return nil, nil
 }
 
-func (t testProvider) Evaluate(cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
+func (t testProvider) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
 	return provider.ProviderEvaluateResponse{}, nil
 }
 
-func (t testProvider) GetDependencies() (map[uri.URI][]*provider.Dep, error) {
+func (t testProvider) GetDependencies(ctx context.Context) (map[uri.URI][]*provider.Dep, error) {
 	return nil, nil
 }
 
-func (t testProvider) GetDependenciesDAG() (map[uri.URI][]provider.DepDAGItem, error) {
+func (t testProvider) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
 	return nil, nil
 }
 

--- a/provider/grpc/provider.go
+++ b/provider/grpc/provider.go
@@ -44,7 +44,6 @@ func NewGRPCClient(config provider.Config, log logr.Logger) *grpcProvider {
 }
 
 func (g *grpcProvider) ProviderInit(ctx context.Context) error {
-	g.ctx = ctx
 	for _, c := range g.config.InitConfig {
 		s, err := g.Init(ctx, g.log, c)
 		if err != nil {
@@ -102,22 +101,21 @@ func (g *grpcProvider) Init(ctx context.Context, log logr.Logger, config provide
 	}
 	return &grpcServiceClient{
 		id:     r.Id,
-		ctx:    ctx,
 		config: config,
 		client: g.Client,
 	}, nil
 }
 
-func (g *grpcProvider) Evaluate(cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
-	return provider.FullResponseFromServiceClients(g.serviceClients, cap, conditionInfo)
+func (g *grpcProvider) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
+	return provider.FullResponseFromServiceClients(ctx, g.serviceClients, cap, conditionInfo)
 }
 
-func (g *grpcProvider) GetDependencies() (map[uri.URI][]*provider.Dep, error) {
-	return provider.FullDepsResponse(g.serviceClients)
+func (g *grpcProvider) GetDependencies(ctx context.Context) (map[uri.URI][]*provider.Dep, error) {
+	return provider.FullDepsResponse(ctx, g.serviceClients)
 }
 
-func (g *grpcProvider) GetDependenciesDAG() (map[uri.URI][]provider.DepDAGItem, error) {
-	return provider.FullDepDAGResponse(g.serviceClients)
+func (g *grpcProvider) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
+	return provider.FullDepDAGResponse(ctx, g.serviceClients)
 }
 
 func (g *grpcProvider) Stop() {

--- a/provider/grpc/service_client.go
+++ b/provider/grpc/service_client.go
@@ -11,20 +11,19 @@ import (
 
 type grpcServiceClient struct {
 	id     int64
-	ctx    context.Context
 	config provider.InitConfig
 	client pb.ProviderServiceClient
 }
 
 var _ provider.ServiceClient = &grpcServiceClient{}
 
-func (g *grpcServiceClient) Evaluate(cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
+func (g *grpcServiceClient) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
 	m := pb.EvaluateRequest{
 		Cap:           cap,
 		ConditionInfo: string(conditionInfo),
 		Id:            g.id,
 	}
-	r, err := g.client.Evaluate(g.ctx, &m)
+	r, err := g.client.Evaluate(ctx, &m)
 	if err != nil {
 		return provider.ProviderEvaluateResponse{}, err
 	}
@@ -85,8 +84,8 @@ func (g *grpcServiceClient) Evaluate(cap string, conditionInfo []byte) (provider
 }
 
 // We don't have dependencies
-func (g *grpcServiceClient) GetDependencies() (map[uri.URI][]*provider.Dep, error) {
-	d, err := g.client.GetDependencies(g.ctx, &pb.ServiceRequest{Id: g.id})
+func (g *grpcServiceClient) GetDependencies(ctx context.Context) (map[uri.URI][]*provider.Dep, error) {
+	d, err := g.client.GetDependencies(ctx, &pb.ServiceRequest{Id: g.id})
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +139,8 @@ func recreateDAGAddedItems(items []*pb.DependencyDAGItem) []provider.DepDAGItem 
 }
 
 // We don't have dependencies
-func (g *grpcServiceClient) GetDependenciesDAG() (map[uri.URI][]provider.DepDAGItem, error) {
-	d, err := g.client.GetDependenciesDAG(g.ctx, &pb.ServiceRequest{Id: g.id})
+func (g *grpcServiceClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
+	d, err := g.client.GetDependenciesDAG(ctx, &pb.ServiceRequest{Id: g.id})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/internal/builtin/provider.go
+++ b/provider/internal/builtin/provider.go
@@ -103,14 +103,14 @@ func (p *builtinProvider) Capabilities() []provider.Capability {
 	return capabilities
 }
 
-func (p *builtinProvider) ProviderInit(context.Context) error {
+func (p *builtinProvider) ProviderInit(ctx context.Context) error {
 	// First load all the tags for all init configs.
 	for _, c := range p.config.InitConfig {
 		p.loadTags(c)
 	}
 
 	for _, c := range p.config.InitConfig {
-		client, err := p.Init(p.ctx, p.log, c)
+		client, err := p.Init(ctx, p.log, c)
 		if err != nil {
 			return nil
 		}
@@ -124,7 +124,7 @@ func (p *builtinProvider) Init(ctx context.Context, log logr.Logger, config prov
 	if config.AnalysisMode != provider.AnalysisMode("") {
 		p.log.V(5).Info("skipping analysis mode setting for builtin")
 	}
-	return &builtintServiceClient{
+	return &builtinServiceClient{
 		config:                             config,
 		tags:                               p.tags,
 		UnimplementedDependenciesComponent: provider.UnimplementedDependenciesComponent{},
@@ -157,8 +157,8 @@ func (p *builtinProvider) loadTags(config provider.InitConfig) error {
 	return nil
 }
 
-func (p *builtinProvider) Evaluate(cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
-	return provider.FullResponseFromServiceClients(p.clients, cap, conditionInfo)
+func (p *builtinProvider) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
+	return provider.FullResponseFromServiceClients(ctx, p.clients, cap, conditionInfo)
 }
 
 func (p *builtinProvider) Stop() {

--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -18,19 +19,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type builtintServiceClient struct {
+type builtinServiceClient struct {
 	config provider.InitConfig
 	tags   map[string]bool
 	provider.UnimplementedDependenciesComponent
 }
 
-var _ provider.ServiceClient = &builtintServiceClient{}
+var _ provider.ServiceClient = &builtinServiceClient{}
 
-func (p *builtintServiceClient) Stop() {
+func (p *builtinServiceClient) Stop() {
 	return
 }
 
-func (p *builtintServiceClient) Evaluate(cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
+func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
 	var cond builtinCondition
 	err := yaml.Unmarshal(conditionInfo, &cond)
 	if err != nil {

--- a/provider/internal/java/filter.go
+++ b/provider/internal/java/filter.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -61,10 +62,10 @@ func (p *javaServiceClient) filterTypesInheritance(symbols []protocol.WorkspaceS
 	return incidents, nil
 }
 
-func (p *javaServiceClient) filterTypeReferences(symbols []protocol.WorkspaceSymbol) ([]provider.IncidentContext, error) {
+func (p *javaServiceClient) filterTypeReferences(ctx context.Context, symbols []protocol.WorkspaceSymbol) ([]provider.IncidentContext, error) {
 	incidents := []provider.IncidentContext{}
 	for _, symbol := range symbols {
-		references := p.GetAllReferences(symbol)
+		references := p.GetAllReferences(ctx, symbol)
 
 		for _, ref := range references {
 			incident, err := p.convertSymbolRefToIncidentContext(symbol, ref)
@@ -106,11 +107,11 @@ func (p *javaServiceClient) filterMethodSymbols(symbols []protocol.WorkspaceSymb
 
 }
 
-func (p *javaServiceClient) filterConstructorSymbols(symbols []protocol.WorkspaceSymbol) ([]provider.IncidentContext, error) {
+func (p *javaServiceClient) filterConstructorSymbols(ctx context.Context, symbols []protocol.WorkspaceSymbol) ([]provider.IncidentContext, error) {
 
 	incidents := []provider.IncidentContext{}
 	for _, symbol := range symbols {
-		references := p.GetAllReferences(symbol)
+		references := p.GetAllReferences(ctx, symbol)
 		for _, ref := range references {
 			incident, err := p.convertSymbolRefToIncidentContext(symbol, ref)
 			if err != nil {

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -103,8 +103,8 @@ func (p *javaProvider) Capabilities() []provider.Capability {
 	return caps
 }
 
-func (p *javaProvider) Evaluate(cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
-	return provider.FullResponseFromServiceClients(p.clients, cap, conditionInfo)
+func (p *javaProvider) Evaluate(ctx context.Context, cap string, conditionInfo []byte) (provider.ProviderEvaluateResponse, error) {
+	return provider.FullResponseFromServiceClients(ctx, p.clients, cap, conditionInfo)
 }
 
 func symbolKindToString(symbolKind protocol.SymbolKind) string {
@@ -278,7 +278,6 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 
 	svcClient := javaServiceClient{
 		rpc:              rpc,
-		ctx:              ctx,
 		cancelFunc:       cancelFunc,
 		config:           config,
 		cmd:              cmd,
@@ -290,7 +289,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		mvnSettingsFile:  mavenSettingsFile,
 	}
 
-	svcClient.initialization()
+	svcClient.initialization(ctx)
 	err = svcClient.depInit()
 	if err != nil {
 		return nil, err
@@ -298,10 +297,10 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	return &svcClient, returnErr
 }
 
-func (p *javaProvider) GetDependencies() (map[uri.URI][]*provider.Dep, error) {
-	return provider.FullDepsResponse(p.clients)
+func (p *javaProvider) GetDependencies(ctx context.Context) (map[uri.URI][]*provider.Dep, error) {
+	return provider.FullDepsResponse(ctx, p.clients)
 }
 
-func (p *javaProvider) GetDependenciesDAG() (map[uri.URI][]provider.DepDAGItem, error) {
-	return provider.FullDepDAGResponse(p.clients)
+func (p *javaProvider) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
+	return provider.FullDepDAGResponse(ctx, p.clients)
 }

--- a/provider/internal/java/util.go
+++ b/provider/internal/java/util.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/konveyor/analyzer-lsp/tracing"
 )
 
 const javaProjectPom = `<?xml version="1.0" encoding="UTF-8"?>
@@ -41,6 +42,9 @@ const javaProjectPom = `<?xml version="1.0" encoding="UTF-8"?>
 // creates new java project and puts the java files in the tree of the project
 // returns path to exploded archive, path to java project, and an error when encountered
 func decompileJava(ctx context.Context, log logr.Logger, archivePath string) (explodedPath, projectPath string, err error) {
+	ctx, span := tracing.StartNewSpan(ctx, "decompile")
+	defer span.End()
+
 	projectPath = filepath.Join(filepath.Dir(archivePath), "java-project")
 
 	err = createJavaProject(ctx, projectPath)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -53,12 +53,12 @@ func init() {
 type UnimplementedDependenciesComponent struct{}
 
 // We don't have dependencies
-func (p *UnimplementedDependenciesComponent) GetDependencies() (map[uri.URI][]*Dep, error) {
+func (p *UnimplementedDependenciesComponent) GetDependencies(ctx context.Context) (map[uri.URI][]*Dep, error) {
 	return nil, nil
 }
 
 // We don't have dependencies
-func (p *UnimplementedDependenciesComponent) GetDependenciesDAG() (map[uri.URI][]DepDAGItem, error) {
+func (p *UnimplementedDependenciesComponent) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]DepDAGItem, error) {
 	return nil, nil
 }
 
@@ -236,14 +236,14 @@ func HasCapability(caps []Capability, name string) bool {
 	return false
 }
 
-func FullResponseFromServiceClients(clients []ServiceClient, cap string, conditionInfo []byte) (ProviderEvaluateResponse, error) {
+func FullResponseFromServiceClients(ctx context.Context, clients []ServiceClient, cap string, conditionInfo []byte) (ProviderEvaluateResponse, error) {
 	fullResp := ProviderEvaluateResponse{
 		Matched:         false,
 		Incidents:       []IncidentContext{},
 		TemplateContext: map[string]interface{}{},
 	}
 	for _, c := range clients {
-		r, err := c.Evaluate(cap, conditionInfo)
+		r, err := c.Evaluate(ctx, cap, conditionInfo)
 		if err != nil {
 			return fullResp, err
 		}
@@ -258,10 +258,10 @@ func FullResponseFromServiceClients(clients []ServiceClient, cap string, conditi
 	return fullResp, nil
 }
 
-func FullDepsResponse(clients []ServiceClient) (map[uri.URI][]*Dep, error) {
+func FullDepsResponse(ctx context.Context, clients []ServiceClient) (map[uri.URI][]*Dep, error) {
 	deps := map[uri.URI][]*Dep{}
 	for _, c := range clients {
-		r, err := c.GetDependencies()
+		r, err := c.GetDependencies(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -273,10 +273,10 @@ func FullDepsResponse(clients []ServiceClient) (map[uri.URI][]*Dep, error) {
 	return deps, nil
 }
 
-func FullDepDAGResponse(clients []ServiceClient) (map[uri.URI][]DepDAGItem, error) {
+func FullDepDAGResponse(ctx context.Context, clients []ServiceClient) (map[uri.URI][]DepDAGItem, error) {
 	deps := map[uri.URI][]DepDAGItem{}
 	for _, c := range clients {
-		r, err := c.GetDependenciesDAG()
+		r, err := c.GetDependenciesDAG(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -310,16 +310,16 @@ type BaseClient interface {
 
 // For some period of time during POC this will be in tree, in the future we need to write something that can do this w/ external binaries
 type ServiceClient interface {
-	Evaluate(cap string, conditionInfo []byte) (ProviderEvaluateResponse, error)
+	Evaluate(ctx context.Context, cap string, conditionInfo []byte) (ProviderEvaluateResponse, error)
 
 	Stop()
 
 	// GetDependencies will get the dependencies
 	// It is the responsibility of the provider to determine how that is done
-	GetDependencies() (map[uri.URI][]*Dep, error)
+	GetDependencies(ctx context.Context) (map[uri.URI][]*Dep, error)
 	// GetDependencies will get the dependencies and return them as a linked list
 	// Top level items are direct dependencies, the rest are indirect dependencies
-	GetDependenciesDAG() (map[uri.URI][]DepDAGItem, error)
+	GetDependenciesDAG(ctx context.Context) (map[uri.URI][]DepDAGItem, error)
 }
 
 type Dep = konveyor.Dep
@@ -358,7 +358,7 @@ func (p ProviderCondition) Ignorable() bool {
 }
 
 func (p ProviderCondition) Evaluate(ctx context.Context, log logr.Logger, condCtx engine.ConditionContext) (engine.ConditionResponse, error) {
-	_, span := tracing.StartNewSpan(
+	ctx, span := tracing.StartNewSpan(
 		ctx, "provider-condition", attribute.Key("cap").String(p.Capability))
 	defer span.End()
 
@@ -386,7 +386,7 @@ func (p ProviderCondition) Evaluate(ctx context.Context, log logr.Logger, condCt
 		panic(err)
 	}
 	span.SetAttributes(attribute.Key("condition").String(string(templatedInfo)))
-	resp, err := p.Client.Evaluate(p.Capability, templatedInfo)
+	resp, err := p.Client.Evaluate(ctx, p.Capability, templatedInfo)
 	if err != nil {
 		// If an error always just return the empty
 		return engine.ConditionResponse{}, err
@@ -394,7 +394,7 @@ func (p ProviderCondition) Evaluate(ctx context.Context, log logr.Logger, condCt
 
 	var deps map[uri.URI][]*Dep
 	if p.DepLabelSelector != nil {
-		deps, err = p.Client.GetDependencies()
+		deps, err = p.Client.GetDependencies(ctx)
 		if err != nil {
 			return engine.ConditionResponse{}, err
 		}
@@ -516,8 +516,11 @@ type DependencyCondition struct {
 }
 
 func (dc DependencyCondition) Evaluate(ctx context.Context, log logr.Logger, condCtx engine.ConditionContext) (engine.ConditionResponse, error) {
+	_, span := tracing.StartNewSpan(ctx, "dep-condition")
+	defer span.End()
+
 	resp := engine.ConditionResponse{}
-	deps, err := dc.Client.GetDependencies()
+	deps, err := dc.Client.GetDependencies(ctx)
 	if err != nil {
 		return resp, err
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -20,7 +20,7 @@ type fakeClient struct {
 
 func (c *fakeClient) Capabilities() []Capability { return nil }
 func (c *fakeClient) HasCapability(string) bool  { return true }
-func (c *fakeClient) Evaluate(string, []byte) (ProviderEvaluateResponse, error) {
+func (c *fakeClient) Evaluate(context.Context, string, []byte) (ProviderEvaluateResponse, error) {
 	return ProviderEvaluateResponse{}, nil
 }
 func (c *fakeClient) Init(context.Context, logr.Logger, InitConfig) (ServiceClient, error) {
@@ -28,14 +28,14 @@ func (c *fakeClient) Init(context.Context, logr.Logger, InitConfig) (ServiceClie
 }
 func (c *fakeClient) Stop() {}
 
-func (c *fakeClient) GetDependencies() (map[uri.URI][]*Dep, error) {
+func (c *fakeClient) GetDependencies(ctx context.Context) (map[uri.URI][]*Dep, error) {
 	m := map[uri.URI][]*Dep{
 		uri.URI("test"): c.dependencies,
 	}
 	return m, nil
 }
 
-func (c *fakeClient) GetDependenciesDAG() (map[uri.URI][]DepDAGItem, error) {
+func (c *fakeClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]DepDAGItem, error) {
 	return nil, nil
 }
 

--- a/provider/server.go
+++ b/provider/server.go
@@ -139,7 +139,7 @@ func (s *server) Evaluate(ctx context.Context, req *libgrpc.EvaluateRequest) (*l
 	client := s.clients[req.Id]
 	s.mutex.RUnlock()
 
-	r, err := client.client.Evaluate(req.Cap, []byte(req.ConditionInfo))
+	r, err := client.client.Evaluate(ctx, req.Cap, []byte(req.ConditionInfo))
 
 	if err != nil {
 		return &libgrpc.EvaluateResponse{
@@ -229,7 +229,7 @@ func (s *server) GetDependencies(ctx context.Context, in *libgrpc.ServiceRequest
 	s.mutex.RLock()
 	client := s.clients[in.Id]
 	s.mutex.RUnlock()
-	deps, err := client.client.GetDependencies()
+	deps, err := client.client.GetDependencies(ctx)
 	if err != nil {
 		return &libgrpc.DependencyResponse{
 			Successful: false,
@@ -297,7 +297,7 @@ func (s *server) GetDependenciesLinkedList(ctx context.Context, in *libgrpc.Serv
 	s.mutex.RLock()
 	client := s.clients[in.Id]
 	s.mutex.RUnlock()
-	deps, err := client.client.GetDependenciesDAG()
+	deps, err := client.client.GetDependenciesDAG(ctx)
 	if err != nil {
 		return &libgrpc.DependencyDAGResponse{
 			Successful: false,


### PR DESCRIPTION
We were using stale context. I observed it when looking at tracer output, some spans were being recorded in the scope of main context, instead of their provider specific context. 

:warning: changes provider api