### PR TITLE
:sparkles: Log full Maven output on errors

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
@@ -310,6 +310,7 @@ func (p *javaServiceClient) getDependenciesForMaven(_ context.Context) (map[uri.
 	cmd.Dir = moddir
 	mvnOutput, err := cmd.CombinedOutput()
 	if err != nil {
+		p.log.Error(err, string(mvnOutput))
 		return nil, err
 	}
 

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -280,6 +280,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		mvnOutput, err := cmd.CombinedOutput()
 		if err != nil {
 			cancelFunc()
+			p.Log.Error(err, string(mvnOutput))
 			return nil, additionalBuiltinConfig, fmt.Errorf("error downloading java artifact %s - %w", mvnUri, err)
 		}
 		downloadedPath := filepath.Join(outputDir,
@@ -694,6 +695,7 @@ func resolveSourcesJarsForMaven(ctx context.Context, log logr.Logger, location, 
 	cmd.Dir = location
 	mvnOutput, err := cmd.CombinedOutput()
 	if err != nil {
+		log.Error(err, string(mvnOutput))
 		return err
 	}
 


### PR DESCRIPTION
Java provider uses mvn command to fetch java binary or its dependencies. There was a check for success/error of those commands, but to identify a root cause and fix the mvn problem, its full output is required.

The maven output can be be exhaustive, but it is logged only in case of its failure.