### PR TITLE
:bug: Fix "grpc unable to get info" messages at startup 

### DIFF
--- a/provider/grpc/provider.go
+++ b/provider/grpc/provider.go
@@ -55,7 +55,9 @@ func (g *grpcProvider) ProviderInit(ctx context.Context) error {
 }
 
 func (g *grpcProvider) Capabilities() []provider.Capability {
-	r, err := g.Client.Capabilities(context.TODO(), &emptypb.Empty{})
+	// Capabilities requests happen at the start of the analyzer-lsp, so it makes
+	// sens to wait until the connection is ready.
+	r, err := g.Client.Capabilities(context.TODO(), &emptypb.Empty{}, grpc.WaitForReady(true))
 	if err != nil {
 		// Handle this smarter in the future, for now log and return empty
 		g.log.V(5).Error(err, "grpc unable to get info")


### PR DESCRIPTION
Fixes #343

Note, that there's some issue where the java provider is matching comments. @shawn-hurley and @pranavgaikwad  I think this related to something you guys were talking about earlier.