### PR TITLE
:ghost: only decompile when directory doesnt exist

### DIFF
--- a/provider/internal/java/filter.go
+++ b/provider/internal/java/filter.go
@@ -229,7 +229,9 @@ func (p *javaServiceClient) getURI(refURI string) (uri.URI, error) {
 
 	javaFileAbsolutePath := filepath.Join(filepath.Dir(jarPath), filepath.Dir(path), javaFileName)
 
-	if _, err := os.Stat(javaFileAbsolutePath); err != nil {
+	// attempt to decompile when directory for the expected java file doesn't exist
+	// if directory exists, assume .java file is present within, this avoids decompiling every Jar
+	if _, err := os.Stat(filepath.Dir(javaFileAbsolutePath)); err != nil {
 		cmd := exec.Command("jar", "xf", filepath.Base(jarPath))
 		cmd.Dir = filepath.Dir(jarPath)
 		err := cmd.Run()


### PR DESCRIPTION
Since we moved the decompilation into filter.go, we are now decompiling prior to filtering the incidents out. In that case, for files with .groovy, .kotlin etc, we are decompiling unnecessarily multiple times without knowing that we are anyway going to fail getting incidents from them later on. This was causing some shim tests to take awful lot of time.