### PR TITLE
:ghost: Revert ":ghost: workflow must use correct addon branch"

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -10,17 +10,8 @@ jobs:
         run: |
           echo "${{ github.event.pull_request.body }}"
           PULL_REQUEST_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oP 'Addon PR: \K\d+' || true)
-          echo "API_TESTS_REF=main" >> $GITHUB_ENV
           if [ -z "$PULL_REQUEST_NUMBER" ]; then
-            if [ -z "${{ github.event.pull_request.base.ref }}" ]; then
-              echo "Using addon branch main"
-              echo "ADDON_REF=main" >>$GITHUB_ENV
-            else
-              echo "Using addon branch ${{ github.event.pull_request.base.ref }}"
-              echo "ADDON_REF=${{ github.event.pull_request.base.ref }}" >>$GITHUB_ENV
-              # when we know the base branch, we should use the identical branch of api tests
-              echo "API_TESTS_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
-            fi
+            echo "ADDON_REF=main" >>$GITHUB_ENV
           else
             echo "ADDON_REF=refs/pull/$PULL_REQUEST_NUMBER/merge" >>$GITHUB_ENV
           fi
@@ -45,6 +36,13 @@ jobs:
           diff \
             <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-dep-output.yaml)) \
             <(yq -P 'sort_keys(..)' -o=props <(cat demo-dep-output.yaml))
+
+      # - name: run demo image and ensure dependency output unchanged
+      #   run: |
+      #     podman run --entrypoint /usr/bin/konveyor-analyzer-dep -v $(pwd)/demo-dep-output.yaml:/analyzer-lsp/demo-dep-output.yaml:Z localhost/testing:latest --output-file=demo-dep-output.yaml --dep-output-file=de
+      #     diff \
+      #       <(yq -P 'sort_keys(..)' -o=props <(git show HEAD:demo-dep-output.yaml)) \
+      #       <(yq -P 'sort_keys(..)' -o=props <(cat demo-dep-output.yaml))
 
       - uses: actions/checkout@v3
         with:
@@ -71,4 +69,3 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
       component_name: tackle2-addon-analyzer
-      api_tests_ref: "${{ env.API_TESTS_REF }}"


### PR DESCRIPTION
Reverts konveyor/analyzer-lsp#561