### PR TITLE
:sparkles: Adding ability for the cache for dependencies to re-gen

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -35,6 +35,7 @@ type javaServiceClient struct {
 	mvnSettingsFile   string
 	globalSettings    string
 	depsMutex         sync.RWMutex
+	depsFileHash      *string
 	depsCache         map[uri.URI][]*provider.Dep
 	depsLocationCache map[string]int
 	includedPaths     []string


### PR DESCRIPTION
* When the pom file has changed (by comparing a hash of the file) we will regen the cache.
* this should work for all the cases that have a pom
* there is a TODO to add this behavior for gradle, but that didn't ever seem to be cached.