### PR TITLE
:bug: Implement sorting on structs when marshaling

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -21,39 +21,30 @@ jobs:
         run: |
           podman run -v $(pwd)/demo-output.yaml:/analyzer-lsp/output.yaml:Z localhost/testing:latest
           diff \
-            <(sort <(sed 's/incidents\.[0-9]\+/incidents\.x/g' <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-output.yaml)))) \
-            <(sort <(sed 's/incidents\.[0-9]\+/incidents\.x/g' <(yq -P 'sort_keys(..)' -o=props <(cat demo-output.yaml))))
+            <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-output.yaml)) \
+            <(yq -P 'sort_keys(..)' -o=props <(cat demo-output.yaml))
 
       - name: run demo image and ensure dependency output unchanged
         run: |
           podman run --entrypoint /usr/bin/konveyor-analyzer-dep -v $(pwd)/demo-dep-output.yaml:/analyzer-lsp/demo-dep-output.yaml:Z localhost/testing:latest --output-file=demo-dep-output.yaml
           podman run -v $(pwd)/demo-output.yaml:/analyzer-lsp/output.yaml:Z localhost/testing:latest
           diff \
-            <(sort <(sed 's/incidents\.[0-9]\+/incidents\.x/g' <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-dep-output.yaml)))) \
-            <(sort <(sed 's/incidents\.[0-9]\+/incidents\.x/g' <(yq -P 'sort_keys(..)' -o=props <(cat demo-dep-output.yaml))))
+            <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-dep-output.yaml)) \
+            <(yq -P 'sort_keys(..)' -o=props <(cat demo-dep-output.yaml))
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          repository: konveyor/tackle2-addon-analyzer
-          ref: main
-          path: tackle2-addon-analyzer
-
-      - name: Build addon and save image
-        working-directory: tackle2-addon-analyzer
+      - name: save image
         run: |
-          IMG=quay.io/konveyor/tackle2-addon-analyzer:latest make image-podman
-          podman save -o /tmp/tackle2-addon-analyzer.tar quay.io/konveyor/tackle2-addon-analyzer:latest
+          podman save -o /tmp/analyzer-lsp.tar quay.io/konveyor/analyzer-lsp:latest
 
       - name: Upload image as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: tackle2-addon-analyzer
-          path: /tmp/tackle2-addon-analyzer.tar
+          name: analyzer-lsp
+          path: /tmp/analyzer-lsp.tar
           retention-days: 1
 
   e2e:
     needs: test
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
-      component_name: tackle2-addon-analyzer
+      component_name: analyzer-lsp

--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -32,19 +32,28 @@ jobs:
             <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-dep-output.yaml)) \
             <(yq -P 'sort_keys(..)' -o=props <(cat demo-dep-output.yaml))
 
-      - name: save image
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repository: konveyor/tackle2-addon-analyzer
+          ref: main
+          path: tackle2-addon-analyzer
+
+      - name: Build addon and save image
+        working-directory: tackle2-addon-analyzer
         run: |
-          podman save -o /tmp/analyzer-lsp.tar quay.io/konveyor/analyzer-lsp:latest
+          IMG=quay.io/konveyor/tackle2-addon-analyzer:latest make image-podman
+          podman save -o /tmp/tackle2-addon-analyzer.tar quay.io/konveyor/tackle2-addon-analyzer:latest
 
       - name: Upload image as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: analyzer-lsp
-          path: /tmp/analyzer-lsp.tar
+          name: tackle2-addon-analyzer
+          path: /tmp/tackle2-addon-analyzer.tar
           retention-days: 1
 
   e2e:
     needs: test
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
-      component_name: analyzer-lsp
+      component_name: tackle2-addon-analyzer

--- a/demo-dep-output.yaml
+++ b/demo-dep-output.yaml
@@ -1,6 +1,31 @@
 - fileURI: file:///analyzer-lsp/examples/golang/go.mod
   provider: go
   dependencies:
+  - name: github.com/armon/go-socks5
+    version: v0.0.0-20160902184237-e75332964ef5
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/davecgh/go-spew
+    version: v1.1.1
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/elazarl/goproxy
+    version: v0.0.0-20180725130230-947c36da3153
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/emicklei/go-restful
+    version: v2.9.5+incompatible
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/evanphx/json-patch
+    version: v4.12.0+incompatible
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
   - name: github.com/go-logr/logr
     version: v1.2.0
     labels:
@@ -11,108 +36,8 @@
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
-  - name: github.com/kisielk/errcheck
-    version: v1.5.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/kisielk/gotool
-    version: v1.0.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/tools
-    version: v0.0.0-20210106214847-113979e3529a
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/google/gofuzz
-    version: v1.1.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/json-iterator/go
-    version: v1.1.12
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/davecgh/go-spew
-    version: v1.1.1
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/google/gofuzz
-    version: v1.0.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/modern-go/concurrent
-    version: v0.0.0-20180228061459-e0a39a4cb421
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/modern-go/reflect2
-    version: v1.0.2
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/stretchr/testify
-    version: v1.3.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/modern-go/concurrent
-    version: v0.0.0-20180306012644-bacd9c7ef1dd
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/net
-    version: v0.0.0-20220127200216-cd36cc0744dd
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/sys
-    version: v0.0.0-20211216021012-1d35b9e2eb4e
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/term
-    version: v0.0.0-20210927222741-03fcf44c2211
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/text
-    version: v0.3.7
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/tools
-    version: v0.0.0-20180917221912-90fa682c2a6e
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: gopkg.in/inf.v0
-    version: v0.9.1
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: gopkg.in/yaml.v2
-    version: v2.4.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: gopkg.in/check.v1
-    version: v0.0.0-20161208181325-20d25e280405
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: k8s.io/apiextensions-apiserver
-    version: v0.24.4
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/emicklei/go-restful
-    version: v2.9.5+incompatible
+  - name: github.com/golang/protobuf
+    version: v1.5.2
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
@@ -131,13 +56,98 @@
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
+  - name: github.com/google/gofuzz
+    version: v1.0.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/google/gofuzz
+    version: v1.1.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
   - name: github.com/google/uuid
     version: v1.1.2
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
+  - name: github.com/json-iterator/go
+    version: v1.1.12
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/json-iterator/go
+    version: v1.1.6
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/kisielk/errcheck
+    version: v1.5.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/kisielk/gotool
+    version: v1.0.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/kr/text
+    version: v0.2.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
   - name: github.com/mitchellh/mapstructure
     version: v1.4.1
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/moby/spdystream
+    version: v0.2.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/modern-go/concurrent
+    version: v0.0.0-20180228061459-e0a39a4cb421
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/modern-go/concurrent
+    version: v0.0.0-20180306012644-bacd9c7ef1dd
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/modern-go/reflect2
+    version: v1.0.1
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/modern-go/reflect2
+    version: v1.0.2
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/mxk/go-flowrate
+    version: v0.0.0-20140419014527-cca7078d478f
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/niemeyer/pretty
+    version: v0.0.0-20200227124842-a10e7caefd8e
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/onsi/ginkgo
+    version: v1.14.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/pkg/errors
+    version: v0.9.1
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/spf13/afero
+    version: v1.2.2
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
@@ -148,6 +158,11 @@
     - konveyor.io/language=go
   - name: github.com/spf13/pflag
     version: v1.0.5
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: github.com/stretchr/testify
+    version: v1.3.0
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
@@ -166,6 +181,41 @@
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
+  - name: golang.org/x/net
+    version: v0.0.0-20220127200216-cd36cc0744dd
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: golang.org/x/sys
+    version: v0.0.0-20211216021012-1d35b9e2eb4e
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: golang.org/x/sys
+    version: v0.0.0-20220209214540-3681064d5158
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: golang.org/x/term
+    version: v0.0.0-20210927222741-03fcf44c2211
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: golang.org/x/text
+    version: v0.3.7
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: golang.org/x/tools
+    version: v0.0.0-20180917221912-90fa682c2a6e
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: golang.org/x/tools
+    version: v0.0.0-20210106214847-113979e3529a
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
   - name: google.golang.org/genproto
     version: v0.0.0-20220107163113-42d7afdf6368
     labels:
@@ -181,7 +231,37 @@
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
+  - name: gopkg.in/check.v1
+    version: v0.0.0-20161208181325-20d25e280405
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: gopkg.in/check.v1
+    version: v1.0.0-20200227125254-8fa46927fb4f
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: gopkg.in/inf.v0
+    version: v0.9.1
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: gopkg.in/yaml.v2
+    version: v2.2.8
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: gopkg.in/yaml.v2
+    version: v2.4.0
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
   - name: k8s.io/api
+    version: v0.24.4
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: k8s.io/apiextensions-apiserver
     version: v0.24.4
     labels:
     - konveyor.io/dep-source=downloadable
@@ -208,6 +288,11 @@
     - konveyor.io/language=go
   - name: k8s.io/component-base
     version: v0.24.4
+    labels:
+    - konveyor.io/dep-source=downloadable
+    - konveyor.io/language=go
+  - name: k8s.io/klog/v2
+    version: v2.0.0
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
@@ -241,143 +326,22 @@
     labels:
     - konveyor.io/dep-source=downloadable
     - konveyor.io/language=go
-  - name: github.com/armon/go-socks5
-    version: v0.0.0-20160902184237-e75332964ef5
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/elazarl/goproxy
-    version: v0.0.0-20180725130230-947c36da3153
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/evanphx/json-patch
-    version: v4.12.0+incompatible
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/golang/protobuf
-    version: v1.5.2
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/kr/text
-    version: v0.2.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/moby/spdystream
-    version: v0.2.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/mxk/go-flowrate
-    version: v0.0.0-20140419014527-cca7078d478f
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/niemeyer/pretty
-    version: v0.0.0-20200227124842-a10e7caefd8e
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/onsi/ginkgo
-    version: v1.14.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/pkg/errors
-    version: v0.9.1
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: golang.org/x/sys
-    version: v0.0.0-20220209214540-3681064d5158
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: gopkg.in/check.v1
-    version: v1.0.0-20200227125254-8fa46927fb4f
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/spf13/afero
-    version: v1.2.2
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: k8s.io/klog/v2
-    version: v2.0.0
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: gopkg.in/yaml.v2
-    version: v2.2.8
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/json-iterator/go
-    version: v1.1.6
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
-  - name: github.com/modern-go/reflect2
-    version: v1.0.1
-    labels:
-    - konveyor.io/dep-source=downloadable
-    - konveyor.io/language=go
 - fileURI: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
   provider: java
   dependencies:
-  - name: io.konveyor.demo.config-utils
-    version: 1.0.0
+  - name: antlr.antlr
+    version: 2.7.7
     type: compile
-    resolvedIdentifier: FE4FE11AAEE77BE10035218537FBF4B2E6EF1D9F
-    extras:
-      artifactId: config-utils
-      groupId: io.konveyor.demo
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=internal
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/konveyor/demo/config-utils/1.0.0
-  - name: org.postgresql.postgresql
-    version: 42.2.23
-    type: compile
-    resolvedIdentifier: 9cb217a3d5b640567ed7c6e8c11f389613c81c4d
-    extras:
-      artifactId: postgresql
-      groupId: org.postgresql
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/postgresql/postgresql/42.2.23
-  - name: org.checkerframework.checker-qual
-    version: 3.5.0
-    type: runtime
     indirect: true
