### PR TITLE
:bug: Use window of correct size in presence of newlines to grab content from xml files

### DIFF
--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -333,7 +333,7 @@ func (b *builtinServiceClient) getLocation(ctx context.Context, path, content st
 	if len(lines) > 0 && lines[len(lines)-1] == "" {
 		lines = lines[:len(lines)-1]
 	}
-	if len(lines) < 1 {
+	if len(lines) < 1 || strings.Join(lines, "") == "" {
 		return location, fmt.Errorf("unable to get code location, empty content")
 	}
 	pattern := fmt.Sprintf(".*?%s", strings.Join(lines, ".*?"))

--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -324,15 +324,19 @@ func (b *builtinServiceClient) getLocation(ctx context.Context, path, content st
 		line := strings.Trim(part, " ")
 		line = strings.ReplaceAll(line, "\t", "")
 		line = regexp.QuoteMeta(line)
-		if line != "" {
-			lines = append(lines, line)
-		}
+		lines = append(lines, line)
+	}
+	// remove leading and trailing empty lines
+	if len(lines) > 0 && lines[0] == "" {
+		lines = lines[1:]
+	}
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
 	}
 	if len(lines) < 1 {
-		return location, fmt.Errorf("unable to get code location, no-op content")
+		return location, fmt.Errorf("unable to get code location, empty content")
 	}
 	pattern := fmt.Sprintf(".*?%s", strings.Join(lines, ".*?"))
-
 	cacheKey := fmt.Sprintf("%s-%s", path, pattern)
 	b.cacheMutex.RLock()
 	val, exists := b.locationCache[cacheKey]

--- a/provider/internal/builtin/service_client_test.go
+++ b/provider/internal/builtin/service_client_test.go
@@ -1,0 +1,62 @@
+package builtin
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/konveyor/analyzer-lsp/provider"
+)
+
+func newLocationForLine(line float64) provider.Location {
+	return provider.Location{
+		StartPosition: provider.Position{
+			Line: line,
+		},
+		EndPosition: provider.Position{
+			Line: line,
+		},
+	}
+}
+
+func Test_builtinServiceClient_getLocation(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    provider.Location
+		wantErr bool
+	}{
+		{
+			name:    "search for innerText with leading and trailing newlines",
+			path:    "./testdata/pom.xml",
+			content: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t",
+			want:    newLocationForLine(117),
+		},
+		{
+			name:    "search for innerText with spaces in between content",
+			path:    "./testdata/pom.xml",
+			content: "\n\t<version>0.0.1-SNAPSHOT</version>\n\n\n\t\t<name>Order Management</name>\n\t\t<packaging>war</packaging>\n",
+			want:    newLocationForLine(6),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &builtinServiceClient{
+				log:           testr.New(t),
+				cacheMutex:    sync.RWMutex{},
+				locationCache: make(map[string]float64),
+			}
+			got, err := b.getLocation(context.TODO(), tt.path, tt.content)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("builtinServiceClient.getLocation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("builtinServiceClient.getLocation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/internal/builtin/testdata/pom.xml
+++ b/provider/internal/builtin/testdata/pom.xml
@@ -1,0 +1,165 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.konveyor.demo</groupId>
+	<artifactId>customers-tomcat</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<name>Order Management</name>
+	<packaging>war</packaging>
+	<description>Remaining services for the legacy Order Management application</description>
+
+	<properties>
+		<java.version>1.8</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<spring-framework.version>5.3.7</spring-framework.version>
+		<tomcat.version>9.0.46</tomcat.version>
+		<spring-data.version>2021.0.1</spring-data.version>
+		<hibernate.version>5.4.32.Final</hibernate.version>
+		<hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
+
+		<postgresql-driver.version>42.2.20</postgresql-driver.version>
+		<jackson.version>2.12.3</jackson.version>
+
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<maven-war-plugin.version>3.3.1</maven-war-plugin.version>
+		<maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>demo-config</id>
+			<name>Azure DevOps</name>
+			<url>https://pkgs.dev.azure.com/ShawnHurley21/demo-config-utils/_packaging/demo-config/maven/v1</url>
+		</repository>
+	</repositories>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-bom</artifactId>
+				<version>${spring-data.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-servlet-api</artifactId>
+			<version>${tomcat.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
+			<version>${spring-framework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>${spring-framework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>${spring-framework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>2.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-jdbc</artifactId>
+			<version>${tomcat.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>${hibernate.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>${hibernate-validator.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.7</version>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>21.1.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.2.23</version>
+		</dependency>
+		<!-- Corporate libraries -->
+		<dependency>
+			<groupId>io.konveyor.demo</groupId>
+			<artifactId>config-utils</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>${maven-war-plugin.version}</version>
+				<configuration>
+					<failOnMissingWebXml>false</failOnMissingWebXml>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>${maven-resources-plugin.version}</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>


### PR DESCRIPTION
We are stripping out empty lines when doing the search, however, in the window that we load into memory we still have to load these empty lines to be able to correctly search content. We only have to get rid of newlines from beginning and the end. 