### PR TITLE
:sparkles: stop building the project when we don't need anything else

### DIFF
--- a/provider/internal/java/service_client.go
+++ b/provider/internal/java/service_client.go
@@ -210,6 +210,9 @@ func (p *javaServiceClient) initialization(ctx context.Context) {
 						"userSettings": p.mvnSettingsFile,
 					},
 				},
+				"autobuild": map[string]interface{}{
+					"enabled": false,
+				},
 				"maven": map[string]interface{}{
 					"downloadSources": downloadSources,
 				},


### PR DESCRIPTION
There is no need to wait for the build for the init step to be complete.

API tests PR: 102