### PR TITLE
:bug: Adding ability for provider and service client to shutdown gracefully

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -229,7 +229,10 @@ func (p *javaServiceClient) GetAllReferences(ctx context.Context, symbol protoco
 
 func (p *javaServiceClient) Stop() {
 	p.cancelFunc()
-	p.cmd.Wait()
+	err := p.cmd.Wait()
+	if err != nil {
+		p.log.Info("stopping java provider", "error", err)
+	}
 }
 
 func (p *javaServiceClient) initialization(ctx context.Context) {


### PR DESCRIPTION
This will update and catch the context cancel to close the pipes for stdin and stdout.