-    resolvedIdentifier: 2f50520c8abea66fbd8d26e481d3aef5c673b510
+    resolvedIdentifier: 83cd2cd674a217ade95a4bb83a8a14f351f48bd0
     extras:
-      artifactId: checker-qual
-      groupId: org.checkerframework
+      artifactId: antlr
+      groupId: antlr
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/checkerframework/checker-qual/3.5.0
-  - name: com.oracle.database.jdbc.ojdbc8
-    version: 21.1.0.0
-    type: compile
-    resolvedIdentifier: 50044485aea10afd7defeee8109c5195b4d3cae2
-    extras:
-      artifactId: ojdbc8
-      groupId: com.oracle.database.jdbc
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/oracle/database/jdbc/ojdbc8/21.1.0.0
+    prefix: file:///root/.m2/repository/antlr/antlr/2.7.7
   - name: ch.qos.logback.logback-classic
     version: 1.1.7
     type: compile
@@ -403,31 +367,6 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/ch/qos/logback/logback-core/1.1.7
-  - name: org.hibernate.validator.hibernate-validator
-    version: 6.2.0.Final
-    type: compile
-    resolvedIdentifier: d6b0760dfffbf379cedd02f715ff4c9a2e215921
-    extras:
-      artifactId: hibernate-validator
-      groupId: org.hibernate.validator
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/hibernate/validator/hibernate-validator/6.2.0.Final
-  - name: jakarta.validation.jakarta.validation-api
-    version: 2.0.2
-    type: compile
-    indirect: true
-    resolvedIdentifier: 5eacc6522521f7eacb081f95cee1e231648461e7
-    extras:
-      artifactId: jakarta.validation-api
-      groupId: jakarta.validation
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/jakarta/validation/jakarta.validation-api/2.0.2
   - name: com.fasterxml.classmate
     version: 1.5.1
     type: compile
@@ -441,83 +380,145 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/com/fasterxml/classmate/1.5.1
-  - name: org.hibernate.hibernate-entitymanager
-    version: 5.4.32.Final
-    type: compile
-    resolvedIdentifier: 3f60db4097732960ec792c033dbb7c34f1b9e328
-    extras:
-      artifactId: hibernate-entitymanager
-      groupId: org.hibernate
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/hibernate/hibernate-entitymanager/5.4.32.Final
-  - name: org.jboss.logging.jboss-logging
-    version: 3.4.1.Final
+  - name: com.fasterxml.jackson.core.jackson-annotations
+    version: 2.12.3
     type: compile
     indirect: true
-    resolvedIdentifier: 40fd4d696c55793e996d1ff3c475833f836c2498
+    resolvedIdentifier: 7275513412694a1aafd08c0287f48469fa0e6e17
     extras:
-      artifactId: jboss-logging
-      groupId: org.jboss.logging
+      artifactId: jackson-annotations
+      groupId: com.fasterxml.jackson.core
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/jboss/logging/jboss-logging/3.4.1.Final
-  - name: org.hibernate.hibernate-core
-    version: 5.4.32.Final
+    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.3
+  - name: com.fasterxml.jackson.core.jackson-core
+    version: 2.12.3
+    type: compile
+    resolvedIdentifier: deb23fe2a7f2b773e18ced2b50d4acc1df8fa366
+    extras:
+      artifactId: jackson-core
+      groupId: com.fasterxml.jackson.core
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.3
+  - name: com.fasterxml.jackson.core.jackson-databind
+    version: 2.12.3
+    type: compile
+    resolvedIdentifier: d6153f8fc60c479ab0f9efb35c034526436a4953
+    extras:
+      artifactId: jackson-databind
+      groupId: com.fasterxml.jackson.core
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.3
+  - name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
+    version: 2.12.3
+    type: runtime
+    indirect: true
+    resolvedIdentifier: f69c636438dcf19c49960c1fe8901320ab85f989
+    extras:
+      artifactId: jackson-datatype-jsr310
+      groupId: com.fasterxml.jackson.datatype
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.12.3
+  - name: com.oracle.database.jdbc.ojdbc8
+    version: 21.1.0.0
+    type: compile
+    resolvedIdentifier: 50044485aea10afd7defeee8109c5195b4d3cae2
+    extras:
+      artifactId: ojdbc8
+      groupId: com.oracle.database.jdbc
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/com/oracle/database/jdbc/ojdbc8/21.1.0.0
+  - name: com.sun.istack.istack-commons-runtime
+    version: 3.0.7
     type: compile
     indirect: true
-    resolvedIdentifier: 99a5e10bf455337014c190e141ec631e9ff71663
+    resolvedIdentifier: c197c86ceec7318b1284bffb49b54226ca774003
     extras:
-      artifactId: hibernate-core
-      groupId: org.hibernate
+      artifactId: istack-commons-runtime
+      groupId: com.sun.istack
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/hibernate/hibernate-core/5.4.32.Final
-  - name: org.javassist.javassist
-    version: 3.27.0-GA
+    prefix: file:///root/.m2/repository/com/sun/istack/istack-commons-runtime/3.0.7
+  - name: com.sun.xml.fastinfoset.FastInfoset
+    version: 1.2.15
     type: compile
     indirect: true
-    resolvedIdentifier: f63e6aa899e15eca8fdaa402a79af4c417252213
+    resolvedIdentifier: bb7b7ec0379982b97c62cd17465cb6d9155f68e8
     extras:
-      artifactId: javassist
-      groupId: org.javassist
+      artifactId: FastInfoset
+      groupId: com.sun.xml.fastinfoset
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/javassist/javassist/3.27.0-GA
-  - name: antlr.antlr
-    version: 2.7.7
+    prefix: file:///root/.m2/repository/com/sun/xml/fastinfoset/FastInfoset/1.2.15
+  - name: io.konveyor.demo.config-utils
+    version: 1.0.0
+    type: compile
+    resolvedIdentifier: FE4FE11AAEE77BE10035218537FBF4B2E6EF1D9F
+    extras:
+      artifactId: config-utils
+      groupId: io.konveyor.demo
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=internal
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/konveyor/demo/config-utils/1.0.0
+  - name: io.micrometer.micrometer-core
+    version: 1.7.0
     type: compile
     indirect: true
-    resolvedIdentifier: 83cd2cd674a217ade95a4bb83a8a14f351f48bd0
+    resolvedIdentifier: bc7dc1605f2099dc3c39156b7f62ac889f54fb67
     extras:
-      artifactId: antlr
-      groupId: antlr
+      artifactId: micrometer-core
+      groupId: io.micrometer
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/antlr/antlr/2.7.7
-  - name: org.jboss.jandex
-    version: 2.2.3.Final
+    prefix: file:///root/.m2/repository/io/micrometer/micrometer-core/1.7.0
+  - name: jakarta.annotation.jakarta.annotation-api
+    version: 1.3.5
     type: compile
     indirect: true
-    resolvedIdentifier: d3865101f0666b63586683bd811d754517f331ab
+    resolvedIdentifier: 59eb84ee0d616332ff44aba065f3888cf002cd2d
     extras:
-      artifactId: jandex
-      groupId: org.jboss
+      artifactId: jakarta.annotation-api
+      groupId: jakarta.annotation
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/jboss/jandex/2.2.3.Final
+    prefix: file:///root/.m2/repository/jakarta/annotation/jakarta.annotation-api/1.3.5
+  - name: jakarta.validation.jakarta.validation-api
+    version: 2.0.2
+    type: compile
+    indirect: true
+    resolvedIdentifier: 5eacc6522521f7eacb081f95cee1e231648461e7
+    extras:
+      artifactId: jakarta.validation-api
+      groupId: jakarta.validation
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/jakarta/validation/jakarta.validation-api/2.0.2
   - name: javax.activation.javax.activation-api
     version: 1.2.0
     type: compile
@@ -531,6 +532,19 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/javax/activation/javax.activation-api/1.2.0
+  - name: javax.persistence.javax.persistence-api
+    version: "2.2"
+    type: compile
+    indirect: true
+    resolvedIdentifier: 25665ac8c0b62f50e6488173233239120fc52c96
+    extras:
+      artifactId: javax.persistence-api
+      groupId: javax.persistence
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/javax/persistence/javax.persistence-api/2.2
   - name: javax.xml.bind.jaxb-api
     version: 2.3.1
     type: compile
@@ -544,6 +558,121 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/javax/xml/bind/jaxb-api/2.3.1
+  - name: net.bytebuddy.byte-buddy
+    version: 1.10.22
+    type: compile
+    indirect: true
+    resolvedIdentifier: ef45d7e2cd1c600d279704f492ed5ce2ceb6cdb5
+    extras:
+      artifactId: byte-buddy
+      groupId: net.bytebuddy
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/net/bytebuddy/byte-buddy/1.10.22
+  - name: org.apache.logging.log4j.log4j-api
+    version: 2.14.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: cd8858fbbde69f46bce8db1152c18a43328aae78
+    extras:
+      artifactId: log4j-api
+      groupId: org.apache.logging.log4j
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/apache/logging/log4j/log4j-api/2.14.1
+  - name: org.apache.logging.log4j.log4j-to-slf4j
+    version: 2.14.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: ce8a86a3f50a4304749828ce68e7478cafbc8039
+    extras:
+      artifactId: log4j-to-slf4j
+      groupId: org.apache.logging.log4j
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/apache/logging/log4j/log4j-to-slf4j/2.14.1
+  - name: org.apache.tomcat.tomcat-jdbc
+    version: 9.0.46
+    type: runtime
+    resolvedIdentifier: 385cb6cb1f6b26c881cd5c1c6ade5f180712ffdc
+    extras:
+      artifactId: tomcat-jdbc
+      groupId: org.apache.tomcat
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/apache/tomcat/tomcat-jdbc/9.0.46
+  - name: org.apache.tomcat.tomcat-juli
+    version: 9.0.46
+    type: runtime
+    indirect: true
+    resolvedIdentifier: 409b519751e104eab51b4347a0d27bf86a4f3bb1
+    extras:
+      artifactId: tomcat-juli
+      groupId: org.apache.tomcat
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/apache/tomcat/tomcat-juli/9.0.46
+  - name: org.apache.tomcat.tomcat-servlet-api
+    version: 9.0.46
+    type: provided
+    resolvedIdentifier: 8e8a27a3456b71b1da2c8adc902ade71bc91fcb4
+    extras:
+      artifactId: tomcat-servlet-api
+      groupId: org.apache.tomcat
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/apache/tomcat/tomcat-servlet-api/9.0.46
+  - name: org.aspectj.aspectjrt
+    version: 1.9.6
+    type: compile
+    indirect: true
+    resolvedIdentifier: 1651849d48659e5703adc2599e694bf67b8c3fc4
+    extras:
+      artifactId: aspectjrt
+      groupId: org.aspectj
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/aspectj/aspectjrt/1.9.6
+  - name: org.checkerframework.checker-qual
+    version: 3.5.0
+    type: runtime
+    indirect: true
+    resolvedIdentifier: 2f50520c8abea66fbd8d26e481d3aef5c673b510
+    extras:
+      artifactId: checker-qual
+      groupId: org.checkerframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/checkerframework/checker-qual/3.5.0
+  - name: org.dom4j.dom4j
+    version: 2.1.3
+    type: compile
+    indirect: true
+    resolvedIdentifier: a75914155a9f5808963170ec20653668a2ffd2fd
+    extras:
+      artifactId: dom4j
+      groupId: org.dom4j
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/dom4j/dom4j/2.1.3
   - name: org.glassfish.jaxb.jaxb-runtime
     version: 2.3.1
     type: compile
