### PR TITLE
:bug: use the location from the inital call

### DIFF
--- a/engine/conditions_test.go
+++ b/engine/conditions_test.go
@@ -15,19 +15,19 @@ func Test_sortConditionEntries(t *testing.T) {
 		{
 			title: "correctly sorted conditions should stay sorted",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					As:   "b",
 					From: "a",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					As:   "b",
 					From: "a",
 				},
@@ -35,19 +35,19 @@ func Test_sortConditionEntries(t *testing.T) {
 		}, {
 			title: "incorrectly sorted conditions should be sorted",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					As:   "b",
 					From: "a",
 				},
-				ConditionEntry{
+				{
 					As: "a",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					As:   "b",
 					From: "a",
 				},
@@ -55,43 +55,43 @@ func Test_sortConditionEntries(t *testing.T) {
 		}, {
 			title: "incorrectly sorted conditions that branch should be sorted",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					As:   "b",
 					From: "a",
 				},
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					As:   "c",
 					From: "b",
 				},
-				ConditionEntry{
+				{
 					As:   "e",
 					From: "d",
 				},
-				ConditionEntry{
+				{
 					As:   "d",
 					From: "b",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					As:   "b",
 					From: "a",
 				},
-				ConditionEntry{
+				{
 					As:   "c",
 					From: "b",
 				},
-				ConditionEntry{
+				{
 					As:   "d",
 					From: "b",
 				},
-				ConditionEntry{
+				{
 					As:   "e",
 					From: "d",
 				},
@@ -99,127 +99,127 @@ func Test_sortConditionEntries(t *testing.T) {
 		}, {
 			title: "longer chains should sort properly",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					From: "e",
 					As:   "f",
 				},
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					From: "d",
 					As:   "e",
 				},
-				ConditionEntry{
+				{
 					From: "a",
 					As:   "b",
 				},
-				ConditionEntry{
+				{
 					From: "b",
 					As:   "c",
 				},
-				ConditionEntry{
+				{
 					From: "c",
 					As:   "d",
 				},
-				ConditionEntry{
+				{
 					From: "f",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					From: "a",
 					As:   "b",
 				},
-				ConditionEntry{
+				{
 					From: "b",
 					As:   "c",
 				},
-				ConditionEntry{
+				{
 					From: "c",
 					As:   "d",
 				},
-				ConditionEntry{
+				{
 					From: "d",
 					As:   "e",
 				},
-				ConditionEntry{
+				{
 					From: "e",
 					As:   "f",
 				},
-				ConditionEntry{
+				{
 					From: "f",
 				},
 			},
 		}, {
 			title: "completely reversed chains should sort properly",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					From: "c",
 				},
-				ConditionEntry{
+				{
 					From: "b",
 					As:   "c",
 				},
-				ConditionEntry{
+				{
 					From: "a",
 					As:   "b",
 				},
-				ConditionEntry{
+				{
 					As: "a",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					From: "a",
 					As:   "b",
 				},
-				ConditionEntry{
+				{
 					From: "b",
 					As:   "c",
 				},
-				ConditionEntry{
+				{
 					From: "c",
 				},
 			},
 		}, {
 			title: "unused As should not cause error",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					From: "c",
 					As:   "d",
 				},
-				ConditionEntry{
+				{
 					From: "b",
 					As:   "c",
 				},
-				ConditionEntry{
+				{
 					From: "a",
 					As:   "b",
 				},
-				ConditionEntry{
+				{
 					As: "a",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
-				ConditionEntry{
+				{
 					From: "a",
 					As:   "b",
 				},
-				ConditionEntry{
+				{
 					From: "b",
 					As:   "c",
 				},
-				ConditionEntry{
+				{
 					From: "c",
 					As:   "d",
 				},
@@ -227,12 +227,12 @@ func Test_sortConditionEntries(t *testing.T) {
 		}, {
 			title: "length 1 lists should not cause error",
 			entries: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
 			},
 			expected: []ConditionEntry{
-				ConditionEntry{
+				{
 					As: "a",
 				},
 			},

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -604,7 +604,7 @@ func (r *ruleEngine) createViolation(ctx context.Context, conditionResponse Cond
 	}, nil
 }
 
-func (r *ruleEngine) getCodeLocation(ctx context.Context, m IncidentContext, rule Rule) (codeSnip string, err error) {
+func (r *ruleEngine) getCodeLocation(_ context.Context, m IncidentContext, rule Rule) (codeSnip string, err error) {
 	if m.CodeLocation == nil {
 		r.logger.V(6).Info("unable to get the code snip", "URI", m.FileURI)
 		return "", nil

--- a/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
@@ -287,7 +287,7 @@ func (p *javaServiceClient) GetDependenciesDAG(ctx context.Context) (map[uri.URI
 	}
 }
 
-func (p *javaServiceClient) getDependenciesForMaven(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
+func (p *javaServiceClient) getDependenciesForMaven(_ context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
 	localRepoPath := getMavenLocalRepoPath(p.mvnSettingsFile)
 
 	path := p.findPom()
@@ -338,7 +338,7 @@ func (p *javaServiceClient) getDependenciesForMaven(ctx context.Context) (map[ur
 
 // getDependenciesForGradle invokes the Gradle wrapper to get the dependency tree and returns all project dependencies
 // TODO: what if no wrapper?
-func (p *javaServiceClient) getDependenciesForGradle(ctx context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
+func (p *javaServiceClient) getDependenciesForGradle(_ context.Context) (map[uri.URI][]provider.DepDAGItem, error) {
 	subprojects, err := p.getGradleSubprojects()
 	if err != nil {
 		return nil, err

--- a/external-providers/java-external-provider/pkg/java_external_provider/dependency_test.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/dependency_test.go
@@ -524,7 +524,6 @@ func Test_parseMavenDepLines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.mavenOutput, "\n")
-			deps := []provider.DepDAGItem{}
 			var err error
 			p := javaServiceClient{
 				log:         testr.New(t),
@@ -540,6 +539,7 @@ func Test_parseMavenDepLines(t *testing.T) {
 			}
 			// we are not testing dep init here, so ignore error
 			p.depInit()
+			var deps []provider.DepDAGItem
 			if deps, err = p.parseMavenDepLines(lines[1:], "testdata", "pom.xml"); (err != nil) != tt.wantErr {
 				t.Errorf("parseMavenDepLines() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -279,6 +279,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 				fmt.Sprintf("%s.%s", strings.Join(mvnCoordinatesParts[1:3], "-"), strings.ToLower(mvnCoordinatesParts[3])))
 		}
 		if _, err := os.Stat(downloadedPath); err != nil {
+			cancelFunc()
 			return nil, fmt.Errorf("failed to download maven artifact to path %s - %w", downloadedPath, err)
 		}
 		config.Location = downloadedPath
@@ -389,6 +390,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	svcClient.initialization(ctx)
 	err = svcClient.depInit()
 	if err != nil {
+		cancelFunc()
 		return nil, err
 	}
 	// Will only set up log follow one time
@@ -416,7 +418,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	return &svcClient, returnErr
 }
 
-func resolveSourcesJarsForGradle(ctx context.Context, log logr.Logger, location string, mvnSettings string, svc *javaServiceClient) error {
+func resolveSourcesJarsForGradle(ctx context.Context, log logr.Logger, location string, _ string, svc *javaServiceClient) error {
 	ctx, span := tracing.StartNewSpan(ctx, "resolve-sources")
 	defer span.End()
 

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -72,7 +72,7 @@ func (p *javaServiceClient) Evaluate(ctx context.Context, cap string, conditionI
 	case 2:
 		incidents, err = p.filterMethodSymbols(symbols)
 	case 3:
-		incidents, err = p.filterConstructorSymbols(ctx, symbols)
+		incidents, err = p.filterDefault(symbols)
 	case 4:
 		incidents, err = p.filterDefault(symbols)
 	case 7:

--- a/external-providers/java-external-provider/pkg/java_external_provider/util_test.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/util_test.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,7 +28,7 @@ func TestRenderPom(t *testing.T) {
 	}
 
 	// Call the function with the temporary directory and sample dependencies
-	err := createJavaProject(nil, tmpDir, dependencies)
+	err := createJavaProject(context.Background(), tmpDir, dependencies)
 	if err != nil {
 		t.Fatalf("createJavaProject returned an error: %v", err)
 	}

--- a/lsp/protocol/enums.go
+++ b/lsp/protocol/enums.go
@@ -117,7 +117,7 @@ func init() {
 	namesTextDocumentSaveReason[int(FocusOut)] = "FocusOut"
 }
 
-func formatEnum(f fmt.State, c rune, i int, names []string, unknown string) {
+func formatEnum(f fmt.State, _ rune, i int, names []string, unknown string) {
 	s := ""
 	if i >= 0 && i < len(names) {
 		s = names[i]

--- a/lsp/protocol/tsdocument_changes.go
+++ b/lsp/protocol/tsdocument_changes.go
@@ -38,5 +38,5 @@ func (d *DocumentChanges) MarshalJSON() ([]byte, error) {
 	} else if d.RenameFile != nil {
 		return json.Marshal(d.RenameFile)
 	}
-	return nil, fmt.Errorf("Empty DocumentChanges union value")
+	return nil, fmt.Errorf("empty DocumentChanges union value")
 }

--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -763,16 +763,16 @@ func (r *RuleParser) getConditionForProvider(langProvider, capability string, va
 
 		fullCondition, ok := value.(map[interface{}]interface{})
 		if !ok {
-			return nil, nil, fmt.Errorf("Unable to parse dependency condition for %s", langProvider)
+			return nil, nil, fmt.Errorf("unable to parse dependency condition for %s", langProvider)
 		}
 		for k, v := range fullCondition {
 			key, ok := k.(string)
 			if !ok {
-				return nil, nil, fmt.Errorf("Unable to parse dependency condition for %s", langProvider)
+				return nil, nil, fmt.Errorf("unable to parse dependency condition for %s", langProvider)
 			}
 			value, ok := v.(string)
 			if !ok {
-				return nil, nil, fmt.Errorf("Unable to parse dependency condition for %s", langProvider)
+				return nil, nil, fmt.Errorf("unable to parse dependency condition for %s", langProvider)
 			}
 			switch key {
 			case "name":
@@ -792,11 +792,11 @@ func (r *RuleParser) getConditionForProvider(langProvider, capability string, va
 
 		}
 		if depCondition.Name == "" {
-			return nil, nil, fmt.Errorf("Unable to parse dependency condition for %s (name is required)", langProvider)
+			return nil, nil, fmt.Errorf("unable to parse dependency condition for %s (name is required)", langProvider)
 		}
 
 		if depCondition.Upperbound == "" && depCondition.Lowerbound == "" {
-			return nil, nil, fmt.Errorf("Unable to parse dependency condition for %s (one of upperbound or lowerbound is required)", langProvider)
+			return nil, nil, fmt.Errorf("unable to parse dependency condition for %s (one of upperbound or lowerbound is required)", langProvider)
 		}
 
 		return &depCondition, client, nil

--- a/parser/rule_parser_test.go
+++ b/parser/rule_parser_test.go
@@ -823,7 +823,7 @@ func TestLoadRules(t *testing.T) {
 				t.Errorf("Got err: %v expected: should have error: %v or message: %v", err, tc.ShouldErr, tc.ErrorMessage)
 				return
 			}
-			if err == nil && tc.ShouldErr {
+			if tc.ShouldErr {
 				t.Errorf("expected error but not none")
 				return
 			}

--- a/provider/grpc/dependency_resolver_client.go
+++ b/provider/grpc/dependency_resolver_client.go
@@ -35,6 +35,10 @@ func (d *dependencyLocationResolverClient) GetLocation(ctx context.Context, dep 
 		},
 		DepFile: depFile,
 	})
+	if err != nil {
+		// Igonore the error so that some failures just continue processing
+		return engine.Location{}, nil
+	}
 	if res == nil || res.Location == nil {
 		return engine.Location{}, nil
 	}

--- a/provider/internal/builtin/provider.go
+++ b/provider/internal/builtin/provider.go
@@ -12,10 +12,6 @@ import (
 
 const TAGS_FILE_INIT_OPTION = "tagsFile"
 
-var (
-	filePathsDescription = "file pattern to search"
-)
-
 var capabilities = []provider.Capability{}
 
 type builtinCondition struct {
@@ -57,7 +53,6 @@ type jsonCondition struct {
 }
 
 type builtinProvider struct {
-	ctx context.Context
 	log logr.Logger
 
 	config provider.Config
@@ -185,5 +180,4 @@ func (p *builtinProvider) Evaluate(ctx context.Context, cap string, conditionInf
 }
 
 func (p *builtinProvider) Stop() {
-	return
 }


### PR DESCRIPTION
I assume we used to find the class definition, and then had to find those references, with the updated call I can only assume we are getting the actual usage and the refenece is now finding the places that this is being called.