### PR TITLE
:sparkles: try to get import references when found

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: konveyor/tackle2-addon-analyzer
-          ref: refs/pull/97/merge
+          ref: ${{ steps.extract-info.outputs.ADDON_REF }}
           path: tackle2-addon-analyzer
 
       - name: Build addon and push images


### PR DESCRIPTION
@djzager 

Basically, when we do our fall back we can find the imports mostly correct, but imports are for namespaces not for actual objects so no definition can be used. Therefore we are getting zero results back for the definiton. 

We can get all the references for the import though, and we can just let the analyzer dedup. 

If you could help get me a windows container image to test with that would helpful (or show me how) 