### PR TITLE
:bug: Add annotation inspection support

### DIFF
--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -912,6 +912,48 @@
           kind: Field
           name: repository
           package: io.konveyor.demo.ordermanagement.service
+    java-annotation-inspection-01:
+      description: |
+        This rule looks for a given class annotated with a given annotation
+      category: mandatory
+      incidents:
+      - uri: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
+        message: Annotation instpection 01
+        codeSnip: "17  import org.springframework.transaction.annotation.EnableTransactionManagement;\n18  \n19  import io.konveyor.demo.config.ApplicationConfiguration;\n20  \n21  @Configuration\n22  @EnableJpaRepositories(basePackages = {\n23          \"io.konveyor.demo.ordermanagement.repository\"\n24  })\n25  @EnableTransactionManagement\n26  @EnableSpringDataWebSupport\n27  public class PersistenceConfig {\n28  \n29      \n30  \t@Bean\n31      public LocalContainerEntityManagerFactoryBean entityManagerFactory() {\n32          final LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();\n33          em.setDataSource(dataSource());\n34          em.setPackagesToScan(\"io.konveyor.demo.ordermanagement.model\");\n35          em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());\n36          em.setJpaProperties(additionalProperties());\n37  "
+        lineNumber: 27
+        variables:
+          file: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
+          kind: Class
+          name: PersistenceConfig
+          package: io.konveyor.demo.ordermanagement.config
+    java-annotation-inspection-02:
+      description: |
+        This rule looks for a given method annotated with a given annotation
+      category: mandatory
+      incidents:
+      - uri: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
+        message: Annotation instpection 02
+        codeSnip: "46          dataSource.setUrl(config.getProperty(\"jdbc.url\"));\n47          dataSource.setUsername(config.getProperty(\"jdbc.user\"));\n48          dataSource.setPassword(config.getProperty(\"jdbc.password\"));\n49  \n50          return dataSource;\n51      }\n52  \n53      @Bean\n54      public PlatformTransactionManager transactionManager() {\n55          final JpaTransactionManager transactionManager = new JpaTransactionManager();\n56          transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());\n57          return transactionManager;\n58      }\n59  \n60      @Bean\n61      public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {\n62          return new PersistenceExceptionTranslationPostProcessor();\n63      }\n64  \n65      final Properties additionalProperties() {\n66      \tApplicationConfiguration config = new ApplicationConfiguration();"
+        lineNumber: 56
+        variables:
+          file: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
+          kind: Method
+          name: transactionManager
+          package: io.konveyor.demo.ordermanagement.config
+    java-annotation-inspection-03:
+      description: |
+        This rule looks for a given field annotated with a given annotation
+      category: mandatory
+      incidents:
+      - uri: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/controller/CustomerController.java
+        message: Annotation instpection 03
+        codeSnip: "11  import org.springframework.web.bind.annotation.GetMapping;\n12  import org.springframework.web.bind.annotation.PathVariable;\n13  import org.springframework.web.bind.annotation.RequestMapping;\n14  import org.springframework.web.bind.annotation.RestController;\n15  \n16  @RestController\n17  @RequestMapping(\"/customers\")\n18  public class CustomerController {\n19  \t\n20  \t@Autowired\n21  \tprivate CustomerService customerService;\n22  \t\n23  \tprivate static Logger logger = Logger.getLogger( CustomerController.class.getName() );\n24  \t\n25  \t@GetMapping(value = \"/{id}\", produces = MediaType.APPLICATION_JSON_VALUE)\n26      public Customer getById(@PathVariable(\"id\") Long id) {\n27  \t\tCustomer c = customerService.findById(id);\n28  \t\tif (c == null) {\n29  \t\t\tthrow new ResourceNotFoundException(\"Requested order doesn't exist\");\n30  \t\t}\n31  \t\tlogger.debug(\"Returning element: \" + c);"
+        lineNumber: 21
+        variables:
+          file: file:///examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/controller/CustomerController.java
+          kind: Field
+          name: customerService
+          package: io.konveyor.demo.ordermanagement.controller
     java-downloaded-maven-artifact:
       description: |
         This rule tests the application downloaded from maven artifact

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -334,7 +334,7 @@ func (r *ruleEngine) runTaggingRules(ctx context.Context, infoRules []ruleMessag
 				rs.Errors[rule.RuleID] = err.Error()
 			}
 		} else if response.Matched && len(response.Incidents) > 0 {
-			r.logger.V(5).Info("info rule was matched", "ruleID", rule.RuleID)
+			r.logger.V(5).Info("rule was matched", "ruleID", rule.RuleID)
 			tags := map[string]bool{}
 			for _, tagString := range rule.Perform.Tag {
 				if strings.Contains(tagString, "{{") && strings.Contains(tagString, "}}") {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -334,7 +334,7 @@ func (r *ruleEngine) runTaggingRules(ctx context.Context, infoRules []ruleMessag
 				rs.Errors[rule.RuleID] = err.Error()
 			}
 		} else if response.Matched && len(response.Incidents) > 0 {
-			r.logger.V(5).Info("rule was matched", "ruleID", rule.RuleID)
+			r.logger.V(5).Info("info rule was matched", "ruleID", rule.RuleID)
 			tags := map[string]bool{}
 			for _, tagString := range rule.Perform.Tag {
 				if strings.Contains(tagString, "{{") && strings.Contains(tagString, "}}") {

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -60,6 +60,7 @@ var locationToCode = map[string]int{
 	"type":                 10,
 	"package":              11,
 	"field":                12,
+	"method":               13,
 }
 
 type javaProvider struct {
@@ -85,9 +86,29 @@ type javaCondition struct {
 	Referenced referenceCondition `yaml:"referenced"`
 }
 
+// java.referenced:
+//   pattern: org.pepito.MiClase
+//   location: FIELD_DECLARATION
+//   annotated:
+//     pattern: org.home.MyAnnotation
+//     elements:
+//       - name: url
+//         value: ...
+
 type referenceCondition struct {
-	Pattern  string `yaml:"pattern"`
-	Location string `yaml:"location"`
+	Pattern   string    `yaml:"pattern"`
+	Location  string    `yaml:"location"`
+	Annotated annotated `yaml:"annotated,omitempty" json:"annotated,omitempty"`
+}
+
+type annotated struct {
+	Pattern  string    `yaml:"pattern" json:"pattern"`
+	Elements []element `yaml:"elements,omitempty" json:"elements,omitempty"`
+}
+
+type element struct {
+	Name  string `yaml:"name" json:"name"`
+	Value string `yaml:"value" json:"value"` // can be a (java) regex pattern
 }
 
 func NewJavaProvider(log logr.Logger, lspServerName string, contextLines int) *javaProvider {
@@ -296,6 +317,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		"-Djava.net.useSystemProxies=true",
 		"-configuration",
 		"./",
+		//"--jvm-arg=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:1044",
 		"-data",
 		workspace,
 	}

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -86,15 +86,6 @@ type javaCondition struct {
 	Referenced referenceCondition `yaml:"referenced"`
 }
 
-// java.referenced:
-//   pattern: org.pepito.MiClase
-//   location: FIELD_DECLARATION
-//   annotated:
-//     pattern: org.home.MyAnnotation
-//     elements:
-//       - name: url
-//         value: ...
-
 type referenceCondition struct {
 	Pattern   string    `yaml:"pattern"`
 	Location  string    `yaml:"location"`

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -338,3 +338,40 @@
     java.referenced:
       pattern: io.konveyor.demo.ordermanagement.repository.CustomerRepository
       location: FIELD
+
+- category: mandatory
+  description: |
+    This rule looks for a given class annotated with a given annotation
+  message: "Annotation instpection 01"
+  ruleID: java-annotation-inspection-01
+  when:
+    java.referenced:
+      pattern: io.konveyor.demo.ordermanagement.config.PersistenceConfig
+      location: TYPE
+      annotated:
+        pattern: org.springframework.data.jpa.repository.config.EnableJpaRepositories
+        elements:
+          - name: basePackages
+            value: "io.konveyor.demo.ordermanagement.repository"
+- category: mandatory
+  description: |
+    This rule looks for a given method annotated with a given annotation
+  message: "Annotation instpection 02"
+  ruleID: java-annotation-inspection-02
+  when:
+    java.referenced:
+      pattern: entityManagerFactory()
+      location: METHOD_DECLARATION
+      annotated:
+        pattern: org.springframework.context.annotation.Bean
+- category: mandatory
+  description: |
+    This rule looks for a given field annotated with a given annotation
+  message: "Annotation instpection 03"
+  ruleID: java-annotation-inspection-03
+  when:
+    java.referenced:
+      pattern: io.konveyor.demo.ordermanagement.service.CustomerService
+      location: FIELD
+      annotated:
+        pattern: org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
This PR adds support for inspecting annotations.

:green_circle: Things that can be done now:
- Check for annotations that are annotating specific `FIELD_DECLARATION`, `METHOD_DECLARATION` or `TYPE`
- Match against `METHOD_DECLARATION`

:red_circle: Things that cannot be done **yet**:
- Match `location: ANNOTATION` and inspect its values.
- Inspect on annotations on `location: CONSTRUCTOR`.

Depends on:
- https://github.com/konveyor/java-analyzer-bundle/pull/104

Fixes:
- https://github.com/konveyor/analyzer-lsp/issues/460
- https://github.com/konveyor/analyzer-lsp/issues/467