### PR TITLE
:sparkles: add rule progress logs

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -459,6 +459,7 @@ func parseTagsFromPerformString(tagString string) ([]string, error) {
 }
 
 func processRule(ctx context.Context, rule Rule, ruleCtx ConditionContext, log logr.Logger) (ConditionResponse, error) {
+	log.WithName("process-rule").Info("processing rule", "ruleID", rule.RuleID)
 	ctx, span := tracing.StartNewSpan(
 		ctx, "process-rule", attribute.Key("rule").String(rule.RuleID))
 	defer span.End()


### PR DESCRIPTION
As [this issue](https://github.com/konveyor/kantra/issues/444) in kantra, it's better to show to log processing in the console so user can know how many rules has been processed.
we can specify the log with "process-rule" name so that the kantra CLI can use log hook to select logs print in console.
related PR in kantra: https://github.com/konveyor/kantra/pull/453