### PR TITLE
:bug: And and Or conditions could pass with exluded data.

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -22,7 +22,11 @@ func (t testConditional) Evaluate(ctx context.Context, log logr.Logger, condCtx 
 	if t.sleep {
 		time.Sleep(5 * time.Second)
 	}
-	return ConditionResponse{Matched: t.ret}, t.err
+	if t.ret {
+		return ConditionResponse{Matched: t.ret, Incidents: []IncidentContext{{FileURI: "test"}}}, t.err
+	} else {
+		return ConditionResponse{Matched: t.ret}, t.err
+	}
 }
 
 func (t testConditional) Ignorable() bool {
@@ -49,6 +53,7 @@ func (t testChainableConditionalAs) Evaluate(ctx context.Context, log logr.Logge
 		TemplateContext: map[string]interface{}{
 			t.documentedKey: t.AsValue,
 		},
+		Incidents: []IncidentContext{{}},
 	}, t.err
 }
 


### PR DESCRIPTION
If the incidents were filtered out in the next step, the resulting complete response matched would still be set incorrectly.

We had to filter out not only the engine layer but the ConditionEntry. 

