### PR TITLE
:bug: Fix compile step

### DIFF
--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -180,17 +180,9 @@ func (p *javaServiceClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI
 
 	moddir := filepath.Dir(path)
 
-	pom, err := gopom.Parse(path)
-	if err != nil {
-		return nil, err
-	}
-
 	args := []string{
 		"dependency:tree",
 		"-Djava.net.useSystemProxies=true",
-	}
-	if pom.Modules != nil {
-		args = append([]string{"compile"}, args...)
 	}
 
 	if p.mvnSettingsFile != "" {

--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -224,7 +224,7 @@ func (p *javaServiceClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI
 func extractSubmoduleTrees(lines []string) [][]string {
 	submoduleTrees := [][]string{}
 
-	beginRegex := regexp.MustCompile(`maven-dependency-plugin:[\d\.]+:tree`)
+	beginRegex := regexp.MustCompile(`(maven-)*dependency(-plugin)*:[\d\.]+:tree`)
 	endRegex := regexp.MustCompile(`\[INFO\] -*$`)
 
 	submod := 0

--- a/provider/internal/java/provider.go
+++ b/provider/internal/java/provider.go
@@ -341,9 +341,6 @@ func resolveSourcesJars(ctx context.Context, log logr.Logger, location, mavenSet
 		"dependency:sources",
 		"-Djava.net.useSystemProxies=true",
 	}
-	if pom.Modules != nil {
-		args = append([]string{"compile"}, args...)
-	}
 
 	if mavenSettings != "" {
 		args = append(args, "-s", mavenSettings)


### PR DESCRIPTION
Fixes #393 

Remove "compile" goal from maven invocations, as some applications may not be compilable with the JDK version we bundle.

Related to https://github.com/konveyor/analyzer-lsp/issues/393 and https://github.com/konveyor/analyzer-lsp/issues/393