### PR TITLE
:sparkles: adding incident label selector CLI option

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -31,6 +31,7 @@ var (
 	errorOnViolations bool
 	labelSelector     string
 	depLabelSelector  string
+	incidentSelector  string
 	logLevel          int
 	enableJaeger      bool
 	jaegerEndpoint    string
@@ -54,6 +55,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&errorOnViolations, "error-on-violation", false, "exit with 3 if any violation are found will also print violations to console")
 	rootCmd.Flags().StringVar(&labelSelector, "label-selector", "", "an expression to select rules based on labels")
 	rootCmd.Flags().StringVar(&depLabelSelector, "dep-label-selector", "", "an expression to select dependencies based on labels. This will filter out the violations from these dependencies as well these dependencies when matching dependency conditions")
+	rootCmd.Flags().StringVar(&incidentSelector, "incident-selector", "", "an expression to select incidents based on custom variables. ex: (!package=io.konveyor.demo.config-utils)")
 	rootCmd.Flags().IntVar(&logLevel, "verbose", 9, "level for logging output")
 	rootCmd.Flags().BoolVar(&enableJaeger, "enable-jaeger", false, "enable tracer exports to jaeger endpoint")
 	rootCmd.Flags().StringVar(&jaegerEndpoint, "jaeger-endpoint", "http://localhost:14268/api/traces", "jaeger endpoint to collect tracing data")
@@ -139,6 +141,7 @@ func main() {
 		engine.WithIncidentLimit(limitIncidents),
 		engine.WithCodeSnipLimit(limitCodeSnips),
 		engine.WithContextLines(contextLines),
+		engine.WithIncidentSelector(incidentSelector),
 	)
 
 	providers := map[string]provider.InternalProviderClient{}
@@ -217,7 +220,7 @@ func main() {
 	if err != nil {
 		log.Error(err, "error writing output file", "file", outputViolations)
 		os.Exit(1) // Treat the error as a fatal error
-	}	
+	}
 }
 
 func validateFlags() error {

--- a/engine/internal/variable_labels.go
+++ b/engine/internal/variable_labels.go
@@ -1,0 +1,18 @@
+package internal
+
+import "fmt"
+
+type VariableLabelSelector map[string]interface{}
+
+func (v VariableLabelSelector) GetLabels() []string {
+	if len(v) == 0 {
+		// adding a single empty string will allow for Not selectors to match
+		// incidents that have no variables
+		return []string{""}
+	}
+	s := []string{}
+	for k, v := range v {
+		s = append(s, fmt.Sprintf("%s=%s", k, v))
+	}
+	return s
+}

--- a/engine/labels/labels_test.go
+++ b/engine/labels/labels_test.go
@@ -3,8 +3,16 @@ package labels
 import (
 	"testing"
 
-	"github.com/konveyor/analyzer-lsp/engine"
+	"github.com/konveyor/analyzer-lsp/engine/internal"
 )
+
+type ruleMeta struct {
+	Labels []string
+}
+
+func (r ruleMeta) GetLabels() []string {
+	return r.Labels
+}
 
 func Test_getBooleanExpression(t *testing.T) {
 	tests := []struct {
@@ -272,7 +280,7 @@ func TestNewRuleSelector(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewLabelSelector[*engine.RuleMeta](tt.expr)
+			_, err := NewLabelSelector[internal.VariableLabelSelector](tt.expr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRuleSelector() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -381,8 +389,8 @@ func Test_ruleSelector_Matches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s, _ := NewLabelSelector[*engine.RuleMeta](tt.expr)
-			if got, _ := s.Matches(&engine.RuleMeta{Labels: tt.ruleLabels}); got != tt.want {
+			s, _ := NewLabelSelector[Labeled](tt.expr)
+			if got, _ := s.Matches(ruleMeta{Labels: tt.ruleLabels}); got != tt.want {
 				t.Errorf("ruleSelector.Matches() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
First thing to complete the incident filtering on packages from the UI, is to have the CLI option. 

This is the first step toward adding this.