@@ -570,316 +699,6 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/org/glassfish/jaxb/txw2/2.3.1
-  - name: com.sun.istack.istack-commons-runtime
-    version: 3.0.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: c197c86ceec7318b1284bffb49b54226ca774003
-    extras:
-      artifactId: istack-commons-runtime
-      groupId: com.sun.istack
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/sun/istack/istack-commons-runtime/3.0.7
-  - name: org.jvnet.staxex.stax-ex
-    version: "1.8"
-    type: compile
-    indirect: true
-    resolvedIdentifier: 8cc35f73da321c29973191f2cf143d29d26a1df7
-    extras:
-      artifactId: stax-ex
-      groupId: org.jvnet.staxex
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/jvnet/staxex/stax-ex/1.8
-  - name: com.sun.xml.fastinfoset.FastInfoset
-    version: 1.2.15
-    type: compile
-    indirect: true
-    resolvedIdentifier: bb7b7ec0379982b97c62cd17465cb6d9155f68e8
-    extras:
-      artifactId: FastInfoset
-      groupId: com.sun.xml.fastinfoset
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/sun/xml/fastinfoset/FastInfoset/1.2.15
-  - name: org.dom4j.dom4j
-    version: 2.1.3
-    type: compile
-    indirect: true
-    resolvedIdentifier: a75914155a9f5808963170ec20653668a2ffd2fd
-    extras:
-      artifactId: dom4j
-      groupId: org.dom4j
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/dom4j/dom4j/2.1.3
-  - name: org.hibernate.common.hibernate-commons-annotations
-    version: 5.1.2.Final
-    type: compile
-    indirect: true
-    resolvedIdentifier: e59ffdbc6ad09eeb33507b39ffcf287679a498c8
-    extras:
-      artifactId: hibernate-commons-annotations
-      groupId: org.hibernate.common
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/hibernate/common/hibernate-commons-annotations/5.1.2.Final
-  - name: javax.persistence.javax.persistence-api
-    version: "2.2"
-    type: compile
-    indirect: true
-    resolvedIdentifier: 25665ac8c0b62f50e6488173233239120fc52c96
-    extras:
-      artifactId: javax.persistence-api
-      groupId: javax.persistence
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/javax/persistence/javax.persistence-api/2.2
-  - name: net.bytebuddy.byte-buddy
-    version: 1.10.22
-    type: compile
-    indirect: true
-    resolvedIdentifier: ef45d7e2cd1c600d279704f492ed5ce2ceb6cdb5
-    extras:
-      artifactId: byte-buddy
-      groupId: net.bytebuddy
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/net/bytebuddy/byte-buddy/1.10.22
-  - name: org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec
-    version: 1.1.1.Final
-    type: compile
-    indirect: true
-    resolvedIdentifier: a8485cab9484dda36e9a8c319e76b5cc18797b58
-    extras:
-      artifactId: jboss-transaction-api_1.2_spec
-      groupId: org.jboss.spec.javax.transaction
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.1.1.Final
-  - name: org.apache.tomcat.tomcat-jdbc
-    version: 9.0.46
-    type: runtime
-    resolvedIdentifier: 385cb6cb1f6b26c881cd5c1c6ade5f180712ffdc
-    extras:
-      artifactId: tomcat-jdbc
-      groupId: org.apache.tomcat
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/apache/tomcat/tomcat-jdbc/9.0.46
-  - name: org.apache.tomcat.tomcat-juli
-    version: 9.0.46
-    type: runtime
-    indirect: true
-    resolvedIdentifier: 409b519751e104eab51b4347a0d27bf86a4f3bb1
-    extras:
-      artifactId: tomcat-juli
-      groupId: org.apache.tomcat
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/apache/tomcat/tomcat-juli/9.0.46
-  - name: org.springframework.boot.spring-boot-starter-actuator
-    version: 2.5.0
-    type: compile
-    resolvedIdentifier: 8fc47befa38bdaa2f2b8f421d8532f03005e2851
-    extras:
-      artifactId: spring-boot-starter-actuator
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-starter-actuator/2.5.0
-  - name: org.springframework.boot.spring-boot-starter
-    version: 2.5.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: a910887c01efcc7d12f3f89a7604d436f26eeb90
-    extras:
-      artifactId: spring-boot-starter
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-starter/2.5.0
-  - name: org.springframework.boot.spring-boot
-    version: 2.5.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: b07513e04ad906ea69ef84293a123cdb83828f06
-    extras:
-      artifactId: spring-boot
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot/2.5.0
-  - name: org.springframework.boot.spring-boot-autoconfigure
-    version: 2.5.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: 64c7bbc941c70895621ed613f38dc66b73ea9341
-    extras:
-      artifactId: spring-boot-autoconfigure
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/2.5.0
-  - name: org.springframework.boot.spring-boot-starter-logging
-    version: 2.5.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: 22401482ba1c5a1dcd3d33e47295779211b913d8
-    extras:
-      artifactId: spring-boot-starter-logging
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-starter-logging/2.5.0
-  - name: org.apache.logging.log4j.log4j-to-slf4j
-    version: 2.14.1
-    type: compile
-    indirect: true
-    resolvedIdentifier: ce8a86a3f50a4304749828ce68e7478cafbc8039
-    extras:
-      artifactId: log4j-to-slf4j
-      groupId: org.apache.logging.log4j
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/apache/logging/log4j/log4j-to-slf4j/2.14.1
-  - name: org.apache.logging.log4j.log4j-api
-    version: 2.14.1
-    type: compile
-    indirect: true
-    resolvedIdentifier: cd8858fbbde69f46bce8db1152c18a43328aae78
-    extras:
-      artifactId: log4j-api
-      groupId: org.apache.logging.log4j
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/apache/logging/log4j/log4j-api/2.14.1
-  - name: org.slf4j.jul-to-slf4j
-    version: 1.7.30
-    type: compile
-    indirect: true
-    resolvedIdentifier: d58bebff8cbf70ff52b59208586095f467656c30
-    extras:
-      artifactId: jul-to-slf4j
-      groupId: org.slf4j
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/slf4j/jul-to-slf4j/1.7.30
-  - name: jakarta.annotation.jakarta.annotation-api
-    version: 1.3.5
-    type: compile
-    indirect: true
-    resolvedIdentifier: 59eb84ee0d616332ff44aba065f3888cf002cd2d
-    extras:
-      artifactId: jakarta.annotation-api
-      groupId: jakarta.annotation
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/jakarta/annotation/jakarta.annotation-api/1.3.5
-  - name: org.yaml.snakeyaml
-    version: "1.28"
-    type: compile
-    indirect: true
-    resolvedIdentifier: 7cae037c3014350c923776548e71c9feb7a69259
-    extras:
-      artifactId: snakeyaml
-      groupId: org.yaml
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/yaml/snakeyaml/1.28
-  - name: org.springframework.boot.spring-boot-actuator-autoconfigure
-    version: 2.5.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: 41956882243e86f8260f649ebdd96597a2ff52a9
-    extras:
-      artifactId: spring-boot-actuator-autoconfigure
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-actuator-autoconfigure/2.5.0
-  - name: org.springframework.boot.spring-boot-actuator
-    version: 2.5.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: e0ac75f1a183f8e6a319a8b03bad1c45d40a2761
-    extras:
-      artifactId: spring-boot-actuator
-      groupId: org.springframework.boot
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-actuator/2.5.0
-  - name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
-    version: 2.12.3
-    type: runtime
-    indirect: true
-    resolvedIdentifier: f69c636438dcf19c49960c1fe8901320ab85f989
-    extras:
-      artifactId: jackson-datatype-jsr310
-      groupId: com.fasterxml.jackson.datatype
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.12.3
-  - name: io.micrometer.micrometer-core
-    version: 1.7.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: bc7dc1605f2099dc3c39156b7f62ac889f54fb67
-    extras:
-      artifactId: micrometer-core
-      groupId: io.micrometer
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/micrometer/micrometer-core/1.7.0
   - name: org.hdrhistogram.HdrHistogram
     version: 2.1.12
     type: compile
@@ -893,6 +712,121 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/org/hdrhistogram/HdrHistogram/2.1.12
+  - name: org.hibernate.common.hibernate-commons-annotations
+    version: 5.1.2.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: e59ffdbc6ad09eeb33507b39ffcf287679a498c8
+    extras:
+      artifactId: hibernate-commons-annotations
+      groupId: org.hibernate.common
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/hibernate/common/hibernate-commons-annotations/5.1.2.Final
+  - name: org.hibernate.hibernate-core
+    version: 5.4.32.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: 99a5e10bf455337014c190e141ec631e9ff71663
+    extras:
+      artifactId: hibernate-core
+      groupId: org.hibernate
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/hibernate/hibernate-core/5.4.32.Final
+  - name: org.hibernate.hibernate-entitymanager
+    version: 5.4.32.Final
+    type: compile
+    resolvedIdentifier: 3f60db4097732960ec792c033dbb7c34f1b9e328
+    extras:
+      artifactId: hibernate-entitymanager
+      groupId: org.hibernate
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/hibernate/hibernate-entitymanager/5.4.32.Final
+  - name: org.hibernate.validator.hibernate-validator
+    version: 6.2.0.Final
+    type: compile
+    resolvedIdentifier: d6b0760dfffbf379cedd02f715ff4c9a2e215921
+    extras:
+      artifactId: hibernate-validator
+      groupId: org.hibernate.validator
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/hibernate/validator/hibernate-validator/6.2.0.Final
+  - name: org.javassist.javassist
+    version: 3.27.0-GA
+    type: compile
+    indirect: true
+    resolvedIdentifier: f63e6aa899e15eca8fdaa402a79af4c417252213
+    extras:
+      artifactId: javassist
+      groupId: org.javassist
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/javassist/javassist/3.27.0-GA
+  - name: org.jboss.jandex
+    version: 2.2.3.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: d3865101f0666b63586683bd811d754517f331ab
+    extras:
+      artifactId: jandex
+      groupId: org.jboss
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/jboss/jandex/2.2.3.Final
+  - name: org.jboss.logging.jboss-logging
+    version: 3.4.1.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: 40fd4d696c55793e996d1ff3c475833f836c2498
+    extras:
+      artifactId: jboss-logging
+      groupId: org.jboss.logging
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/jboss/logging/jboss-logging/3.4.1.Final
+  - name: org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec
+    version: 1.1.1.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: a8485cab9484dda36e9a8c319e76b5cc18797b58
+    extras:
+      artifactId: jboss-transaction-api_1.2_spec
+      groupId: org.jboss.spec.javax.transaction
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.1.1.Final
+  - name: org.jvnet.staxex.stax-ex
+    version: "1.8"
+    type: compile
+    indirect: true
+    resolvedIdentifier: 8cc35f73da321c29973191f2cf143d29d26a1df7
+    extras:
+      artifactId: stax-ex
+      groupId: org.jvnet.staxex
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/jvnet/staxex/stax-ex/1.8
   - name: org.latencyutils.LatencyUtils
     version: 2.0.3
     type: runtime
