### PR TITLE
:bug: Adding internal template context value for dependency

### DIFF
--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -358,16 +358,19 @@
         variables:
           name: golang.org/x/text
           version: v0.3.7
+          konveyor.io/internal/dependency-rule: true
       - uri: file:///examples/golang/go.mod
         message: dependency k8s.io/apimachinery with v0.24.4 is bad and you should feel bad for using it
         variables:
           name: k8s.io/apimachinery
           version: v0.24.4
+          konveyor.io/internal/dependency-rule: true
       - uri: file:///examples/golang/go.mod
         message: dependency sigs.k8s.io/structured-merge-diff/v4 with v4.2.1 is bad and you should feel bad for using it
         variables:
           name: sigs.k8s.io/structured-merge-diff/v4
           version: v4.2.1
+          konveyor.io/internal/dependency-rule: true
       effort: 1
     java-gradle-project:
       description: |
@@ -427,6 +430,7 @@
         variables:
           name: junit.junit
           version: "4.12"
+          konveyor.io/internal/dependency-rule: true
       - uri: file:///examples/java/pom.xml
         message: dependency io.fabric8.kubernetes-client with 6.0.0 is bad and you should feel bad for using it
         codeSnip: "26  \n27    <dependencies>\n28      <dependency>\n29        <groupId>junit</groupId>\n30        <artifactId>junit</artifactId>\n31        <version>4.11</version>\n32        <scope>test</scope>\n33      </dependency>\n34      <dependency>\n35        <groupId>io.fabric8</groupId>\n36        <artifactId>kubernetes-client</artifactId>\n37        <version>6.0.0</version>\n38      </dependency>\n39      <dependency>\n40        <groupId>io.fabric8</groupId>\n41        <artifactId>kubernetes-client-api</artifactId>\n42        <version>6.0.0</version>\n43      </dependency>\n44      <dependency>\n45        <groupId>javax</groupId>\n46        <artifactId>javaee-api</artifactId>"
@@ -434,6 +438,7 @@
         variables:
           name: io.fabric8.kubernetes-client
           version: 6.0.0
+          konveyor.io/internal/dependency-rule: true
       - uri: file:///examples/java/pom.xml
         message: dependency junit.junit with 4.11 is bad and you should feel bad for using it
         codeSnip: "20    <properties>\n21      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n22      <maven.compiler.source>1.7</maven.compiler.source>\n23      <maven.compiler.target>1.7</maven.compiler.target>\n24      <javaee-api.version>7.0</javaee-api.version>\n25    </properties>\n26  \n27    <dependencies>\n28      <dependency>\n29        <groupId>junit</groupId>\n30        <artifactId>junit</artifactId>\n31        <version>4.11</version>\n32        <scope>test</scope>\n33      </dependency>\n34      <dependency>\n35        <groupId>io.fabric8</groupId>\n36        <artifactId>kubernetes-client</artifactId>\n37        <version>6.0.0</version>\n38      </dependency>\n39      <dependency>\n40        <groupId>io.fabric8</groupId>"
@@ -441,6 +446,7 @@
         variables:
           name: junit.junit
           version: "4.11"
+          konveyor.io/internal/dependency-rule: true
       effort: 1
     jboss-eap5-7-xml-02000:
       description: ""
@@ -580,6 +586,7 @@
         variables:
           name: javax.activation.activation
           version: "1.1"
+          konveyor.io/internal/dependency-rule: true
       effort: 1
     python-sample-rule-001:
       description: ""

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -740,8 +740,9 @@ func (dc DependencyCondition) Evaluate(ctx context.Context, log logr.Logger, con
 		incident := engine.IncidentContext{
 			FileURI: matchedDep.uri,
 			Variables: map[string]interface{}{
-				"name":    matchedDep.dep.Name,
-				"version": matchedDep.dep.Version,
+				"name":                                 matchedDep.dep.Name,
+				"version":                              matchedDep.dep.Version,
+				"konveyor.io/internal/dependency-rule": true,
 			},
 		}
 		if depLocationResolver != nil {


### PR DESCRIPTION
This is to allow us to know when the `java.dependency` (or other dependency capabilities) are called. This will allow kai to know when the incident is targeting dependencies and will allow it to pass to the correct task_runner.