### PR TITLE
:sparkles: Identify interesting Jars to decomp and improve decomp performance

### DIFF
--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -78,12 +78,12 @@ func (p *javaServiceClient) GetDependencies(ctx context.Context) (map[uri.URI][]
 	return m, nil
 }
 
-func (p *javaServiceClient) getLocalRepoPath() string {
+func getMavenLocalRepoPath(mvnSettingsFile string) string {
 	args := []string{
 		"help:evaluate", "-Dexpression=settings.localRepository", "-q", "-DforceStdout",
 	}
-	if p.mvnSettingsFile != "" {
-		args = append(args, "-s", p.mvnSettingsFile)
+	if mvnSettingsFile != "" {
+		args = append(args, "-s", mvnSettingsFile)
 	}
 	cmd := exec.Command("mvn", args...)
 	var outb bytes.Buffer
@@ -147,7 +147,7 @@ func (p *javaServiceClient) GetDependencyFallback(ctx context.Context) (map[uri.
 }
 
 func (p *javaServiceClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
-	localRepoPath := p.getLocalRepoPath()
+	localRepoPath := getMavenLocalRepoPath(p.mvnSettingsFile)
 
 	path := p.findPom()
 	file := uri.File(path)

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -325,6 +325,7 @@ func resolveSourcesJars(ctx context.Context, log logr.Logger, location, mavenSet
 	if err != nil {
 		return err
 	}
+	defer mvnOutput.Close()
 	args := []string{
 		"dependency:sources",
 		"-Djava.net.useSystemProxies=true",

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	JavaFile          = ".java"
 	JavaArchive       = ".jar"
 	WebArchive        = ".war"
 	EnterpriseArchive = ".ear"

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -227,17 +227,15 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		config.Location = sourceLocation
 		// for binaries, we fallback to looking at .jar files only for deps
 		config.DependencyPath = depLocation
-		// for binaries, always run in source-only mode as we don't know how to correctly resolve deps
-		config.AnalysisMode = provider.SourceOnlyAnalysisMode
 		isBinary = true
-	default:
-		// when location points to source code, we attempt to decompile
-		// JARs of dependencies that don't have a sources JAR attached
-		err := resolveSourcesJars(ctx, log, config.Location, mavenSettingsFile)
-		if err != nil {
-			// TODO (pgaikwad): should we ignore this failure?
-			log.Error(err, "failed to resolve sources jar for location", "location", config.Location)
-		}
+	}
+
+	// we attempt to decompile JARs of dependencies that don't have a sources JAR attached
+	// we need to do this for jdtls to correctly recognize source attachment for dep
+	err := resolveSourcesJars(ctx, log, config.Location, mavenSettingsFile)
+	if err != nil {
+		// TODO (pgaikwad): should we ignore this failure?
+		log.Error(err, "failed to resolve sources jar for location", "location", config.Location)
 	}
 
 	// handle proxy settings

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -348,15 +348,15 @@ func resolveSourcesJars(ctx context.Context, log logr.Logger, location, mavenSet
 		return nil
 	}
 	for _, artifact := range artifacts {
-		groupDirs := filepath.Join(strings.Split(artifact.groupId, ".")...)
-		artifactDirs := filepath.Join(strings.Split(artifact.artifactId, ".")...)
-		jarName := fmt.Sprintf("%s-%s.jar", artifact.artifactId, artifact.version)
+		groupDirs := filepath.Join(strings.Split(artifact.GroupId, ".")...)
+		artifactDirs := filepath.Join(strings.Split(artifact.ArtifactId, ".")...)
+		jarName := fmt.Sprintf("%s-%s.jar", artifact.ArtifactId, artifact.Version)
 		decompileJobs = append(decompileJobs, decompileJob{
 			artifact: artifact,
 			inputPath: filepath.Join(
-				m2Repo, groupDirs, artifactDirs, artifact.version, jarName),
+				m2Repo, groupDirs, artifactDirs, artifact.Version, jarName),
 			outputPath: filepath.Join(
-				m2Repo, groupDirs, artifactDirs, artifact.version, "decompiled", jarName),
+				m2Repo, groupDirs, artifactDirs, artifact.Version, "decompiled", jarName),
 		})
 	}
 	err = decompile(ctx, log, alwaysDecompileFilter(true), 10, decompileJobs, "")
@@ -393,9 +393,9 @@ func parseUnresolvedSources(output io.Reader) ([]javaArtifact, error) {
 			artifacts = append(artifacts,
 				javaArtifact{
 					packaging:  JavaArchive,
-					artifactId: artifactId,
-					groupId:    groupId,
-					version:    version,
+					ArtifactId: artifactId,
+					GroupId:    groupId,
+					Version:    version,
 				})
 		}
 	}

--- a/provider/internal/java/provider_test.go
+++ b/provider/internal/java/provider_test.go
@@ -26,9 +26,9 @@ The following files have NOT been resolved:
 			wantList: []javaArtifact{
 				{
 					packaging:  JavaArchive,
-					groupId:    "io.konveyor.demo",
-					artifactId: "config-utils",
-					version:    "1.0.0",
+					GroupId:    "io.konveyor.demo",
+					ArtifactId: "config-utils",
+					Version:    "1.0.0",
 				},
 			},
 		},

--- a/provider/internal/java/provider_test.go
+++ b/provider/internal/java/provider_test.go
@@ -1,0 +1,43 @@
+package java
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_parseUnresolvedSources(t *testing.T) {
+	tests := []struct {
+		name      string
+		mvnOutput string
+		wantErr   bool
+		wantList  []string
+	}{
+		{
+			name: "valid sources output",
+			mvnOutput: `
+The following files have been resolved:
+   org.springframework.boot:spring-boot:jar:sources:2.5.0:compile
+
+The following files have NOT been resolved:
+   io.konveyor.demo:config-utils:jar:sources:1.0.0:compile
+`,
+			wantErr: false,
+			wantList: []string{
+				"io/konveyor/demo/config-utils/1.0.0/config-utils-1.0.0.jar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outputReader := strings.NewReader(tt.mvnOutput)
+			gotList, gotErr := parseUnresolvedSources(outputReader)
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("parseUnresolvedSources() gotErr = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+			if !reflect.DeepEqual(gotList, tt.wantList) {
+				t.Errorf("parseUnresolvedSources() gotList = %v, wantList %v", gotList, tt.wantList)
+			}
+		})
+	}
+}

--- a/provider/internal/java/provider_test.go
+++ b/provider/internal/java/provider_test.go
@@ -11,7 +11,7 @@ func Test_parseUnresolvedSources(t *testing.T) {
 		name      string
 		mvnOutput string
 		wantErr   bool
-		wantList  []string
+		wantList  []javaArtifact
 	}{
 		{
 			name: "valid sources output",
@@ -23,8 +23,13 @@ The following files have NOT been resolved:
    io.konveyor.demo:config-utils:jar:sources:1.0.0:compile
 `,
 			wantErr: false,
-			wantList: []string{
-				"io/konveyor/demo/config-utils/1.0.0/config-utils-1.0.0.jar",
+			wantList: []javaArtifact{
+				{
+					packaging:  JavaArchive,
+					groupId:    "io.konveyor.demo",
+					artifactId: "config-utils",
+					version:    "1.0.0",
+				},
 			},
 		},
 	}

--- a/provider/internal/java/service_client.go
+++ b/provider/internal/java/service_client.go
@@ -19,7 +19,6 @@ import (
 
 type javaServiceClient struct {
 	rpc              *jsonrpc2.Conn
-	ctx              context.Context
 	cancelFunc       context.CancelFunc
 	config           provider.InitConfig
 	log              logr.Logger

--- a/provider/internal/java/util.go
+++ b/provider/internal/java/util.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bufio"
 	"context"
-	"encoding/xml"
 	"fmt"
 	"io"
 	"math"
@@ -14,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"text/template"
 
 	"github.com/go-logr/logr"
 	"github.com/konveyor/analyzer-lsp/engine/labels"
@@ -38,6 +38,13 @@ const javaProjectPom = `<?xml version="1.0" encoding="UTF-8"?>
   </properties>
 
   <dependencies>
+{{range .}}
+    <dependency>
+      <groupId>{{.GroupId}}</groupId>
+      <artifactId>{{.ArtifactId}}</artifactId>
+      <version>{{.Version}}</version>
+    </dependency>
+{{end}}
   </dependencies>
 
   <build>
@@ -47,9 +54,9 @@ const javaProjectPom = `<?xml version="1.0" encoding="UTF-8"?>
 
 type javaArtifact struct {
 	packaging  string
-	groupId    string
-	artifactId string
-	version    string
+	GroupId    string
+	ArtifactId string
+	Version    string
 }
 
 type decompileFilter interface {
@@ -65,7 +72,7 @@ func (a alwaysDecompileFilter) shouldDecompile(j javaArtifact) bool {
 type excludeOpenSourceDecompileFilter map[string]*depLabelItem
 
 func (o excludeOpenSourceDecompileFilter) shouldDecompile(j javaArtifact) bool {
-	matchWith := fmt.Sprintf("%s.%s", j.groupId, j.artifactId)
+	matchWith := fmt.Sprintf("%s.%s", j.GroupId, j.ArtifactId)
 	for _, r := range o {
 		if r.r.MatchString(matchWith) {
 			if _, ok := r.labels[labels.AsString(provider.DepSourceLabel, javaDepSourceOpenSource)]; ok {
@@ -122,8 +129,9 @@ func decompile(ctx context.Context, log logr.Logger, filter decompileFilter, wor
 				}
 				// if we just decompiled a java archive, we need to
 				// explode it further and copy files to project
+				// TODO(djzager): should we grab deps?
 				if job.artifact.packaging == JavaArchive && projectPath != "" {
-					_, _, err = explode(ctx, log, job.outputPath, projectPath)
+					_, _, _, err = explode(ctx, log, job.outputPath, projectPath)
 					if err != nil {
 						log.V(5).Error(err, "failed to explode decompiled jar", "path", job.inputPath)
 					}
@@ -152,20 +160,20 @@ func decompileJava(ctx context.Context, log logr.Logger, archivePath string) (ex
 
 	projectPath = filepath.Join(filepath.Dir(archivePath), "java-project")
 
-	err = createJavaProject(ctx, projectPath)
+	decompFilter := alwaysDecompileFilter(true)
+
+	explodedPath, decompJobs, deps, err := explode(ctx, log, archivePath, projectPath)
+	if err != nil {
+		log.Error(err, "failed to decompile archive", "path", archivePath)
+		return "", "", err
+	}
+
+	err = createJavaProject(ctx, projectPath, deps)
 	if err != nil {
 		log.Error(err, "failed to create java project", "path", projectPath)
 		return "", "", err
 	}
 	log.V(5).Info("created java project", "path", projectPath)
-
-	decompFilter := alwaysDecompileFilter(true)
-
-	explodedPath, decompJobs, err := explode(ctx, log, archivePath, projectPath)
-	if err != nil {
-		log.Error(err, "failed to decompile archive", "path", archivePath)
-		return "", "", err
-	}
 
 	err = decompile(context.TODO(), log, decompFilter, 10, decompJobs, projectPath)
 	if err != nil {
@@ -177,12 +185,12 @@ func decompileJava(ctx context.Context, log logr.Logger, archivePath string) (ex
 }
 
 // explode explodes the given JAR, WAR or EAR archive, generates javaArtifact struct for given archive
-// and identifies all .class found recursively. returns output path, a list of decompileJob for .class & .jar files
-// .jar files will only be added as decompileJob when we are unable to add them to project's pom file
-func explode(ctx context.Context, log logr.Logger, archivePath, projectPath string) (string, []decompileJob, error) {
+// and identifies all .class found recursively. returns output path, a list of decompileJob for .class files
+func explode(ctx context.Context, log logr.Logger, archivePath, projectPath string) (string, []decompileJob, []javaArtifact, error) {
+	var dependencies []javaArtifact
 	fileInfo, err := os.Stat(archivePath)
 	if err != nil {
-		return "", nil, err
+		return "", nil, dependencies, err
 	}
 
 	// Create the destDir directory using the same permissions as the Java archive file
@@ -191,12 +199,12 @@ func explode(ctx context.Context, log logr.Logger, archivePath, projectPath stri
 	// make sure execute bits are set so that fernflower can decompile
 	err = os.MkdirAll(destDir, fileInfo.Mode()|0111)
 	if err != nil {
-		return "", nil, err
+		return "", nil, dependencies, err
 	}
 
 	archive, err := zip.OpenReader(archivePath)
 	if err != nil {
-		return "", nil, err
+		return "", nil, dependencies, err
 	}
 	defer archive.Close()
 
@@ -206,7 +214,7 @@ func explode(ctx context.Context, log logr.Logger, archivePath, projectPath stri
 		// Stop processing if our context is cancelled
 		select {
 		case <-ctx.Done():
-			return "", decompileJobs, ctx.Err()
+			return "", decompileJobs, dependencies, ctx.Err()
 		default:
 		}
 
@@ -225,23 +233,23 @@ func explode(ctx context.Context, log logr.Logger, archivePath, projectPath stri
 		}
 
 		if err = os.MkdirAll(filepath.Dir(filePath), f.Mode()|0111); err != nil {
-			return "", decompileJobs, err
+			return "", decompileJobs, dependencies, err
 		}
 
 		dstFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode()|0111)
 		if err != nil {
-			return "", decompileJobs, err
+			return "", decompileJobs, dependencies, err
 		}
 		defer dstFile.Close()
 
 		archiveFile, err := f.Open()
 		if err != nil {
-			return "", decompileJobs, err
+			return "", decompileJobs, dependencies, err
 		}
 		defer archiveFile.Close()
 
 		if _, err := io.Copy(dstFile, archiveFile); err != nil {
-			return "", decompileJobs, err
+			return "", decompileJobs, dependencies, err
 		}
 		switch {
 		// when it's a .class file, decompile it into java project
@@ -279,14 +287,15 @@ func explode(ctx context.Context, log logr.Logger, archivePath, projectPath stri
 			}
 		// decompile web archives
 		case strings.HasSuffix(f.Name, WebArchive):
-			_, nestedJobs, err := explode(ctx, log, filePath, projectPath)
+			// TODO(djzager): Should we add these deps to the pom?
+			_, nestedJobs, _, err := explode(ctx, log, filePath, projectPath)
 			if err != nil {
 				log.Error(err, "failed to decompile file", "file", filePath)
 			}
 			decompileJobs = append(decompileJobs, nestedJobs...)
-		// nested JARs won't be exploded further, they will be decompiled as whole
+		// attempt to add nested jars as dependency before decompiling
 		case strings.HasSuffix(f.Name, JavaArchive):
-			artifact, err := addProjectDep(ctx, filepath.Join(projectPath, "pom.xml"), filePath)
+			dep, err := toDependency(ctx, filePath)
 			if err != nil {
 				log.Error(err, "failed to add dep", "file", filePath)
 				// when we fail to identify a dep we will fallback to
@@ -294,28 +303,40 @@ func explode(ctx context.Context, log logr.Logger, archivePath, projectPath stri
 				outputPath := filepath.Join(
 					filepath.Dir(filePath), fmt.Sprintf("%s-decompiled",
 						strings.TrimSuffix(f.Name, JavaArchive)), filepath.Base(f.Name))
+				// TODO(djzager): Is it possible for the
 				decompileJobs = append(decompileJobs, decompileJob{
 					inputPath:  filePath,
 					outputPath: outputPath,
 					artifact: javaArtifact{
 						packaging:  JavaArchive,
-						groupId:    artifact.groupId,
-						artifactId: artifact.artifactId,
+						GroupId:    dep.GroupId,
+						ArtifactId: dep.ArtifactId,
 					},
 				})
+			}
+			if (dep != javaArtifact{}) {
+				dependencies = append(dependencies, dep)
 			}
 		}
 	}
 
-	return destDir, decompileJobs, nil
+	return destDir, decompileJobs, dependencies, nil
 }
 
-func createJavaProject(ctx context.Context, dir string) error {
+func createJavaProject(ctx context.Context, dir string, dependencies []javaArtifact) error {
+	tmpl := template.Must(template.New("javaProjectPom").Parse(javaProjectPom))
+
 	err := os.MkdirAll(filepath.Join(dir, "src", "main", "java"), 0755)
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Join(dir, "pom.xml"), []byte(javaProjectPom), 0755)
+
+	pom, err := os.OpenFile(filepath.Join(dir, "pom.xml"), os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+
+	err = tmpl.Execute(pom, dependencies)
 	if err != nil {
 		return err
 	}
@@ -345,23 +366,7 @@ func moveFile(srcPath string, destPath string) error {
 	return nil
 }
 
-type project struct {
-	XMLName    xml.Name     `xml:"project"`
-	Dependency dependencies `xml:"dependencies"`
-}
-
-type dependencies struct {
-	XMLName    xml.Name     `xml:"dependencies"`
-	Dependency []dependency `xml:"dependency"`
-}
-
-type dependency struct {
-	GroupID    string `xml:"groupId"`
-	ArtifactID string `xml:"artifactId"`
-	Version    string `xml:"version"`
-}
-
-func addProjectDep(ctx context.Context, pomFile string, jarFile string) (javaArtifact, error) {
+func toDependency(ctx context.Context, jarFile string) (javaArtifact, error) {
 	dep := javaArtifact{}
 	jar, err := zip.OpenReader(jarFile)
 	if err != nil {
@@ -388,36 +393,17 @@ func addProjectDep(ctx context.Context, pomFile string, jarFile string) (javaArt
 			for scanner.Scan() {
 				line := scanner.Text()
 				if strings.HasPrefix(line, "version=") {
-					dep.version = strings.TrimSpace(strings.TrimPrefix(line, "version="))
+					dep.Version = strings.TrimSpace(strings.TrimPrefix(line, "version="))
 				} else if strings.HasPrefix(line, "artifactId=") {
-					dep.artifactId = strings.TrimSpace(strings.TrimPrefix(line, "artifactId="))
+					dep.ArtifactId = strings.TrimSpace(strings.TrimPrefix(line, "artifactId="))
 				} else if strings.HasPrefix(line, "groupId=") {
-					dep.groupId = strings.TrimSpace(strings.TrimPrefix(line, "groupId="))
+					dep.GroupId = strings.TrimSpace(strings.TrimPrefix(line, "groupId="))
 				}
 			}
 
-			// Read the pom
-			content, err := os.ReadFile(pomFile)
-			if err != nil {
-				return dep, err
-			}
-
-			// Unmarshal the existing pom.xml content into a Project struct
-			var project project
-			if err := xml.Unmarshal(content, &project); err != nil {
-				return dep, err
-			}
-			project.Dependency.Dependency = append(project.Dependency.Dependency, dependency{GroupID: dep.groupId, ArtifactID: dep.artifactId, Version: dep.version})
-			// Marshal the modified Project struct back to XML
-			updatedXML, err := xml.MarshalIndent(project, "", "  ")
-			if err != nil {
-				return dep, err
-			}
-
-			err = os.WriteFile(pomFile, updatedXML, 0755)
 			return dep, err
 		}
 	}
 
-	return dep, err
+	return dep, fmt.Errorf("failed to construct artifact from jar")
 }

--- a/provider/internal/java/util_test.go
+++ b/provider/internal/java/util_test.go
@@ -1,0 +1,98 @@
+package java
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRenderPom(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Define some sample dependencies
+	dependencies := []javaArtifact{
+		{
+			GroupId:    "com.example",
+			ArtifactId: "example-artifact",
+			Version:    "1.0.0",
+		},
+		{
+			GroupId:    "org.another",
+			ArtifactId: "another-artifact",
+			Version:    "2.0.0",
+		},
+	}
+
+	// Call the function with the temporary directory and sample dependencies
+	err := createJavaProject(nil, tmpDir, dependencies)
+	if err != nil {
+		t.Fatalf("createJavaProject returned an error: %v", err)
+	}
+
+	// Verify that the project directory and pom.xml file were created
+	projectDir := filepath.Join(tmpDir, "src", "main", "java")
+	pomFile := filepath.Join(tmpDir, "pom.xml")
+
+	if _, err := os.Stat(projectDir); os.IsNotExist(err) {
+		t.Errorf("Java source directory not created: %v", err)
+	}
+
+	if _, err := os.Stat(pomFile); os.IsNotExist(err) {
+		t.Errorf("pom.xml file not created: %v", err)
+	}
+
+	// Read the generated pom.xml content
+	pomContent, err := os.ReadFile(pomFile)
+	if err != nil {
+		t.Fatalf("error reading pom.xml file: %v", err)
+	}
+
+	// Define the expected pom.xml content
+	expectedPom := `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.konveyor</groupId>
+  <artifactId>java-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>java-project</name>
+  <url>http://www.konveyor.io</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>example-artifact</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.another</groupId>
+      <artifactId>another-artifact</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+  </build>
+</project>
+`
+
+	// Compare the generated pom.xml content with the expected content
+	if !bytes.Equal(pomContent, []byte(expectedPom)) {
+		t.Errorf("Generated pom.xml content does not match the expected content")
+		fmt.Println(string(pomContent))
+		fmt.Println("expected POM")
+		fmt.Println(expectedPom)
+	}
+}


### PR DESCRIPTION
Fixes #317 
Fixes #319 

Summary of changes:
* When decompiling binaries, for every JAR we find, we attempt to look at its metadata to get artifact and group. If we dont find metadata, we look it up on maven central using its sha. For all such JARs that we find accurate information about, we add them to java project's pom as dependencies. For all other JARs, we send them to decompile.

* In decompile, we are running concurrently. Also, instead of decompiling each class file individually, we are now decompiling whole JAR using fernflower and then exploding it (this is faster than individual .class file decompile)

* Prior to initing Java provider, we are now downloading sources for all dependencies. If we find any that don't have sources, we are passing them to decompile. 

* When getting dependencies for a binary, we are now using same logic from step 1 to get more fine grained info for a JAR.