### PR TITLE
:sparkles: add new scope for excluded patterns [Part 1]

### DIFF
--- a/engine/conditions.go
+++ b/engine/conditions.go
@@ -311,6 +311,7 @@ func gatherChain(start ConditionEntry, entries []ConditionEntry) []ConditionEntr
 
 // Chain Templates are used by rules and providers to pass context around during rule execution.
 type ChainTemplate struct {
-	Filepaths []string               `yaml:"filepaths"`
-	Extras    map[string]interface{} `yaml:"extras"`
+	Filepaths     []string               `yaml:"filepaths,omitempty"`
+	Extras        map[string]interface{} `yaml:"extras,omitempty"`
+	ExcludedPaths []string               `yaml:"excludedPaths,omitempty"`
 }

--- a/engine/scopes.go
+++ b/engine/scopes.go
@@ -95,6 +95,10 @@ func (i *includedPathScope) AddToContext(conditionCTX *ConditionContext) error {
 }
 
 func (i *includedPathScope) FilterResponse(response IncidentContext) bool {
+	// when there are no included paths set, everything is included
+	if len(i.paths) == 0 {
+		return false
+	}
 	for _, path := range i.paths {
 		if string(response.FileURI) != "" && response.FileURI.Filename() == path {
 			return false

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -334,8 +334,8 @@ type ProviderContext struct {
 }
 
 func (p *ProviderContext) GetScopedFilepaths() (bool, []string) {
-	for key, value := range p.Template {
-		if key == engine.TemplateContextPathScopeKey {
+	if value, ok := p.Template[engine.TemplateContextPathScopeKey]; ok {
+		if len(value.Filepaths) > 0 {
 			return true, value.Filepaths
 		}
 	}


### PR DESCRIPTION
This only does post discovery filtering. We need to do pre-filtering which is incoming in another PR.