@@ -906,6 +840,275 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/org/latencyutils/LatencyUtils/2.0.3
+  - name: org.postgresql.postgresql
+    version: 42.2.23
+    type: compile
+    resolvedIdentifier: 9cb217a3d5b640567ed7c6e8c11f389613c81c4d
+    extras:
+      artifactId: postgresql
+      groupId: org.postgresql
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/postgresql/postgresql/42.2.23
+  - name: org.slf4j.jul-to-slf4j
+    version: 1.7.30
+    type: compile
+    indirect: true
+    resolvedIdentifier: d58bebff8cbf70ff52b59208586095f467656c30
+    extras:
+      artifactId: jul-to-slf4j
+      groupId: org.slf4j
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/slf4j/jul-to-slf4j/1.7.30
+  - name: org.slf4j.slf4j-api
+    version: 1.7.26
+    type: compile
+    indirect: true
+    resolvedIdentifier: 77100a62c2e6f04b53977b9f541044d7d722693d
+    extras:
+      artifactId: slf4j-api
+      groupId: org.slf4j
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/slf4j/slf4j-api/1.7.26
+  - name: org.springframework.boot.spring-boot
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: b07513e04ad906ea69ef84293a123cdb83828f06
+    extras:
+      artifactId: spring-boot
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot/2.5.0
+  - name: org.springframework.boot.spring-boot-actuator
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: e0ac75f1a183f8e6a319a8b03bad1c45d40a2761
+    extras:
+      artifactId: spring-boot-actuator
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-actuator/2.5.0
+  - name: org.springframework.boot.spring-boot-actuator-autoconfigure
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 41956882243e86f8260f649ebdd96597a2ff52a9
+    extras:
+      artifactId: spring-boot-actuator-autoconfigure
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-actuator-autoconfigure/2.5.0
+  - name: org.springframework.boot.spring-boot-autoconfigure
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 64c7bbc941c70895621ed613f38dc66b73ea9341
+    extras:
+      artifactId: spring-boot-autoconfigure
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/2.5.0
+  - name: org.springframework.boot.spring-boot-starter
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: a910887c01efcc7d12f3f89a7604d436f26eeb90
+    extras:
+      artifactId: spring-boot-starter
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-starter/2.5.0
+  - name: org.springframework.boot.spring-boot-starter-actuator
+    version: 2.5.0
+    type: compile
+    resolvedIdentifier: 8fc47befa38bdaa2f2b8f421d8532f03005e2851
+    extras:
+      artifactId: spring-boot-starter-actuator
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-starter-actuator/2.5.0
+  - name: org.springframework.boot.spring-boot-starter-logging
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 22401482ba1c5a1dcd3d33e47295779211b913d8
+    extras:
+      artifactId: spring-boot-starter-logging
+      groupId: org.springframework.boot
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/boot/spring-boot-starter-logging/2.5.0
+  - name: org.springframework.data.spring-data-commons
+    version: 2.5.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: c950ca1a05e928e9fb75420b4ac07713428e9969
+    extras:
+      artifactId: spring-data-commons
+      groupId: org.springframework.data
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/data/spring-data-commons/2.5.1
+  - name: org.springframework.data.spring-data-jpa
+    version: 2.5.1
+    type: compile
+    resolvedIdentifier: 881f7ae140f424b3bdb1b0c27a61b93e0bee9fa5
+    extras:
+      artifactId: spring-data-jpa
+      groupId: org.springframework.data
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/data/spring-data-jpa/2.5.1
+  - name: org.springframework.spring-aop
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: b86edd2455f8c4399068c999beb9ea2a9e7f2047
+    extras:
+      artifactId: spring-aop
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-aop/5.3.7
+  - name: org.springframework.spring-beans
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 8b1eacd7aaa12f7d173a2f0836d28bd0c1b098fe
+    extras:
+      artifactId: spring-beans
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-beans/5.3.7
+  - name: org.springframework.spring-context
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 330b3957efdcdebe3550b8e2c5d45a4c25496626
+    extras:
+      artifactId: spring-context
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-context/5.3.7
+  - name: org.springframework.spring-core
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 4aad1b62bd347a806fe693c9d67b376a3ad8151c
+    extras:
+      artifactId: spring-core
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-core/5.3.7
+  - name: org.springframework.spring-expression
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 13351fce0a604957cd6a41478ebb54a953a0245e
+    extras:
+      artifactId: spring-expression
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-expression/5.3.7
+  - name: org.springframework.spring-jcl
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: ccd8bde38bad689737295fa220e1c70680676d72
+    extras:
+      artifactId: spring-jcl
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-jcl/5.3.7
+  - name: org.springframework.spring-jdbc
+    version: 5.3.7
+    type: compile
+    resolvedIdentifier: 5caf72035a9b8a3a09ef82322cd2497aedddc487
+    extras:
+      artifactId: spring-jdbc
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-jdbc/5.3.7
+  - name: org.springframework.spring-orm
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: f1892fe7a6671348d6546facbd40159b7e6f64a2
+    extras:
+      artifactId: spring-orm
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-orm/5.3.7
+  - name: org.springframework.spring-tx
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 98be572c2bf3bd08724363b0bba71bcef59c4739
+    extras:
+      artifactId: spring-tx
+      groupId: org.springframework
+      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/springframework/spring-tx/5.3.7
   - name: org.springframework.spring-web
     version: 5.3.7
     type: compile
@@ -930,225 +1133,35 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/org/springframework/spring-webmvc/5.3.7
-  - name: org.springframework.spring-expression
-    version: 5.3.7
+  - name: org.yaml.snakeyaml
+    version: "1.28"
     type: compile
     indirect: true
-    resolvedIdentifier: 13351fce0a604957cd6a41478ebb54a953a0245e
+    resolvedIdentifier: 7cae037c3014350c923776548e71c9feb7a69259
     extras:
-      artifactId: spring-expression
-      groupId: org.springframework
+      artifactId: snakeyaml
+      groupId: org.yaml
       pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-expression/5.3.7
-  - name: org.springframework.spring-jdbc
-    version: 5.3.7
-    type: compile
-    resolvedIdentifier: 5caf72035a9b8a3a09ef82322cd2497aedddc487
-    extras:
-      artifactId: spring-jdbc
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-jdbc/5.3.7
-  - name: org.springframework.data.spring-data-jpa
-    version: 2.5.1
-    type: compile
-    resolvedIdentifier: 881f7ae140f424b3bdb1b0c27a61b93e0bee9fa5
-    extras:
-      artifactId: spring-data-jpa
-      groupId: org.springframework.data
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/data/spring-data-jpa/2.5.1
-  - name: org.springframework.data.spring-data-commons
-    version: 2.5.1
-    type: compile
-    indirect: true
-    resolvedIdentifier: c950ca1a05e928e9fb75420b4ac07713428e9969
-    extras:
-      artifactId: spring-data-commons
-      groupId: org.springframework.data
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/data/spring-data-commons/2.5.1
-  - name: org.springframework.spring-orm
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: f1892fe7a6671348d6546facbd40159b7e6f64a2
-    extras:
-      artifactId: spring-orm
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-orm/5.3.7
-  - name: org.springframework.spring-context
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: 330b3957efdcdebe3550b8e2c5d45a4c25496626
-    extras:
-      artifactId: spring-context
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-context/5.3.7
-  - name: org.springframework.spring-aop
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: b86edd2455f8c4399068c999beb9ea2a9e7f2047
-    extras:
-      artifactId: spring-aop
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-aop/5.3.7
-  - name: org.springframework.spring-tx
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: 98be572c2bf3bd08724363b0bba71bcef59c4739
-    extras:
-      artifactId: spring-tx
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-tx/5.3.7
-  - name: org.springframework.spring-beans
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: 8b1eacd7aaa12f7d173a2f0836d28bd0c1b098fe
-    extras:
-      artifactId: spring-beans
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-beans/5.3.7
-  - name: org.springframework.spring-core
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: 4aad1b62bd347a806fe693c9d67b376a3ad8151c
-    extras:
-      artifactId: spring-core
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-core/5.3.7
-  - name: org.springframework.spring-jcl
-    version: 5.3.7
-    type: compile
-    indirect: true
-    resolvedIdentifier: ccd8bde38bad689737295fa220e1c70680676d72
-    extras:
-      artifactId: spring-jcl
-      groupId: org.springframework
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/springframework/spring-jcl/5.3.7
-  - name: org.aspectj.aspectjrt
-    version: 1.9.6
-    type: compile
-    indirect: true
-    resolvedIdentifier: 1651849d48659e5703adc2599e694bf67b8c3fc4
-    extras:
-      artifactId: aspectjrt
-      groupId: org.aspectj
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/aspectj/aspectjrt/1.9.6
-  - name: org.slf4j.slf4j-api
-    version: 1.7.26
-    type: compile
-    indirect: true
-    resolvedIdentifier: 77100a62c2e6f04b53977b9f541044d7d722693d
-    extras:
-      artifactId: slf4j-api
-      groupId: org.slf4j
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/slf4j/slf4j-api/1.7.26
-  - name: com.fasterxml.jackson.core.jackson-databind
-    version: 2.12.3
-    type: compile
-    resolvedIdentifier: d6153f8fc60c479ab0f9efb35c034526436a4953
-    extras:
-      artifactId: jackson-databind
-      groupId: com.fasterxml.jackson.core
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.3
-  - name: com.fasterxml.jackson.core.jackson-annotations
-    version: 2.12.3
-    type: compile
-    indirect: true
-    resolvedIdentifier: 7275513412694a1aafd08c0287f48469fa0e6e17
-    extras:
-      artifactId: jackson-annotations
-      groupId: com.fasterxml.jackson.core
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.3
-  - name: com.fasterxml.jackson.core.jackson-core
-    version: 2.12.3
-    type: compile
-    resolvedIdentifier: deb23fe2a7f2b773e18ced2b50d4acc1df8fa366
-    extras:
-      artifactId: jackson-core
-      groupId: com.fasterxml.jackson.core
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.3
-  - name: org.apache.tomcat.tomcat-servlet-api
-    version: 9.0.46
-    type: provided
-    resolvedIdentifier: 8e8a27a3456b71b1da2c8adc902ade71bc91fcb4
-    extras:
-      artifactId: tomcat-servlet-api
-      groupId: org.apache.tomcat
-      pomPath: /analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/apache/tomcat/tomcat-servlet-api/9.0.46
+    prefix: file:///root/.m2/repository/org/yaml/snakeyaml/1.28
 - fileURI: file:///analyzer-lsp/examples/java/pom.xml
   provider: java
   dependencies:
