### PR TITLE
:bug: Test cases for #390

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -27,7 +27,6 @@ jobs:
       - name: run demo image and ensure dependency output unchanged
         run: |
           podman run --entrypoint /usr/bin/konveyor-analyzer-dep -v $(pwd)/demo-dep-output.yaml:/analyzer-lsp/demo-dep-output.yaml:Z localhost/testing:latest --output-file=demo-dep-output.yaml
-          podman run -v $(pwd)/demo-output.yaml:/analyzer-lsp/output.yaml:Z localhost/testing:latest
           diff \
             <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-dep-output.yaml)) \
             <(yq -P 'sort_keys(..)' -o=props <(cat demo-dep-output.yaml))

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 .vscode
 .idea
+.settings/
+.classpath
+.project
+target/
 *.metadata*
 jdt.ls-java-project
 examples/java/*.project
-examples/java/target
-examples/java/.settings
-examples/java/.classpath
-examples/java/.project
 examples/python/.venv
 examples/python/__pycache__
 org.eclipse.core*

--- a/demo-dep-output.yaml
+++ b/demo-dep-output.yaml
@@ -1165,6 +1165,7 @@
   - name: com.fasterxml.jackson.core.jackson-core
     version: 2.13.3
     type: compile
+    indirect: true
     resolvedIdentifier: a27014716e4421684416e5fa83d896ddb87002da
     extras:
       artifactId: jackson-core
@@ -1177,6 +1178,7 @@
   - name: com.fasterxml.jackson.core.jackson-databind
     version: 2.13.3
     type: compile
+    indirect: true
     resolvedIdentifier: 56deb9ea2c93a7a556b3afbedd616d342963464e
     extras:
       artifactId: jackson-databind
@@ -1189,6 +1191,7 @@
   - name: com.fasterxml.jackson.dataformat.jackson-dataformat-yaml
     version: 2.13.3
     type: compile
+    indirect: true
     resolvedIdentifier: 9363ded5441b1fee62d5be0604035690ca759a2a
     extras:
       artifactId: jackson-dataformat-yaml
@@ -1201,6 +1204,7 @@
   - name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
     version: 2.13.3
     type: compile
+    indirect: true
     resolvedIdentifier: ad2f4c61aeb9e2a8bb5e4a3ed782cfddec52d972
     extras:
       artifactId: jackson-datatype-jsr310
@@ -1249,6 +1253,19 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/com/squareup/okio/okio/1.15.0
+  - name: com.sun.mail.javax.mail
+    version: 1.5.0
+    type: provided
+    indirect: true
+    resolvedIdentifier: ec2410fdf7e0a3022e7c2a2e6241039d1abc1e98
+    extras:
+      artifactId: javax.mail
+      groupId: com.sun.mail
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/com/sun/mail/javax.mail/1.5.0
   - name: io.fabric8.kubernetes-client
     version: 6.0.0
     type: compile
@@ -1289,6 +1306,7 @@
   - name: io.fabric8.kubernetes-model-admissionregistration
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 9e3b0d4caa3d033fa0f71c71d8a535a748b280ba
     extras:
       artifactId: kubernetes-model-admissionregistration
@@ -1301,6 +1319,7 @@
   - name: io.fabric8.kubernetes-model-apiextensions
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: eac63b8dec80e96c4356c91ed0a332415efcb75e
     extras:
       artifactId: kubernetes-model-apiextensions
@@ -1313,6 +1332,7 @@
   - name: io.fabric8.kubernetes-model-apps
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 4dbda6401058a5fd3a4c6be88fc1bf4f99296c4f
     extras:
       artifactId: kubernetes-model-apps
@@ -1325,6 +1345,7 @@
   - name: io.fabric8.kubernetes-model-autoscaling
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: b353e45133fbc80791d676b16203ec94c0958b7d
     extras:
       artifactId: kubernetes-model-autoscaling
@@ -1337,6 +1358,7 @@
   - name: io.fabric8.kubernetes-model-batch
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 9f14cbfc75d172fa81f3f6ad793bdd45a2decaec
     extras:
       artifactId: kubernetes-model-batch
@@ -1349,6 +1371,7 @@
   - name: io.fabric8.kubernetes-model-certificates
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 33f5a3f386cddda55003e1616303ab924fcd3ca5
     extras:
       artifactId: kubernetes-model-certificates
@@ -1374,6 +1397,7 @@
   - name: io.fabric8.kubernetes-model-coordination
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: cd454532158351d8ff37616dc33749ca2a85c8d1
     extras:
       artifactId: kubernetes-model-coordination
@@ -1386,6 +1410,7 @@
   - name: io.fabric8.kubernetes-model-core
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 73469e4a7baec7600455d7f4a121c6680e80bf35
     extras:
       artifactId: kubernetes-model-core
@@ -1398,6 +1423,7 @@
   - name: io.fabric8.kubernetes-model-discovery
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 246ad448a1868b3c601394e21350a9602adef24c
     extras:
       artifactId: kubernetes-model-discovery
@@ -1410,6 +1436,7 @@
   - name: io.fabric8.kubernetes-model-events
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 204c2c78a4a8e0b5f5ebc1b788c9f22a8c1b14ab
     extras:
       artifactId: kubernetes-model-events
@@ -1422,6 +1449,7 @@
   - name: io.fabric8.kubernetes-model-extensions
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 60c9e43f1f34ab9c145798471926c07e13e45ecf
     extras:
       artifactId: kubernetes-model-extensions
@@ -1434,6 +1462,7 @@
   - name: io.fabric8.kubernetes-model-flowcontrol
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 3b01d9eab7e7d7c9d46d8828202bff78fbdaa7d9
     extras:
       artifactId: kubernetes-model-flowcontrol
@@ -1446,6 +1475,7 @@
   - name: io.fabric8.kubernetes-model-metrics
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 1a400f8f7915bd2a68fa075605768d762aaad4cb
     extras:
       artifactId: kubernetes-model-metrics
@@ -1458,6 +1488,7 @@
   - name: io.fabric8.kubernetes-model-networking
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: c87e11bebb26bb48660765b42a68f9577336b799
     extras:
       artifactId: kubernetes-model-networking
@@ -1470,6 +1501,7 @@
   - name: io.fabric8.kubernetes-model-node
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 972706f6dffa518e11c94647cf47e188db6115f6
     extras:
       artifactId: kubernetes-model-node
@@ -1482,6 +1514,7 @@
   - name: io.fabric8.kubernetes-model-policy
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 15b3011eb5ff48b9fc2bd8bcc4db697ca9ec30e4
     extras:
       artifactId: kubernetes-model-policy
@@ -1494,6 +1527,7 @@
   - name: io.fabric8.kubernetes-model-rbac
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 03ad461761d775ff9c252d2b26a4977d22dd0f3a
     extras:
       artifactId: kubernetes-model-rbac
@@ -1506,6 +1540,7 @@
   - name: io.fabric8.kubernetes-model-scheduling
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: a5fae7294f5c39fb9d7cffb7280b55ca458c9128
     extras:
       artifactId: kubernetes-model-scheduling
@@ -1518,6 +1553,7 @@
   - name: io.fabric8.kubernetes-model-storageclass
     version: 6.0.0
     type: compile
+    indirect: true
     resolvedIdentifier: 6ffa61f9021d07a4a9d785e83a513955a3c48073
     extras:
       artifactId: kubernetes-model-storageclass
@@ -1540,6 +1576,117 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/io/fabric8/zjsonpatch/0.3.0
+  - name: io.netty.netty-buffer
+    version: 4.1.76.Final
+    type: runtime
+    resolvedIdentifier: 231f5042a5050773eb22a918e84daff3f00892f2
+    extras:
+      artifactId: netty-buffer
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-buffer/4.1.76.Final
+  - name: io.netty.netty-common
+    version: 4.1.76.Final
+    type: runtime
+    resolvedIdentifier: 38d0b500f098dc89497b6e608d7427186f533cf0
+    extras:
+      artifactId: netty-common
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-common/4.1.76.Final
+  - name: io.netty.netty-resolver
+    version: 4.1.76.Final
+    type: runtime
+    indirect: true
+    resolvedIdentifier: e0b225a33772cb7bba73dc296cccefa6826ab8cc
+    extras:
+      artifactId: netty-resolver
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-resolver/4.1.76.Final
+  - name: io.netty.netty-transport
+    version: 4.1.76.Final
+    type: runtime
+    resolvedIdentifier: f01d2f935005b6fdb2fedc23114d2ae717749c36
+    extras:
+      artifactId: netty-transport
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-transport/4.1.76.Final
+  - name: io.netty.netty-transport-classes-epoll
+    version: 4.1.76.Final
+    type: runtime
+    resolvedIdentifier: 921b92a76116674218af3dc4bbf43d73884e4146
+    extras:
+      artifactId: netty-transport-classes-epoll
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-transport-classes-epoll/4.1.76.Final
+  - name: io.netty.netty-transport-native-epoll
+    version: 4.1.76.Final
+    classifier: linux-x86_64
+    type: runtime
+    resolvedIdentifier: e1ee2a9c5f63b1b71260caf127a1e50667d62854
+    extras:
+      artifactId: netty-transport-native-epoll
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-transport-native-epoll/4.1.76.Final
+  - name: io.netty.netty-transport-native-unix-common
+    version: 4.1.76.Final
+    type: runtime
+    resolvedIdentifier: d5ed8c4be9680203c53f7ed788225c12c4d87ee0
+    extras:
+      artifactId: netty-transport-native-unix-common
+      groupId: io.netty
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/netty/netty-transport-native-unix-common/4.1.76.Final
+  - name: javax.activation.activation
+    version: "1.1"
+    type: provided
+    indirect: true
+    resolvedIdentifier: e6cb541461c2834bdea3eb920f1884d1eb508b50
+    extras:
+      artifactId: activation
+      groupId: javax.activation
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/javax/activation/activation/1.1
+  - name: javax.javaee-api
+    version: "7.0"
+    type: provided
+    resolvedIdentifier: 51399f902cc27a808122edcbebfaa1ad989954ba
+    extras:
+      artifactId: javaee-api
+      groupId: javax
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/javax/javaee-api/7.0
   - name: junit.junit
     version: "4.11"
     type: test
@@ -1568,6 +1715,7 @@
   - name: org.slf4j.slf4j-api
     version: 1.7.36
     type: compile
+    indirect: true
     resolvedIdentifier: 6c62681a2f655b49963a5983b8b0950a6120ae14
     extras:
       artifactId: slf4j-api

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -146,26 +146,94 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+      - uri: file:///analyzer-lsp/examples/java/dummy/pom.xml
+        message: |-
+          <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
+                           as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
+        variables:
+          data: dependency
+          innerText: "\n            javax\n            javaee-api\n            \n            ${javaee-api.version}\n            provided\n        "
+          matchingXML: |-
+            <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
+                             as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
-        codeSnip: "25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>\n41      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n42        <plugins>\n43          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->\n44          <plugin>\n45            <artifactId>maven-clean-plugin</artifactId>"
-        lineNumber: 34
+        codeSnip: |-
+          30        <version>4.11</version>
+          31        <scope>test</scope>
+          32      </dependency>
+          33      <dependency>
+          34        <groupId>io.fabric8</groupId>
+          35        <artifactId>kubernetes-client</artifactId>
+          36        <version>6.0.0</version>
+          37      </dependency>
+          38      <dependency>
+          39        <groupId>io.fabric8</groupId>
+          40        <artifactId>kubernetes-client-api</artifactId>
+          41        <version>6.0.0</version>
+          42      </dependency>
+          43      <dependency>
+          44        <groupId>javax</groupId>
+          45        <artifactId>javaee-api</artifactId>
+          46        <version>${javaee-api.version}</version>
+          47        <scope>provided</scope>
+          48      </dependency>
+          49      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->
+          50      <dependency>
+        lineNumber: 39
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
-        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
-        lineNumber: 29
+        codeSnip: "25  \n26    <dependencies>\n27      <dependency>\n28        <groupId>junit</groupId>\n29        <artifactId>junit</artifactId>\n30        <version>4.11</version>\n31        <scope>test</scope>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38      <dependency>\n39        <groupId>io.fabric8</groupId>\n40        <artifactId>kubernetes-client-api</artifactId>\n41        <version>6.0.0</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>javax</groupId>\n45        <artifactId>javaee-api</artifactId>"
+        lineNumber: 34
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
+        codeSnip: "42      </dependency>\n43      <dependency>\n44        <groupId>javax</groupId>\n45        <artifactId>javaee-api</artifactId>\n46        <version>${javaee-api.version}</version>\n47        <scope>provided</scope>\n48      </dependency>\n49      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->\n50      <dependency>\n51        <groupId>io.netty</groupId>\n52        <artifactId>netty-transport-native-epoll</artifactId>\n53        <version>4.1.76.Final</version>\n54        <classifier>linux-x86_64</classifier>\n55        <scope>runtime</scope>\n56      </dependency>\n57    </dependencies>\n58  \n59    <build>\n60      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n61        <plugins>\n62          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->"
+        lineNumber: 51
+        variables:
+          data: dependency
+          innerText: "\n      io.netty\n      netty-transport-native-epoll\n      4.1.76.Final\n      linux-x86_64\n      runtime\n    "
+          matchingXML: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: <groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>
+        codeSnip: |-
+          35        <artifactId>kubernetes-client</artifactId>
+          36        <version>6.0.0</version>
+          37      </dependency>
+          38      <dependency>
+          39        <groupId>io.fabric8</groupId>
+          40        <artifactId>kubernetes-client-api</artifactId>
+          41        <version>6.0.0</version>
+          42      </dependency>
+          43      <dependency>
+          44        <groupId>javax</groupId>
+          45        <artifactId>javaee-api</artifactId>
+          46        <version>${javaee-api.version}</version>
+          47        <scope>provided</scope>
+          48      </dependency>
+          49      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->
+          50      <dependency>
+          51        <groupId>io.netty</groupId>
+          52        <artifactId>netty-transport-native-epoll</artifactId>
+          53        <version>4.1.76.Final</version>
+          54        <classifier>linux-x86_64</classifier>
+          55        <scope>runtime</scope>
+        lineNumber: 44
+        variables:
+          data: dependency
+          innerText: "\n      javax\n      javaee-api\n      ${javaee-api.version}\n      provided\n    "
+          matchingXML: <groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
-        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
-        lineNumber: 23
+        codeSnip: "19    <properties>\n20      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n21      <maven.compiler.source>1.7</maven.compiler.source>\n22      <maven.compiler.target>1.7</maven.compiler.target>\n23      <javaee-api.version>7.0</javaee-api.version>\n24    </properties>\n25  \n26    <dependencies>\n27      <dependency>\n28        <groupId>junit</groupId>\n29        <artifactId>junit</artifactId>\n30        <version>4.11</version>\n31        <scope>test</scope>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38      <dependency>\n39        <groupId>io.fabric8</groupId>"
+        lineNumber: 28
         variables:
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
@@ -229,15 +297,15 @@
       incidents:
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency io.fabric8.kubernetes-client with 6.0.0 is bad and you should feel bad for using it
-        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
-        lineNumber: 29
+        codeSnip: "25  \n26    <dependencies>\n27      <dependency>\n28        <groupId>junit</groupId>\n29        <artifactId>junit</artifactId>\n30        <version>4.11</version>\n31        <scope>test</scope>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38      <dependency>\n39        <groupId>io.fabric8</groupId>\n40        <artifactId>kubernetes-client-api</artifactId>\n41        <version>6.0.0</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>javax</groupId>\n45        <artifactId>javaee-api</artifactId>"
+        lineNumber: 34
         variables:
           name: io.fabric8.kubernetes-client
           version: 6.0.0
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency junit.junit with 4.11 is bad and you should feel bad for using it
-        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
-        lineNumber: 23
+        codeSnip: "19    <properties>\n20      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n21      <maven.compiler.source>1.7</maven.compiler.source>\n22      <maven.compiler.target>1.7</maven.compiler.target>\n23      <javaee-api.version>7.0</javaee-api.version>\n24    </properties>\n25  \n26    <dependencies>\n27      <dependency>\n28        <groupId>junit</groupId>\n29        <artifactId>junit</artifactId>\n30        <version>4.11</version>\n31        <scope>test</scope>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38      <dependency>\n39        <groupId>io.fabric8</groupId>"
+        lineNumber: 28
         variables:
           name: junit.junit
           version: "4.11"
@@ -250,55 +318,6 @@
         lineNumber: 10
         variables:
           file: file:///analyzer-lsp/examples/golang/main.go
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-        message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;\n 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {"
-        lineNumber: 3
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-          kind: Module
-          name: io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-        message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
-        codeSnip: " 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {\n14          CustomResourceDefinition crd = new CustomResourceDefinition();\n15          System.out.println( crd );\n16  \n17          GenericClass<String> element = new GenericClass<String>(\"Hello world!\");\n18          element.get();\n19      }\n20  }\n"
-        lineNumber: 14
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-          kind: Method
-          name: main
-    lang-ref-003:
-      description: ""
-      category: potential
-      incidents:
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-        message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java:14
-        codeSnip: " 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {\n14          CustomResourceDefinition crd = new CustomResourceDefinition();\n15          System.out.println( crd );\n16  \n17          GenericClass<String> element = new GenericClass<String>(\"Hello world!\");\n18          element.get();\n19      }\n20  }\n"
-        lineNumber: 14
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-          kind: Method
-          name: main
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-        message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java:3
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;\n 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {"
-        lineNumber: 3
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-          kind: Module
-          name: io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition
-    lang-ref-004:
-      description: ""
-      category: potential
-      incidents:
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-        message: found generic call
-        codeSnip: " 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {\n14          CustomResourceDefinition crd = new CustomResourceDefinition();\n15          System.out.println( crd );\n16  \n17          GenericClass<String> element = new GenericClass<String>(\"Hello world!\");\n18          element.get();\n19      }\n20  }\n"
-        lineNumber: 18
-        variables:
-          VariableName: element
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-          kind: Method
-          name: main
     multiple-actions-001:
       description: ""
       category: potential
@@ -345,46 +364,6 @@
         lineNumber: 27
         variables:
           file: file:///analyzer-lsp/examples/python/main.py
-    singleton-sessionbean-00001:
-      description: ""
-      category: potential
-      incidents:
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-        message: condition entries should evaluate out of order
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import javax.ejb.SessionBean;\n 4  import javax.ejb.Singleton;\n 5  \n 6  @Singleton\n 7  public class Bean implements SessionBean {\n 8  }\n"
-        lineNumber: 6
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-          kind: Class
-          name: Singleton
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-        message: condition entries should evaluate out of order
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import javax.ejb.SessionBean;\n 4  import javax.ejb.Singleton;\n 5  \n 6  @Singleton\n 7  public class Bean implements SessionBean {\n 8  }\n"
-        lineNumber: 7
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-          kind: Class
-          name: Bean
-    singleton-sessionbean-00002:
-      description: ""
-      category: potential
-      incidents:
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-        message: condition entries should evaluate in order
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import javax.ejb.SessionBean;\n 4  import javax.ejb.Singleton;\n 5  \n 6  @Singleton\n 7  public class Bean implements SessionBean {\n 8  }\n"
-        lineNumber: 6
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-          kind: Class
-          name: Singleton
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-        message: condition entries should evaluate in order
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import javax.ejb.SessionBean;\n 4  import javax.ejb.Singleton;\n 5  \n 6  @Singleton\n 7  public class Bean implements SessionBean {\n 8  }\n"
-        lineNumber: 7
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/Singleton.java
-          kind: Class
-          name: Bean
     tech-tag-001:
       description: ""
       category: potential
@@ -540,26 +519,94 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+      - uri: file:///analyzer-lsp/examples/java/dummy/pom.xml
+        message: |-
+          POM XML dependencies - '<groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
+                           as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>'
+        variables:
+          data: dependency
+          innerText: "\n            javax\n            javaee-api\n            \n            ${javaee-api.version}\n            provided\n        "
+          matchingXML: |-
+            <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
+                             as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>'
-        codeSnip: "25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>\n41      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n42        <plugins>\n43          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->\n44          <plugin>\n45            <artifactId>maven-clean-plugin</artifactId>"
-        lineNumber: 34
+        codeSnip: |-
+          30        <version>4.11</version>
+          31        <scope>test</scope>
+          32      </dependency>
+          33      <dependency>
+          34        <groupId>io.fabric8</groupId>
+          35        <artifactId>kubernetes-client</artifactId>
+          36        <version>6.0.0</version>
+          37      </dependency>
+          38      <dependency>
+          39        <groupId>io.fabric8</groupId>
+          40        <artifactId>kubernetes-client-api</artifactId>
+          41        <version>6.0.0</version>
+          42      </dependency>
+          43      <dependency>
+          44        <groupId>javax</groupId>
+          45        <artifactId>javaee-api</artifactId>
+          46        <version>${javaee-api.version}</version>
+          47        <scope>provided</scope>
+          48      </dependency>
+          49      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->
+          50      <dependency>
+        lineNumber: 39
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>'
-        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
-        lineNumber: 29
+        codeSnip: "25  \n26    <dependencies>\n27      <dependency>\n28        <groupId>junit</groupId>\n29        <artifactId>junit</artifactId>\n30        <version>4.11</version>\n31        <scope>test</scope>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38      <dependency>\n39        <groupId>io.fabric8</groupId>\n40        <artifactId>kubernetes-client-api</artifactId>\n41        <version>6.0.0</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>javax</groupId>\n45        <artifactId>javaee-api</artifactId>"
+        lineNumber: 34
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: POM XML dependencies - '<groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>'
+        codeSnip: "42      </dependency>\n43      <dependency>\n44        <groupId>javax</groupId>\n45        <artifactId>javaee-api</artifactId>\n46        <version>${javaee-api.version}</version>\n47        <scope>provided</scope>\n48      </dependency>\n49      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->\n50      <dependency>\n51        <groupId>io.netty</groupId>\n52        <artifactId>netty-transport-native-epoll</artifactId>\n53        <version>4.1.76.Final</version>\n54        <classifier>linux-x86_64</classifier>\n55        <scope>runtime</scope>\n56      </dependency>\n57    </dependencies>\n58  \n59    <build>\n60      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n61        <plugins>\n62          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->"
+        lineNumber: 51
+        variables:
+          data: dependency
+          innerText: "\n      io.netty\n      netty-transport-native-epoll\n      4.1.76.Final\n      linux-x86_64\n      runtime\n    "
+          matchingXML: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: POM XML dependencies - '<groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>'
+        codeSnip: |-
+          35        <artifactId>kubernetes-client</artifactId>
+          36        <version>6.0.0</version>
+          37      </dependency>
+          38      <dependency>
+          39        <groupId>io.fabric8</groupId>
+          40        <artifactId>kubernetes-client-api</artifactId>
+          41        <version>6.0.0</version>
+          42      </dependency>
+          43      <dependency>
+          44        <groupId>javax</groupId>
+          45        <artifactId>javaee-api</artifactId>
+          46        <version>${javaee-api.version}</version>
+          47        <scope>provided</scope>
+          48      </dependency>
+          49      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->
+          50      <dependency>
+          51        <groupId>io.netty</groupId>
+          52        <artifactId>netty-transport-native-epoll</artifactId>
+          53        <version>4.1.76.Final</version>
+          54        <classifier>linux-x86_64</classifier>
+          55        <scope>runtime</scope>
+        lineNumber: 44
+        variables:
+          data: dependency
+          innerText: "\n      javax\n      javaee-api\n      ${javaee-api.version}\n      provided\n    "
+          matchingXML: <groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>'
-        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
-        lineNumber: 23
+        codeSnip: "19    <properties>\n20      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n21      <maven.compiler.source>1.7</maven.compiler.source>\n22      <maven.compiler.target>1.7</maven.compiler.target>\n23      <javaee-api.version>7.0</javaee-api.version>\n24    </properties>\n25  \n26    <dependencies>\n27      <dependency>\n28        <groupId>junit</groupId>\n29        <artifactId>junit</artifactId>\n30        <version>4.11</version>\n31        <scope>test</scope>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38      <dependency>\n39        <groupId>io.fabric8</groupId>"
+        lineNumber: 28
         variables:
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
@@ -571,3 +618,7 @@
   unmatched:
   - file-002
   - lang-ref-002
+  - lang-ref-003
+  - lang-ref-004
+  - singleton-sessionbean-00001
+  - singleton-sessionbean-00002

--- a/examples/java/dummy/pom.xml
+++ b/examples/java/dummy/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.example.apps</groupId>
+        <artifactId>java</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dummy</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
+                 as the property cannot be resolved here but only in the parent POM -->
+            <version>${javaee-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/java/dummy/src/main/java/com/example/apps/Main.java
+++ b/examples/java/dummy/src/main/java/com/example/apps/Main.java
@@ -1,0 +1,7 @@
+package com.example.apps;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -7,15 +7,20 @@
   <groupId>com.example.apps</groupId>
   <artifactId>java</artifactId>
   <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
   <name>java</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
+  <modules>
+    <module>dummy</module>
+  </modules>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
+    <javaee-api.version>7.0</javaee-api.version>
   </properties>
 
   <dependencies>
@@ -38,7 +43,7 @@
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>7.0</version>
+      <version>${javaee-api.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -35,6 +35,12 @@
       <artifactId>kubernetes-client-api</artifactId>
       <version>6.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>7.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -46,6 +46,14 @@
       <version>${javaee-api.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>4.1.76.Final</version>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/examples/java/src/main/java/com/example/apps/Bean.java
+++ b/examples/java/src/main/java/com/example/apps/Bean.java
@@ -4,5 +4,5 @@ import javax.ejb.SessionBean;
 import javax.ejb.Singleton;
 
 @Singleton
-public class Bean implements SessionBean {
+public abstract class Bean implements SessionBean {
 }


### PR DESCRIPTION
Adding test cases for #390.

The Java example was refactored to make it run (i.e., `mvn compile` at least), and extended by a submodule.
The submodule contains a property based dependency version which cannot be immediately resolved, as there is no `properties` definition in the submodule itself. 

The hotfix provided by #425 prevents the binary from failing. 
Nevertheless, the version property should be resolved from the parent pom which is not yet addressed.

As the bug report only was about the SEGV caused by the problem, #390 may be closed anyway.