### PR TITLE
:bug: handle correct structs for protobof init calls

### DIFF
--- a/provider/testdata/provider_settings_invalid.yaml
+++ b/provider/testdata/provider_settings_invalid.yaml
@@ -1,0 +1,21 @@
+- name: "go"
+  binaryPath: "/usr/bin/generic-external-provider"
+  initConfig:
+  - analysisMode: "full"
+    providerSpecificConfig: 
+      lspServerName: "generic"
+      lspServerPath: "/root/go/bin/gopls"
+      lspServerArgs: 
+      - "string"
+      lspServerInitializationOptions: ""
+      workspaceFolders: 
+      - "file:///analyzer-lsp/examples/golang"
+      dependencyFolders: []
+      groupVersionKinds: 
+      - group: "apps"
+        version: "v1"
+        kind: "Deployment"
+        1: "newThing"
+      object: 
+        nestedObject: "object"
+      dependencyProviderPath: "/usr/bin/golang-dependency-provider"

--- a/provider/testdata/provider_settings_nested_types.json
+++ b/provider/testdata/provider_settings_nested_types.json
@@ -1,0 +1,23 @@
+
+[
+    {
+        "name": "go",
+        "binaryPath": "/usr/bin/generic-external-provider",
+        "initConfig": [{
+            "analysisMode": "full",
+            "providerSpecificConfig": {
+                "lspServerName": "generic",
+                "lspServerPath": "/root/go/bin/gopls",
+                "lspServerArgs": ["string"],
+                "lspServerInitializationOptions": "",
+
+                "workspaceFolders": ["file:///analyzer-lsp/examples/golang"],
+                "dependencyFolders": [],
+                "groupVersionKinds": [{"group": "apps", "version": "v1", "kind": "Deployment"}],
+                "object": {"nestedObject": "object"},
+
+                "dependencyProviderPath": "/usr/bin/golang-dependency-provider"
+            }
+        }]
+    }
+]

--- a/provider/testdata/provider_settings_simple.yaml
+++ b/provider/testdata/provider_settings_simple.yaml
@@ -1,0 +1,20 @@
+- name: "go"
+  binaryPath: "/usr/bin/generic-external-provider"
+  initConfig:
+  - analysisMode: "full"
+    providerSpecificConfig: 
+      lspServerName: "generic"
+      lspServerPath: "/root/go/bin/gopls"
+      lspServerArgs: 
+      - "string"
+      lspServerInitializationOptions: ""
+      workspaceFolders: 
+      - "file:///analyzer-lsp/examples/golang"
+      dependencyFolders: []
+      groupVersionKinds: 
+      - group: "apps"
+        version: "v1"
+        kind: "Deployment"
+      object: 
+        nestedObject: "object"
+      dependencyProviderPath: "/usr/bin/golang-dependency-provider"


### PR DESCRIPTION
Adding validation of the keys in provider-specific config to only be strings

Adding test cases to validate both JSON and yaml provider settings files will work.

fixes #501 