### PR TITLE
:bug: Prevent gradle logic from decompressing jars all the time

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/filter.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/filter.go
@@ -318,12 +318,14 @@ func (p *javaServiceClient) getURI(refURI string) (string, uri.URI, error) {
 		}
 		javaFileAbsolutePath = filepath.Join(filepath.Dir(sourcesFile), filepath.Dir(path), javaFileName)
 
-		cmd := exec.Command("jar", "xf", filepath.Base(sourcesFile))
-		cmd.Dir = filepath.Dir(sourcesFile)
-		err = cmd.Run()
-		if err != nil {
-			fmt.Printf("\n java error%v", err)
-			return "", "", err
+		if _, err := os.Stat(filepath.Dir(javaFileAbsolutePath)); err != nil {
+			cmd := exec.Command("jar", "xf", filepath.Base(sourcesFile))
+			cmd.Dir = filepath.Dir(sourcesFile)
+			err = cmd.Run()
+			if err != nil {
+				fmt.Printf("\n java error%v", err)
+				return "", "", err
+			}
 		}
 	}
 


### PR DESCRIPTION
The gradle analysis was uncompressing jars every time because of a lack of a check for the existence of the already decompressed directory.

- Related to https://github.com/konveyor/tackle2-hub/issues/667
- Partly fixes https://github.com/konveyor/analyzer-lsp/issues/662