+  - name: com.fasterxml.jackson.core.jackson-annotations
+    version: 2.13.3
+    type: compile
+    indirect: true
+    resolvedIdentifier: 7198b3aac15285a49e218e08441c5f70af00fc51
+    extras:
+      artifactId: jackson-annotations
+      groupId: com.fasterxml.jackson.core
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.13.3
   - name: com.fasterxml.jackson.core.jackson-core
     version: 2.13.3
     type: compile
@@ -1173,18 +1186,6 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.13.3
-  - name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
-    version: 2.13.3
-    type: compile
-    resolvedIdentifier: ad2f4c61aeb9e2a8bb5e4a3ed782cfddec52d972
-    extras:
-      artifactId: jackson-datatype-jsr310
-      groupId: com.fasterxml.jackson.datatype
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.13.3
   - name: com.fasterxml.jackson.dataformat.jackson-dataformat-yaml
     version: 2.13.3
     type: compile
@@ -1197,322 +1198,31 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.13.3
-  - name: org.yaml.snakeyaml
-    version: "1.30"
-    type: compile
-    indirect: true
-    resolvedIdentifier: 8fde7fe2586328ac3c68db92045e1c8759125000
-    extras:
-      artifactId: snakeyaml
-      groupId: org.yaml
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/yaml/snakeyaml/1.30
-  - name: org.slf4j.slf4j-api
-    version: 1.7.36
-    type: compile
-    resolvedIdentifier: 6c62681a2f655b49963a5983b8b0950a6120ae14
-    extras:
-      artifactId: slf4j-api
-      groupId: org.slf4j
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/org/slf4j/slf4j-api/1.7.36
-  - name: io.fabric8.kubernetes-model-node
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 972706f6dffa518e11c94647cf47e188db6115f6
-    extras:
-      artifactId: kubernetes-model-node
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-node/6.0.0
-  - name: io.fabric8.kubernetes-model-storageclass
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 6ffa61f9021d07a4a9d785e83a513955a3c48073
-    extras:
-      artifactId: kubernetes-model-storageclass
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-storageclass/6.0.0
-  - name: io.fabric8.kubernetes-model-scheduling
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: a5fae7294f5c39fb9d7cffb7280b55ca458c9128
-    extras:
-      artifactId: kubernetes-model-scheduling
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-scheduling/6.0.0
-  - name: io.fabric8.kubernetes-model-policy
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 15b3011eb5ff48b9fc2bd8bcc4db697ca9ec30e4
-    extras:
-      artifactId: kubernetes-model-policy
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-policy/6.0.0
-  - name: io.fabric8.kubernetes-model-metrics
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 1a400f8f7915bd2a68fa075605768d762aaad4cb
-    extras:
-      artifactId: kubernetes-model-metrics
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-metrics/6.0.0
-  - name: io.fabric8.kubernetes-model-networking
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: c87e11bebb26bb48660765b42a68f9577336b799
-    extras:
-      artifactId: kubernetes-model-networking
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-networking/6.0.0
-  - name: io.fabric8.kubernetes-model-flowcontrol
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 3b01d9eab7e7d7c9d46d8828202bff78fbdaa7d9
-    extras:
-      artifactId: kubernetes-model-flowcontrol
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-flowcontrol/6.0.0
-  - name: io.fabric8.kubernetes-model-extensions
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 60c9e43f1f34ab9c145798471926c07e13e45ecf
-    extras:
-      artifactId: kubernetes-model-extensions
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-extensions/6.0.0
-  - name: io.fabric8.kubernetes-model-events
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 204c2c78a4a8e0b5f5ebc1b788c9f22a8c1b14ab
-    extras:
-      artifactId: kubernetes-model-events
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-events/6.0.0
-  - name: io.fabric8.kubernetes-model-discovery
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 246ad448a1868b3c601394e21350a9602adef24c
-    extras:
-      artifactId: kubernetes-model-discovery
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-discovery/6.0.0
-  - name: io.fabric8.kubernetes-model-coordination
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: cd454532158351d8ff37616dc33749ca2a85c8d1
-    extras:
-      artifactId: kubernetes-model-coordination
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-coordination/6.0.0
-  - name: io.fabric8.kubernetes-model-certificates
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 33f5a3f386cddda55003e1616303ab924fcd3ca5
-    extras:
-      artifactId: kubernetes-model-certificates
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-certificates/6.0.0
-  - name: io.fabric8.kubernetes-model-batch
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 9f14cbfc75d172fa81f3f6ad793bdd45a2decaec
-    extras:
-      artifactId: kubernetes-model-batch
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-batch/6.0.0
-  - name: io.fabric8.kubernetes-model-apiextensions
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: eac63b8dec80e96c4356c91ed0a332415efcb75e
-    extras:
-      artifactId: kubernetes-model-apiextensions
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-apiextensions/6.0.0
-  - name: io.fabric8.kubernetes-model-autoscaling
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: b353e45133fbc80791d676b16203ec94c0958b7d
-    extras:
-      artifactId: kubernetes-model-autoscaling
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-autoscaling/6.0.0
-  - name: io.fabric8.kubernetes-model-apps
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 4dbda6401058a5fd3a4c6be88fc1bf4f99296c4f
-    extras:
-      artifactId: kubernetes-model-apps
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-apps/6.0.0
-  - name: io.fabric8.kubernetes-model-admissionregistration
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 9e3b0d4caa3d033fa0f71c71d8a535a748b280ba
-    extras:
-      artifactId: kubernetes-model-admissionregistration
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-admissionregistration/6.0.0
-  - name: io.fabric8.kubernetes-model-rbac
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 03ad461761d775ff9c252d2b26a4977d22dd0f3a
-    extras:
-      artifactId: kubernetes-model-rbac
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-rbac/6.0.0
-  - name: io.fabric8.kubernetes-model-core
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 73469e4a7baec7600455d7f4a121c6680e80bf35
-    extras:
-      artifactId: kubernetes-model-core
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-core/6.0.0
-  - name: io.fabric8.kubernetes-model-common
-    version: 6.0.0
-    type: compile
-    indirect: true
-    resolvedIdentifier: 7d45968cf6b9902e37d5d542f42ee2daed203e3d
-    extras:
-      artifactId: kubernetes-model-common
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-common/6.0.0
-  - name: com.fasterxml.jackson.core.jackson-annotations
+  - name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
     version: 2.13.3
     type: compile
-    indirect: true
-    resolvedIdentifier: 7198b3aac15285a49e218e08441c5f70af00fc51
+    resolvedIdentifier: ad2f4c61aeb9e2a8bb5e4a3ed782cfddec52d972
     extras:
-      artifactId: jackson-annotations
-      groupId: com.fasterxml.jackson.core
+      artifactId: jackson-datatype-jsr310
+      groupId: com.fasterxml.jackson.datatype
       pomPath: /analyzer-lsp/examples/java/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.13.3
-  - name: io.fabric8.kubernetes-client-api
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: 3f54cdb10f54b413fe4b8a0d4d044d33174bd271
-    extras:
-      artifactId: kubernetes-client-api
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-client-api/6.0.0
-  - name: io.fabric8.kubernetes-client
-    version: 6.0.0
-    type: compile
-    resolvedIdentifier: d0831d44e12313df8989fc1d4a9c90452f08858e
-    extras:
-      artifactId: kubernetes-client
-      groupId: io.fabric8
-      pomPath: /analyzer-lsp/examples/java/pom.xml
-    labels:
-    - konveyor.io/dep-source=open-source
-    - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-client/6.0.0
-  - name: io.fabric8.kubernetes-httpclient-okhttp
-    version: 6.0.0
+    prefix: file:///root/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.13.3
+  - name: com.squareup.okhttp3.logging-interceptor
+    version: 3.12.12
     type: runtime
     indirect: true
-    resolvedIdentifier: 70690b98acb07a809c55d15d7cf45f53ec1026e1
+    resolvedIdentifier: d952189f6abb148ff72aab246aa8c28cf99b469f
     extras:
-      artifactId: kubernetes-httpclient-okhttp
-      groupId: io.fabric8
+      artifactId: logging-interceptor
+      groupId: com.squareup.okhttp3
       pomPath: /analyzer-lsp/examples/java/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-httpclient-okhttp/6.0.0
+    prefix: file:///root/.m2/repository/com/squareup/okhttp3/logging-interceptor/3.12.12
   - name: com.squareup.okhttp3.okhttp
     version: 3.12.12
     type: runtime
@@ -1539,19 +1249,284 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/com/squareup/okio/okio/1.15.0
-  - name: com.squareup.okhttp3.logging-interceptor
-    version: 3.12.12
-    type: runtime
-    indirect: true
-    resolvedIdentifier: d952189f6abb148ff72aab246aa8c28cf99b469f
+  - name: io.fabric8.kubernetes-client
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: d0831d44e12313df8989fc1d4a9c90452f08858e
     extras:
