### PR TITLE
:bug: Fix empty code snippet in XML when the match is a key of the node, not an inner value

### DIFF
--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -767,6 +767,19 @@
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
           matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
+    xml-test-key-match:
+      description: Test code snippets when match is a key of a XML node
+      category: potential
+      incidents:
+      - uri: file:///analyzer-lsp/examples/java/beans.xml
+        message: The code snippet should point to <beans> in the beans.xml file
+        codeSnip: " 8   *\n 9   * http://www.apache.org/licenses/LICENSE-2.0\n10   *\n11   * Unless required by applicable law or agreed to in writing, software\n12   * distributed under the License is distributed on an \"AS IS\" BASIS,\n13   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n14   * See the License for the specific language governing permissions and\n15   * limitations under the License.\n16  -->\n17  <beans xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\"\n18         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n19         xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee \n20                             http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd\"\n21         version=\"1.1\" bean-discovery-mode=\"all\">\n22  </beans>\n"
+        lineNumber: 17
+        variables:
+          data: beans
+          innerText: |2+
+
+          matchingXML: ""
   errors:
     error-rule-001: |-
       unable to get query info: yaml: unmarshal errors:

--- a/examples/java/beans.xml
+++ b/examples/java/beans.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ * (C) Copyright IBM Corporation 2015.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -173,7 +173,12 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 							"data":        node.Data,
 						},
 					}
-					location, err := p.getLocation(ctx, ab, node.InnerText())
+					content := strings.Trim(node.InnerText(), " ")
+					content = strings.Trim(content, "\n")
+					if content == "" {
+						content = node.Data
+					}
+					location, err := p.getLocation(ctx, ab, content)
 					if err == nil {
 						incident.CodeLocation = &location
 						lineNo := int(location.StartPosition.Line)

--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -173,8 +173,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 							"data":        node.Data,
 						},
 					}
-					content := strings.Trim(node.InnerText(), " ")
-					content = strings.Trim(content, "\n")
+					content := strings.TrimSpace(node.InnerText())
 					if content == "" {
 						content = node.Data
 					}

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -231,3 +231,14 @@
         deprecatedIn: "v1.9.0"
         removedIn: "v1.16.0"
         replacementAPI: "apps/v1"
+- category: potential
+  description: "Test code snippets when match is a key of a XML node"
+  message: "The code snippet should point to <beans> in the beans.xml file"
+  ruleID: xml-test-key-match
+  when:
+    builtin.xml:
+      filepaths:
+      - beans.xml
+      namespaces:
+        b: http://xmlns.jcp.org/xml/ns/javaee
+      xpath: /b:beans


### PR DESCRIPTION
Fixes #503 