### PR TITLE
:bug: Fix file URI prefix for JARs and do not move found JARs so dependency CLI can still find them

### DIFF
--- a/provider/internal/java/dependency.go
+++ b/provider/internal/java/dependency.go
@@ -185,8 +185,8 @@ func (p *javaServiceClient) GetDependenciesFallback(ctx context.Context, locatio
 				dep.Version = *d.Version
 			}
 			if m2Repo != "" && d.ArtifactID != nil && d.GroupID != nil {
-				dep.FileURIPrefix = filepath.Join(m2Repo,
-					strings.Replace(*d.GroupID, ".", "/", -1), *d.ArtifactID, dep.Version)
+				dep.FileURIPrefix = fmt.Sprintf("file://%s", filepath.Join(m2Repo,
+					strings.Replace(*d.GroupID, ".", "/", -1), *d.ArtifactID, dep.Version))
 			}
 		}
 		deps = append(deps, &dep)
@@ -359,8 +359,8 @@ func (w *walker) walkDirForJar(path string, info fs.DirEntry, err error) error {
 			// when we can successfully get javaArtifact from a jar
 			// we added it to the pom and it should be in m2Repo path
 			if w.m2RepoPath != "" {
-				d.FileURIPrefix = filepath.Join(w.m2RepoPath,
-					strings.Replace(artifact.GroupId, ".", "/", -1), artifact.ArtifactId, artifact.Version)
+				d.FileURIPrefix = fmt.Sprintf("file://%s", filepath.Join(w.m2RepoPath,
+					strings.Replace(artifact.GroupId, ".", "/", -1), artifact.ArtifactId, artifact.Version))
 			}
 		}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -498,7 +498,8 @@ func matchDepLabelSelector(s *labels.LabelSelector[*Dep], inc IncidentContext, d
 			return false, err
 		}
 		for _, d := range depList {
-			if strings.HasPrefix(string(inc.FileURI), d.FileURIPrefix) {
+			if d.FileURIPrefix != "" &&
+				strings.HasPrefix(string(inc.FileURI), d.FileURIPrefix) {
 				matched = true
 			}
 		}


### PR DESCRIPTION
Fixes #544 