-      artifactId: logging-interceptor
-      groupId: com.squareup.okhttp3
+      artifactId: kubernetes-client
+      groupId: io.fabric8
       pomPath: /analyzer-lsp/examples/java/pom.xml
     labels:
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
-    prefix: file:///root/.m2/repository/com/squareup/okhttp3/logging-interceptor/3.12.12
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-client/6.0.0
+  - name: io.fabric8.kubernetes-client-api
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 3f54cdb10f54b413fe4b8a0d4d044d33174bd271
+    extras:
+      artifactId: kubernetes-client-api
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-client-api/6.0.0
+  - name: io.fabric8.kubernetes-httpclient-okhttp
+    version: 6.0.0
+    type: runtime
+    indirect: true
+    resolvedIdentifier: 70690b98acb07a809c55d15d7cf45f53ec1026e1
+    extras:
+      artifactId: kubernetes-httpclient-okhttp
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-httpclient-okhttp/6.0.0
+  - name: io.fabric8.kubernetes-model-admissionregistration
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 9e3b0d4caa3d033fa0f71c71d8a535a748b280ba
+    extras:
+      artifactId: kubernetes-model-admissionregistration
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-admissionregistration/6.0.0
+  - name: io.fabric8.kubernetes-model-apiextensions
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: eac63b8dec80e96c4356c91ed0a332415efcb75e
+    extras:
+      artifactId: kubernetes-model-apiextensions
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-apiextensions/6.0.0
+  - name: io.fabric8.kubernetes-model-apps
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 4dbda6401058a5fd3a4c6be88fc1bf4f99296c4f
+    extras:
+      artifactId: kubernetes-model-apps
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-apps/6.0.0
+  - name: io.fabric8.kubernetes-model-autoscaling
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: b353e45133fbc80791d676b16203ec94c0958b7d
+    extras:
+      artifactId: kubernetes-model-autoscaling
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-autoscaling/6.0.0
+  - name: io.fabric8.kubernetes-model-batch
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 9f14cbfc75d172fa81f3f6ad793bdd45a2decaec
+    extras:
+      artifactId: kubernetes-model-batch
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-batch/6.0.0
+  - name: io.fabric8.kubernetes-model-certificates
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 33f5a3f386cddda55003e1616303ab924fcd3ca5
+    extras:
+      artifactId: kubernetes-model-certificates
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-certificates/6.0.0
+  - name: io.fabric8.kubernetes-model-common
+    version: 6.0.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 7d45968cf6b9902e37d5d542f42ee2daed203e3d
+    extras:
+      artifactId: kubernetes-model-common
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-common/6.0.0
+  - name: io.fabric8.kubernetes-model-coordination
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: cd454532158351d8ff37616dc33749ca2a85c8d1
+    extras:
+      artifactId: kubernetes-model-coordination
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-coordination/6.0.0
+  - name: io.fabric8.kubernetes-model-core
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 73469e4a7baec7600455d7f4a121c6680e80bf35
+    extras:
+      artifactId: kubernetes-model-core
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-core/6.0.0
+  - name: io.fabric8.kubernetes-model-discovery
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 246ad448a1868b3c601394e21350a9602adef24c
+    extras:
+      artifactId: kubernetes-model-discovery
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-discovery/6.0.0
+  - name: io.fabric8.kubernetes-model-events
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 204c2c78a4a8e0b5f5ebc1b788c9f22a8c1b14ab
+    extras:
+      artifactId: kubernetes-model-events
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-events/6.0.0
+  - name: io.fabric8.kubernetes-model-extensions
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 60c9e43f1f34ab9c145798471926c07e13e45ecf
+    extras:
+      artifactId: kubernetes-model-extensions
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-extensions/6.0.0
+  - name: io.fabric8.kubernetes-model-flowcontrol
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 3b01d9eab7e7d7c9d46d8828202bff78fbdaa7d9
+    extras:
+      artifactId: kubernetes-model-flowcontrol
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-flowcontrol/6.0.0
+  - name: io.fabric8.kubernetes-model-metrics
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 1a400f8f7915bd2a68fa075605768d762aaad4cb
+    extras:
+      artifactId: kubernetes-model-metrics
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-metrics/6.0.0
+  - name: io.fabric8.kubernetes-model-networking
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: c87e11bebb26bb48660765b42a68f9577336b799
+    extras:
+      artifactId: kubernetes-model-networking
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-networking/6.0.0
+  - name: io.fabric8.kubernetes-model-node
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 972706f6dffa518e11c94647cf47e188db6115f6
+    extras:
+      artifactId: kubernetes-model-node
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-node/6.0.0
+  - name: io.fabric8.kubernetes-model-policy
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 15b3011eb5ff48b9fc2bd8bcc4db697ca9ec30e4
+    extras:
+      artifactId: kubernetes-model-policy
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-policy/6.0.0
+  - name: io.fabric8.kubernetes-model-rbac
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 03ad461761d775ff9c252d2b26a4977d22dd0f3a
+    extras:
+      artifactId: kubernetes-model-rbac
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-rbac/6.0.0
+  - name: io.fabric8.kubernetes-model-scheduling
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: a5fae7294f5c39fb9d7cffb7280b55ca458c9128
+    extras:
+      artifactId: kubernetes-model-scheduling
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-scheduling/6.0.0
+  - name: io.fabric8.kubernetes-model-storageclass
+    version: 6.0.0
+    type: compile
+    resolvedIdentifier: 6ffa61f9021d07a4a9d785e83a513955a3c48073
+    extras:
+      artifactId: kubernetes-model-storageclass
+      groupId: io.fabric8
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/io/fabric8/kubernetes-model-storageclass/6.0.0
   - name: io.fabric8.zjsonpatch
     version: 0.3.0
     type: compile
@@ -1590,3 +1565,28 @@
     - konveyor.io/dep-source=open-source
     - konveyor.io/language=java
     prefix: file:///root/.m2/repository/org/hamcrest/hamcrest-core/1.3
+  - name: org.slf4j.slf4j-api
+    version: 1.7.36
+    type: compile
+    resolvedIdentifier: 6c62681a2f655b49963a5983b8b0950a6120ae14
+    extras:
+      artifactId: slf4j-api
+      groupId: org.slf4j
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/slf4j/slf4j-api/1.7.36
+  - name: org.yaml.snakeyaml
+    version: "1.30"
+    type: compile
+    indirect: true
+    resolvedIdentifier: 8fde7fe2586328ac3c68db92045e1c8759125000
+    extras:
+      artifactId: snakeyaml
+      groupId: org.yaml
+      pomPath: /analyzer-lsp/examples/java/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///root/.m2/repository/org/yaml/snakeyaml/1.30

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -12,18 +12,24 @@
       incidents:
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
+        codeSnip: "108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>"
+        lineNumber: 117
         variables:
           data: dependency
           innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
           matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+        codeSnip: "59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  "
+        lineNumber: 68
         variables:
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
           matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
+        codeSnip: "63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>"
+        lineNumber: 72
         variables:
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
@@ -38,18 +44,24 @@
           matchingXML: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
+        codeSnip: "113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>"
+        lineNumber: 122
         variables:
           data: dependency
           innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
           matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+        codeSnip: "124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>\n139  \t<build>\n140  \t\t<plugins>\n141  \t\t\t<plugin>\n142  \t\t\t\t<groupId>org.apache.maven.plugins</groupId>\n143  \t\t\t\t<artifactId>maven-compiler-plugin</artifactId>\n144  \t\t\t\t<version>${maven-compiler-plugin.version}</version>"
+        lineNumber: 133
         variables:
           data: dependency
           innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
           matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
+        codeSnip: " 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>"
+        lineNumber: 101
         variables:
           data: dependency
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
@@ -64,30 +76,40 @@
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
+        codeSnip: "103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>"
+        lineNumber: 112
         variables:
           data: dependency
           innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
           matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
+        codeSnip: " 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 107
         variables:
           data: dependency
           innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
           matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
+        codeSnip: "118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>"
+        lineNumber: 127
         variables:
           data: dependency
           innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
           matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
+        codeSnip: " 87  \t\t\t<artifactId>spring-webmvc</artifactId>\n 88  \t\t\t<version>${spring-framework.version}</version>\n 89  \t\t</dependency>\n 90  \t\t<dependency>\n 91  \t\t\t<groupId>org.springframework</groupId>\n 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 96
         variables:
           data: dependency
           innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
           matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
+        codeSnip: "43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>"
+        lineNumber: 52
         variables:
           data: dependency
           innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
@@ -109,12 +131,6 @@
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-jdbc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
-        variables:
-          data: dependency
-          innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
-          matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
         codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
         lineNumber: 86
@@ -124,24 +140,32 @@
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+        codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
+        lineNumber: 86
         variables:
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+        codeSnip: "25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>\n41      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n42        <plugins>\n43          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->\n44          <plugin>\n45            <artifactId>maven-clean-plugin</artifactId>"
+        lineNumber: 34
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
+        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
+        lineNumber: 29
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
+        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
+        lineNumber: 23
         variables:
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
@@ -212,6 +236,8 @@
           version: 6.0.0
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency junit.junit with 4.11 is bad and you should feel bad for using it
+        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
+        lineNumber: 23
         variables:
           name: junit.junit
           version: "4.11"
@@ -380,18 +406,24 @@
       incidents:
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>'
+        codeSnip: "108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>"
+        lineNumber: 117
         variables:
           data: dependency
           innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
           matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>'
+        codeSnip: "59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  "
+        lineNumber: 68
         variables:
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
           matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>'
+        codeSnip: "63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>"
+        lineNumber: 72
         variables:
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
@@ -406,18 +438,24 @@
           matchingXML: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>'
+        codeSnip: "113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>"
+        lineNumber: 122
         variables:
           data: dependency
           innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
           matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>'
+        codeSnip: "124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>\n139  \t<build>\n140  \t\t<plugins>\n141  \t\t\t<plugin>\n142  \t\t\t\t<groupId>org.apache.maven.plugins</groupId>\n143  \t\t\t\t<artifactId>maven-compiler-plugin</artifactId>\n144  \t\t\t\t<version>${maven-compiler-plugin.version}</version>"
+        lineNumber: 133
         variables:
           data: dependency
           innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
           matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>'
+        codeSnip: " 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>"
+        lineNumber: 101
         variables:
           data: dependency
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
@@ -432,30 +470,40 @@
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>'
+        codeSnip: "103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>"
+        lineNumber: 112
         variables:
           data: dependency
           innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
           matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>'
+        codeSnip: " 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 107
         variables:
           data: dependency
           innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
           matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>'
+        codeSnip: "118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>"
+        lineNumber: 127
         variables:
           data: dependency
           innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
           matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>'
+        codeSnip: " 87  \t\t\t<artifactId>spring-webmvc</artifactId>\n 88  \t\t\t<version>${spring-framework.version}</version>\n 89  \t\t</dependency>\n 90  \t\t<dependency>\n 91  \t\t\t<groupId>org.springframework</groupId>\n 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 96
         variables:
           data: dependency
           innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
           matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>'
+        codeSnip: "43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>"
+        lineNumber: 52
         variables:
           data: dependency
           innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
@@ -486,24 +534,32 @@
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>'
+        codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
+        lineNumber: 86
         variables:
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>'
+        codeSnip: "25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>\n41      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n42        <plugins>\n43          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->\n44          <plugin>\n45            <artifactId>maven-clean-plugin</artifactId>"
+        lineNumber: 34
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>'
+        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
+        lineNumber: 29
         variables:
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>'
+        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
+        lineNumber: 23
         variables:
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -1,39 +1,33 @@
 - name: konveyor-analysis
   tags:
-  - License=Apache
-  - Language=Golang
+  - Backend=Golang
   - Infra=Kubernetes
   - Java
-  - Backend=Golang
+  - Language=Golang
+  - License=Apache
   violations:
     chain-pom-001:
       description: ""
       category: potential
       incidents:
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
-        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
-        lineNumber: 23
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
         variables:
           data: dependency
-          innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
-          matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
-        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
-        lineNumber: 29
+          innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
+          matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
         variables:
           data: dependency
-          innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
-          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
-        codeSnip: "25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>\n41      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n42        <plugins>\n43          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->\n44          <plugin>\n45            <artifactId>maven-clean-plugin</artifactId>"
-        lineNumber: 34
+          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
+          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
         variables:
           data: dependency
-          innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
-          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
+          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
         codeSnip: "36  \t\t\t<id>demo-config</id>\n37  \t\t\t<name>Azure DevOps</name>\n38  \t\t\t<url>https://pkgs.dev.azure.com/ShawnHurley21/demo-config-utils/_packaging/demo-config/maven/v1</url>\n39  \t\t</repository>\n40  \t</repositories>\n41  \n42  \t<dependencyManagement>\n43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>"
@@ -43,13 +37,23 @@
           innerText: "\n\t\t\t\tcom.fasterxml.jackson\n\t\t\t\tjackson-bom\n\t\t\t\t${jackson.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
           matchingXML: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
-        codeSnip: "43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>"
-        lineNumber: 52
+        message: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
         variables:
           data: dependency
-          innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
-          matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
+          innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
+          matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+        variables:
+          data: dependency
+          innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
+          matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
+        variables:
+          data: dependency
+          innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
+          matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
         codeSnip: "53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>"
