### PR TITLE
:ghost: Improve running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN microdnf install gcc-c++ python-devel python3-devel -y
 RUN python3 -m ensurepip --upgrade
 RUN python3 -m pip install python-lsp-server
 
-COPY --from=jaeger-builder /go/bin/all-in-one-linux /usr/bin/
+COPY --from=jaeger-builder /go/bin/all-in-one-linux /usr/local/bin/all-in-one-linux
 
 COPY --from=yq-builder /usr/bin/yq /usr/bin/yq
 
@@ -41,6 +41,7 @@ COPY --from=builder /analyzer-lsp/external-providers/golang-dependency-provider/
 COPY provider_container_settings.json /analyzer-lsp/provider_settings.json
 
 WORKDIR /analyzer-lsp
+RUN chgrp -R 0 /analyzer-lsp && chmod -R g=u /analyzer-lsp
 
 EXPOSE 16686
 


### PR DESCRIPTION
With this change we can at least run as non-root.

I would also proprose moving binaries that need to be accessible to all users be installed in /usr/local/bin. But as of right now it seems we have configs (or something) hard coded to this location.
https://github.com/konveyor/java-analyzer-bundle/blob/main/Dockerfile#L41

https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html

