### PR TITLE
:bug: Be able to process FIELD rules

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -47,8 +47,8 @@ jobs:
         if: steps.extract-info.outputs.BUILD_BUNDLE == 'true'
         with:
           fetch-depth: 0
-          repository: konveyor/java-analyzer-bundle
-          ref: "${{ steps.extract-info.outputs.JAVA_BUNDLE_REF }}"
+          repository: jmle/java-analyzer-bundle
+          ref: "field-search"
           path: java-analyzer-bundle
       
       - name: build java analyzer bundle image

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -595,6 +595,17 @@
         variables:
           file: file:///examples/python/file_a.py
       effort: 1
+    python-sample-rule-003:
+      description: ""
+      category: potential
+      incidents:
+      - uri: file:///examples/python/main.py
+        message: python sample rule 003
+        codeSnip: "19      # Create an instance of the API class\n20      api_instance = kubernetes.client.ApiextensionsV1Api(api_client)\n21      body = kubernetes.client.V1CustomResourceDefinition() # V1CustomResourceDefinition | \n22      pretty = 'pretty_example' # str | If 'true', then the output is pretty printed. (optional)\n23      dry_run = 'dry_run_example' # str | When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed (optional)\n24      field_manager = 'field_manager_example' # str | fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. (optional)\n25      field_validation = 'field_validation_example' # str | fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered. (optional)\n26  \n27      try:\n28          api_response = api_instance.create_custom_resource_definition(body, pretty=pretty, dry_run=dry_run, field_manager=field_manager, field_validation=field_validation)\n29          pprint(api_response)\n30      except ApiException as e:\n31          print(\"Exception when calling ApiextensionsV1Api->create_custom_resource_definition: %s\\n\" % e)\n"
+        lineNumber: 28
+        variables:
+          file: file:///examples/python/main.py
+      effort: 1
     singleton-sessionbean-00001:
       description: ""
       category: potential
@@ -899,6 +910,19 @@
           matchingXML: ""
       effort: 1
   insights:
+    field-rule-00001:
+      description: Sample field declaration rule
+      category: mandatory
+      incidents:
+      - uri: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/service/CustomerService.java
+        message: Field found
+        codeSnip: " 8  import org.springframework.data.domain.Page;\n 9  import org.springframework.data.domain.Pageable;\n10  import org.springframework.stereotype.Service;\n11  import org.springframework.transaction.annotation.Transactional;\n12  \n13  @Service\n14  @Transactional\n15  public class CustomerService implements ICustomerService{\n16  \t\n17  \t@Autowired\n18  \tprivate CustomerRepository repository;\n19  \t\n20  \tprivate static Logger logger = Logger.getLogger( CustomerService.class.getName() );\n21  \t\n22  \tpublic Customer findById(Long id) {\n23  \t\tlogger.debug(\"Entering CustomerService.findById()\");\n24  \t\tCustomer c = repository.findById(id).orElse(null);\n25  \t\tlogger.debug(\"Returning element: \" + c);\n26  \t\treturn c;\n27  \t}\n28  \t"
+        lineNumber: 18
+        variables:
+          file: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/service/CustomerService.java
+          kind: Field
+          name: repository
+          package: io.konveyor.demo.ordermanagement.service
     java-downloaded-maven-artifact:
       description: |
         This rule tests the application downloaded from maven artifact
@@ -1072,4 +1096,3 @@
   unmatched:
   - file-002
   - lang-ref-002
-  - python-sample-rule-003

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -58,6 +58,7 @@ var locationToCode = map[string]int{
 	"variable_declaration": 9,
 	"type":                 10,
 	"package":              11,
+	"field":                12,
 }
 
 type javaProvider struct {

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -80,6 +80,8 @@ func (p *javaServiceClient) Evaluate(ctx context.Context, cap string, conditionI
 		incidents, err = p.filterDefault(symbols)
 	case 11:
 		incidents, err = p.filterDefault(symbols)
+	case 12:
+		incidents, err = p.filterDefault(symbols)
 	default:
 
 	}

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -330,3 +330,11 @@
   when:
     java.referenced:
       pattern: io.javaoperatorsdk.operator.Operator
+- category: mandatory
+  description: Sample field declaration rule
+  message: "Field found"
+  ruleID: field-rule-00001
+  when:
+    java.referenced:
+      pattern: io.konveyor.demo.ordermanagement.repository.CustomerRepository
+      location: FIELD


### PR DESCRIPTION
Enables rule authors to create `java.referenced` conditions with `location: FIELD`.

- Bundle PR: https://github.com/konveyor/java-analyzer-bundle/pull/96
- Fixes https://github.com/konveyor/analyzer-lsp/issues/622