### PR TITLE
:sparkles: Update Maven Search API HTTP GET request to use HTTPS

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/util.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/util.go
@@ -547,8 +547,8 @@ func constructArtifactFromSHA(jarFile string) (javaArtifact, error) {
 
 	sha1sum := hex.EncodeToString(hash.Sum(nil))
 
-	// Make an HTTP request to search.maven.org
-	searchURL := fmt.Sprintf("http://search.maven.org/solrsearch/select?q=1:%s&rows=20&wt=json", sha1sum)
+	// Make an HTTPS request to search.maven.org
+	searchURL := fmt.Sprintf("https://search.maven.org/solrsearch/select?q=1:%s&rows=20&wt=json", sha1sum)
 	resp, err := http.Get(searchURL)
 	if err != nil {
 		return dep, err


### PR DESCRIPTION
#### PR Summary
Java-external-provider: Updated the HTTP GET API call to HTTPS to ensure secure communication with Maven Central Index.
- `external-providers/java-external-provider/pkg/java_external_provider/util.go`: Changed the search URL from `http` to `https` for Maven Central Index API call.