### PR TITLE
:bug: fixing panic when the deferenced slice variable is nil

### DIFF
--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -137,7 +137,7 @@ func (p *javaServiceClient) GetDependenciesFallback(ctx context.Context, locatio
 
 	// have to get both <dependencies> and <dependencyManagement> dependencies (if present)
 	var pomDeps []gopom.Dependency
-	if pom.Dependencies != nil {
+	if pom.Dependencies != nil && *pom.Dependencies != nil {
 		pomDeps = append(pomDeps, *pom.Dependencies...)
 	}
 	if pom.DependencyManagement != nil {


### PR DESCRIPTION
See the playground to prove out we need this:
https://go.dev/play/p/qKDgySCoHwz

fixes MTA-1647 panic on OpenRMS