### PR TITLE
:sparkles: Use perl regexes to improve special char handling

### DIFF
--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -80,7 +80,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 			return response, fmt.Errorf("could not parse provided regex pattern as string: %v", conditionInfo)
 		}
 		var outputBytes []byte
-		grep := exec.Command("grep", "-o", "-n", "-R", "-E", c.Pattern, p.config.Location)
+		grep := exec.Command("grep", "-o", "-n", "-R", "-P", c.Pattern, p.config.Location)
 		outputBytes, err := grep.Output()
 		if err != nil {
 			if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 1 {


### PR DESCRIPTION
The `-E` option in `grep` won't properly handle things like `\n` or `\t`. Using perl regexes fixes the problem.

Current success rate improves marginally, from 68.72% to 68.92%.