### PR TITLE
:bug: adding timeout for RPC call

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/konveyor/analyzer-lsp/jsonrpc2"
@@ -137,7 +138,9 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, query, location s
 	}
 
 	var refs []protocol.WorkspaceSymbol
-	err := p.rpc.Call(ctx, "workspace/executeCommand", wsp, &refs)
+	// If it takes us 5min to complete a request, then we are in trouble
+	timeOutCtx, _ := context.WithTimeout(ctx, 5*time.Minute)
+	err := p.rpc.Call(timeOutCtx, "workspace/executeCommand", wsp, &refs)
 	if err != nil {
 		if jsonrpc2.IsRPCClosed(err) {
 			p.log.Error(err, "connection to the language server is closed, language server is not running")


### PR DESCRIPTION
This cuased a problem when the language server is OOM killed and the read step was always waiting causing an indefinite hang. This will timeout these requests. 