@@ -59,21 +63,35 @@
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-servlet-api\n\t\t\t${tomcat.version}\n\t\t\tprovided\n\t\t"
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
-        codeSnip: "59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  "
-        lineNumber: 68
+        message: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
         variables:
           data: dependency
-          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
-          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+          innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
+          matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
-        codeSnip: "63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>"
-        lineNumber: 72
+        message: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
         variables:
           data: dependency
-          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
-          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
+          innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
+          matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
+        variables:
+          data: dependency
+          innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
+          matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
+        variables:
+          data: dependency
+          innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
+          matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
+        variables:
+          data: dependency
+          innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
+          matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId>
         codeSnip: "67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>"
@@ -92,8 +110,6 @@
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
-        codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
-        lineNumber: 86
         variables:
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
@@ -107,75 +123,35 @@
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-web\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
-        codeSnip: " 87  \t\t\t<artifactId>spring-webmvc</artifactId>\n 88  \t\t\t<version>${spring-framework.version}</version>\n 89  \t\t</dependency>\n 90  \t\t<dependency>\n 91  \t\t\t<groupId>org.springframework</groupId>\n 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>"
-        lineNumber: 96
+        message: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
-          matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
-        codeSnip: " 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>"
-        lineNumber: 101
+          innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
+          matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
-          matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
-        codeSnip: " 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>"
-        lineNumber: 107
+          innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
+          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
-          matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
-        codeSnip: "103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>"
-        lineNumber: 112
+          innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
+          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
-          matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
-        codeSnip: "108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>"
-        lineNumber: 117
-        variables:
-          data: dependency
-          innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
-          matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
-        codeSnip: "113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>"
-        lineNumber: 122
-        variables:
-          data: dependency
-          innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
-          matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
-        codeSnip: "118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>"
-        lineNumber: 127
-        variables:
-          data: dependency
-          innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
-          matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
-        codeSnip: "124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>\n139  \t<build>\n140  \t\t<plugins>\n141  \t\t\t<plugin>\n142  \t\t\t\t<groupId>org.apache.maven.plugins</groupId>\n143  \t\t\t\t<artifactId>maven-compiler-plugin</artifactId>\n144  \t\t\t\t<version>${maven-compiler-plugin.version}</version>"
-        lineNumber: 133
-        variables:
-          data: dependency
-          innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
-          matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+          innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
+          matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
     file-001:
       description: Testing that we can get all the go files in the project
       category: potential
       labels:
-      - testing
       - test
+      - testing
       incidents:
       - uri: file:///analyzer-lsp/examples/golang/dummy/test_functions.go
         message: all go files
@@ -228,23 +204,26 @@
       category: potential
       incidents:
       - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: dependency junit.junit with 4.11 is bad and you should feel bad for using it
-        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
-        lineNumber: 23
-        variables:
-          name: junit.junit
-          version: "4.11"
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency io.fabric8.kubernetes-client with 6.0.0 is bad and you should feel bad for using it
         codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
         lineNumber: 29
         variables:
           name: io.fabric8.kubernetes-client
           version: 6.0.0
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: dependency junit.junit with 4.11 is bad and you should feel bad for using it
+        variables:
+          name: junit.junit
+          version: "4.11"
     lang-ref-001:
       description: ""
       category: potential
       incidents:
+      - uri: file:///analyzer-lsp/examples/golang/main.go
+        message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
+        lineNumber: 10
+        variables:
+          file: file:///analyzer-lsp/examples/golang/main.go
       - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
         message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
         codeSnip: " 1  package com.example.apps;\n 2  \n 3  import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;\n 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {"
@@ -261,23 +240,10 @@
           file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
           kind: Method
           name: main
-      - uri: file:///analyzer-lsp/examples/golang/main.go
-        message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
-        lineNumber: 10
-        variables:
-          file: file:///analyzer-lsp/examples/golang/main.go
     lang-ref-003:
       description: ""
       category: potential
       incidents:
