### PR TITLE
:seedling: Unify builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest as builder
 WORKDIR /analyzer-lsp
 
 COPY cmd /analyzer-lsp/cmd


### PR DESCRIPTION
Updating builder image in Dockerfile to match to other components (like Hub) and internal builds.