-      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-        message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java:3
-        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;\n 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {"
-        lineNumber: 3
-        variables:
-          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
-          kind: Module
-          name: io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition
       - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
         message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java:14
         codeSnip: " 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {\n14          CustomResourceDefinition crd = new CustomResourceDefinition();\n15          System.out.println( crd );\n16  \n17          GenericClass<String> element = new GenericClass<String>(\"Hello world!\");\n18          element.get();\n19      }\n20  }\n"
@@ -286,6 +252,14 @@
           file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
           kind: Method
           name: main
+      - uri: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
+        message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java:3
+        codeSnip: " 1  package com.example.apps;\n 2  \n 3  import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;\n 4  \n 5  public class App \n 6  {\n 7  \n 8      /**\n 9       * {@link CustomResourceDefinition}\n10       * @param args\n11       */\n12      public static void main( String[] args )\n13      {"
+        lineNumber: 3
+        variables:
+          file: file:///analyzer-lsp/examples/java/src/main/java/com/example/apps/App.java
+          kind: Module
+          name: io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition
     lang-ref-004:
       description: ""
       category: potential
@@ -404,30 +378,24 @@
       description: ""
       category: potential
       incidents:
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: POM XML dependencies - '<groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>'
-        codeSnip: "14  \n15    <properties>\n16      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n17      <maven.compiler.source>1.7</maven.compiler.source>\n18      <maven.compiler.target>1.7</maven.compiler.target>\n19    </properties>\n20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>"
-        lineNumber: 23
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>'
         variables:
           data: dependency
-          innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
-          matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>'
-        codeSnip: "20  \n21    <dependencies>\n22      <dependency>\n23        <groupId>junit</groupId>\n24        <artifactId>junit</artifactId>\n25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>"
-        lineNumber: 29
+          innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
+          matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>'
         variables:
           data: dependency
-          innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
-          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
-      - uri: file:///analyzer-lsp/examples/java/pom.xml
-        message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>'
-        codeSnip: "25        <version>4.11</version>\n26        <scope>test</scope>\n27      </dependency>\n28      <dependency>\n29        <groupId>io.fabric8</groupId>\n30        <artifactId>kubernetes-client</artifactId>\n31        <version>6.0.0</version>\n32      </dependency>\n33      <dependency>\n34        <groupId>io.fabric8</groupId>\n35        <artifactId>kubernetes-client-api</artifactId>\n36        <version>6.0.0</version>\n37      </dependency>\n38    </dependencies>\n39  \n40    <build>\n41      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n42        <plugins>\n43          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->\n44          <plugin>\n45            <artifactId>maven-clean-plugin</artifactId>"
-        lineNumber: 34
+          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
+          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>'
         variables:
           data: dependency
-          innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
-          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
+          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>'
         codeSnip: "36  \t\t\t<id>demo-config</id>\n37  \t\t\t<name>Azure DevOps</name>\n38  \t\t\t<url>https://pkgs.dev.azure.com/ShawnHurley21/demo-config-utils/_packaging/demo-config/maven/v1</url>\n39  \t\t</repository>\n40  \t</repositories>\n41  \n42  \t<dependencyManagement>\n43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>"
@@ -437,13 +405,23 @@
           innerText: "\n\t\t\t\tcom.fasterxml.jackson\n\t\t\t\tjackson-bom\n\t\t\t\t${jackson.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
           matchingXML: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>'
-        codeSnip: "43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>"
-        lineNumber: 52
+        message: POM XML dependencies - '<groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>'
         variables:
           data: dependency
-          innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
-          matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
+          innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
+          matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>'
+        variables:
+          data: dependency
+          innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
+          matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>'
+        variables:
+          data: dependency
+          innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
+          matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>'
         codeSnip: "53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>"
@@ -453,21 +431,35 @@
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-servlet-api\n\t\t\t${tomcat.version}\n\t\t\tprovided\n\t\t"
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>'
-        codeSnip: "59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  "
-        lineNumber: 68
+        message: POM XML dependencies - '<groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>'
         variables:
           data: dependency
-          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
-          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+          innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
+          matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>'
-        codeSnip: "63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>"
-        lineNumber: 72
+        message: POM XML dependencies - '<groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>'
         variables:
           data: dependency
-          innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
-          matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
+          innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
+          matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>'
+        variables:
+          data: dependency
+          innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
+          matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>'
+        variables:
+          data: dependency
+          innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
+          matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
+      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
+        message: POM XML dependencies - '<groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>'
+        variables:
+          data: dependency
+          innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
+          matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId>'
         codeSnip: "67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>"
@@ -485,14 +477,6 @@
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-jdbc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>'
-        codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
-        lineNumber: 86
-        variables:
-          data: dependency
-          innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
-          matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>'
         codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
         lineNumber: 86
@@ -501,69 +485,29 @@
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-web\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>'
-        codeSnip: " 87  \t\t\t<artifactId>spring-webmvc</artifactId>\n 88  \t\t\t<version>${spring-framework.version}</version>\n 89  \t\t</dependency>\n 90  \t\t<dependency>\n 91  \t\t\t<groupId>org.springframework</groupId>\n 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>"
-        lineNumber: 96
+        message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>'
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
-          matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>'
-        codeSnip: " 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>"
-        lineNumber: 101
+          innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
+          matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>'
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
-          matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>'
-        codeSnip: " 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>"
-        lineNumber: 107
+          innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
+          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>'
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
-          matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>'
-        codeSnip: "103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>"
-        lineNumber: 112
+          innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
+          matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
+      - uri: file:///analyzer-lsp/examples/java/pom.xml
+        message: POM XML dependencies - '<groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>'
         variables:
           data: dependency
-          innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
-          matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>'
-        codeSnip: "108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>"
-        lineNumber: 117
-        variables:
-          data: dependency
-          innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
-          matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>'
-        codeSnip: "113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>"
-        lineNumber: 122
-        variables:
-          data: dependency
-          innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
-          matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>'
-        codeSnip: "118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>"
-        lineNumber: 127
-        variables:
-          data: dependency
-          innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
-          matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
-      - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
-        message: POM XML dependencies - '<groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>'
-        codeSnip: "124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>\n139  \t<build>\n140  \t\t<plugins>\n141  \t\t\t<plugin>\n142  \t\t\t\t<groupId>org.apache.maven.plugins</groupId>\n143  \t\t\t\t<artifactId>maven-compiler-plugin</artifactId>\n144  \t\t\t\t<version>${maven-compiler-plugin.version}</version>"
-        lineNumber: 133
-        variables:
-          data: dependency
-          innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
-          matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+          innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
+          matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
   errors:
     error-rule-001: |-
       unable to get query info: yaml: unmarshal errors:

--- a/output/v1/konveyor/violations.go
+++ b/output/v1/konveyor/violations.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"go.lsp.dev/uri"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -16,30 +17,55 @@ const (
 type RuleSet struct {
 	// Name is a name for the ruleset.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
 	// Description text description for the ruleset.
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+
 	// Tags list of generated tags from the rules in this ruleset.
 	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+
 	// Violations is a map containing violations generated for the
 	// matched rules in this ruleset. Keys are rule IDs, values are
 	// their respective generated violations.
 	Violations map[string]Violation `yaml:"violations,omitempty" json:"violations,omitempty"`
+
 	// Errors is a map containing errors generated during evaluation
 	// of rules in this ruleset. Keys are rule IDs, values are
 	// their respective generated errors.
 	Errors map[string]string `yaml:"errors,omitempty" json:"errors,omitempty"`
+
 	// Unmatched is a list of rule IDs of the rules that weren't matched.
 	Unmatched []string `yaml:"unmatched,omitempty" json:"unmatched,omitempty"`
+
 	// Skipped is a list of rule IDs that were skipped
 	Skipped []string `yaml:"skipped,omitempty" json:"skipped,omitempty"`
 }
 
-func (r RuleSet) MarshalYAML() (interface{}, error) {
+// Sorts all fields in a canonical way on a RuleSet
+func (r *RuleSet) sortFields() {
 	sort.Strings(r.Tags)
 	sort.Strings(r.Unmatched)
 	sort.Strings(r.Skipped)
+}
 
+func (r RuleSet) MarshalYAML() (interface{}, error) {
+	r.sortFields()
 	return r, nil
+}
+
+func (r RuleSet) MarshalJSON() ([]byte, error) {
+	b, err := yaml.Marshal(r)
+	if err != nil {
+		return b, err
+	}
+
+	m := map[string]any{}
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
 }
 
 type Category string
@@ -49,10 +75,12 @@ var (
 	// This is used when you are trying to communicate that something may be wrong/incorrect
 	// But individual situations may require more context.
 	Potential Category = "potential"
+
 	// Optional - rule states that there is an issue, but that this issue can be fixed later.
 	// Primary use case is when migrating frameworks, and something has a deprecated notice,
 	// You should fix this but it wont break the migration/upgrade.
 	Optional Category = "optional"
+
 	// Mandatory - rule states that there is an issue that must be fixed.
 	// This is used, based on the ruleset, to tell the user that this is a real issue.
 	// For migrations, this means it must be fixed or the upgrade with fail.
@@ -83,60 +111,104 @@ type Violation struct {
 	Effort *int `yaml:"effort,omitempty" json:"effort,omitempty"`
 }
 
-func (v Violation) MarshalYAML() (interface{}, error) {
+// Sorts all fields in a canonical way on a Violation
+func (v *Violation) sortFields() {
 	sort.Strings(v.Labels)
+
 	sort.SliceStable(v.Incidents, func(i, j int) bool {
-		if v.Incidents[i].URI != v.Incidents[j].URI {
-			return v.Incidents[i].URI < v.Incidents[j].URI
-		}
-
-		if v.Incidents[i].Message != v.Incidents[j].Message {
-			return v.Incidents[i].Message < v.Incidents[j].Message
-		}
-
-		if v.Incidents[i].CodeSnip != v.Incidents[j].CodeSnip {
-			return v.Incidents[i].CodeSnip < v.Incidents[j].CodeSnip
-		}
-
-		if *v.Incidents[i].LineNumber != *v.Incidents[j].LineNumber {
-			return *v.Incidents[i].LineNumber < *v.Incidents[j].LineNumber
-		}
-
-		return false
+		return v.Incidents[i].cmpLess(&v.Incidents[j])
 	})
+
 	sort.SliceStable(v.Links, func(i, j int) bool {
-		if v.Links[i].URL != v.Links[j].URL {
-			return v.Links[i].URL < v.Links[j].URL
-		}
-
-		if v.Links[i].Title != v.Links[j].Title {
-			return v.Links[i].Title < v.Links[j].Title
-		}
-
-		return false
+		return v.Links[i].cmpLess(&v.Links[j])
 	})
+}
 
+func (v Violation) MarshalYAML() (interface{}, error) {
+	v.sortFields()
 	return v, nil
+}
+
+func (v Violation) MarshalJSON() ([]byte, error) {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return b, err
+	}
+
+	m := map[string]any{}
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
 }
 
 // Incident defines instance of a violation
 type Incident struct {
 	// URI defines location in the codebase where violation is found
 	URI uri.URI `yaml:"uri" json:"uri"`
+
 	// Message text description about the incident
 	Message  string `yaml:"message" json:"message"`
 	CodeSnip string `yaml:"codeSnip,omitempty" json:"codeSnip,omitempty"`
+
 	// Extras reserved for additional data
-	//Extras json.RawMessage
+	// Extras json.RawMessage
 	LineNumber *int                   `yaml:"lineNumber,omitempty" json:"lineNumber,omitempty"`
 	Variables  map[string]interface{} `yaml:"variables,omitempty" json:"variables,omitempty"`
+}
+
+// Lexicographically compares two Incidents
+func (i *Incident) cmpLess(other *Incident) bool {
+	if i.URI != other.URI {
+		return i.URI < other.URI
+	}
+
+	if i.Message != other.Message {
+		return i.Message < other.Message
+	}
+
+	if i.CodeSnip != other.CodeSnip {
+		return i.CodeSnip < other.CodeSnip
+	}
+
+	if i.LineNumber == nil {
+		x := 0
+		i.LineNumber = &x
+	}
+
+	if other.LineNumber == nil {
+		x := 0
+		other.LineNumber = &x
+	}
+
+	if *(*i).LineNumber != *(*other).LineNumber {
+		return *(*i).LineNumber < *(*other).LineNumber
+	}
+
+	return false
 }
 
 // Link defines an external hyperlink
 type Link struct {
 	URL string `yaml:"url" json:"url"`
+
 	// Title optional description
 	Title string `yaml:"title,omitempty" json:"title,omitempty"`
+}
+
+// Lexicographically compares two Links
+func (l *Link) cmpLess(other *Link) bool {
+	if l.Title != other.Title {
+		return l.Title < other.Title
+	}
+
+	if l.URL != other.URL {
+		return l.URL < other.URL
+	}
+
+	return false
 }
 
 type Dep struct {
@@ -150,12 +222,12 @@ type Dep struct {
 	FileURIPrefix      string                 `json:"prefix,omitempty" yaml:"prefix,omitempty"`
 }
 
-func (d Dep) MarshalYAML() (interface{}, error) {
+// Sorts all fields in a canonical way on a Dep
+func (d *Dep) sortFields() {
 	sort.Strings(d.Labels)
-
-	return d, nil
 }
 
+// Lexicographically compares two Deps
 func (d Dep) cmpLess(other Dep) bool {
 	if d.Name != other.Name {
 		return d.Name < other.Name
@@ -190,6 +262,26 @@ func (d Dep) cmpLess(other Dep) bool {
 	return false
 }
 
+func (d Dep) MarshalYAML() (interface{}, error) {
+	d.sortFields()
+	return d, nil
+}
+
+func (d Dep) MarshalJSON() ([]byte, error) {
+	b, err := yaml.Marshal(d)
+	if err != nil {
+		return b, err
+	}
+
+	m := map[string]any{}
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
+}
+
 func (d *Dep) GetLabels() []string {
 	return d.Labels
 }
@@ -199,14 +291,100 @@ type DepDAGItem struct {
 	AddedDeps []DepDAGItem `yaml:"addedDep,omitempty" json:"addedDep,omitempty"`
 }
 
+// Sorts all fields in a canonical way on a DepDAGItem
+func (d *DepDAGItem) sortFields() {
+	for i := range d.AddedDeps {
+		d.AddedDeps[i].sortFields()
+	}
+
+	sort.SliceStable(d.AddedDeps, func(i int, j int) bool {
+		return d.AddedDeps[i].Dep.cmpLess(d.AddedDeps[j].Dep)
+	})
+}
+
+func (d DepDAGItem) MarshalYAML() (interface{}, error) {
+	d.sortFields()
+	return d, nil
+}
+
+func (d DepDAGItem) MarshalJSON() ([]byte, error) {
+	b, err := yaml.Marshal(d)
+	if err != nil {
+		return b, err
+	}
+
+	m := map[string]any{}
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
+}
+
 type DepsFlatItem struct {
 	FileURI      string `yaml:"fileURI" json:"fileURI"`
 	Provider     string `yaml:"provider" json:"provider"`
 	Dependencies []*Dep `yaml:"dependencies" json:"dependencies"`
 }
 
+// Sorts all fields in a canonical way on a DepsFlatItem
+func (d *DepsFlatItem) sortFields() {
+	sort.SliceStable(d.Dependencies, func(i, j int) bool {
+		return (*d.Dependencies[i]).cmpLess(*d.Dependencies[j])
+	})
+}
+
+func (d DepsFlatItem) MarshalYAML() (interface{}, error) {
+	d.sortFields()
+	return d, nil
+}
+
+func (d DepsFlatItem) MarshalJSON() ([]byte, error) {
+	b, err := yaml.Marshal(d)
+	if err != nil {
+		return b, err
+	}
+
+	m := map[string]any{}
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
+}
+
 type DepsTreeItem struct {
 	FileURI      string       `yaml:"fileURI" json:"fileURI"`
 	Provider     string       `yaml:"provider" json:"provider"`
 	Dependencies []DepDAGItem `yaml:"dependencies" json:"dependencies"`
+}
+
+// Sorts all fields in a canonical way on a DepsTreeItem
+func (d *DepsTreeItem) sortFields() {
+	// Technically doesn't traverse the entire tree
+	sort.SliceStable(d.Dependencies, func(i, j int) bool {
+		return d.Dependencies[i].Dep.cmpLess(d.Dependencies[j].Dep)
+	})
+}
+
+func (d DepsTreeItem) MarshalYAML() (interface{}, error) {
+	d.sortFields()
+	return d, nil
+}
+
+func (d DepsTreeItem) MarshalJSON() ([]byte, error) {
+	b, err := yaml.Marshal(d)
+	if err != nil {
+		return b, err
+	}
+
+	m := map[string]any{}
+	err = yaml.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
 }

--- a/output/v1/konveyor/violations.go
+++ b/output/v1/konveyor/violations.go
@@ -53,6 +53,13 @@ func (r RuleSet) MarshalYAML() (interface{}, error) {
 	return r, nil
 }
 
+// NOTE(jsussman): Might have some performance issues.
+//
+// MarshalYAML's return value is (interface{}, error), meaning it simply
+// propagates the object forward, unmarshalling whatever you return.
+// MarshalJSON's return value is ([]byte, error), meaning you have to build the
+// JSON yourself. You'd think we can simply call r.sortFields and then
+// json.Marshal(r) like MarshalYAML, but that causes infinite recursion.
 func (r RuleSet) MarshalJSON() ([]byte, error) {
 	b, err := yaml.Marshal(r)
 	if err != nil {


### PR DESCRIPTION
Fixes #418 

`demo-output.yaml`'s diff looks really ugly, but all this PR does is shuffle some stuff around. 

With this, we may not the `sed` and `yq` stuff in this workflow anymore:

https://github.com/konveyor/analyzer-lsp/blob/740142ea98dbd39b22a63e2da7bfa2374b86be29/.github/workflows/demo-testing.yml#L20-L25