### PR TITLE
:sparkles: Removed Maven Search and build up dep info from jar

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/konveyor/analyzer-lsp/engine/labels"
 	"github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/analyzer-lsp/provider"
@@ -603,6 +604,7 @@ func (p *javaServiceClient) discoverDepsFromJars(path string, ll map[uri.URI][]k
 		m2RepoPath:  getMavenLocalRepoPath(p.mvnSettingsFile),
 		seen:        map[string]bool{},
 		initialPath: path,
+		log:         p.log,
 	}
 	filepath.WalkDir(path, w.walkDirForJar)
 }
@@ -614,6 +616,7 @@ type walker struct {
 	initialPath string
 	seen        map[string]bool
 	pomPaths    []string
+	log         logr.Logger
 }
 
 func (w *walker) walkDirForJar(path string, info fs.DirEntry, err error) error {
@@ -632,7 +635,7 @@ func (w *walker) walkDirForJar(path string, info fs.DirEntry, err error) error {
 		d := provider.Dep{
 			Name: info.Name(),
 		}
-		artifact, _ := toDependency(context.TODO(), path)
+		artifact, _ := toDependency(context.TODO(), path, w.log)
 		if (artifact != javaArtifact{}) {
 			d.Name = fmt.Sprintf("%s.%s", artifact.GroupId, artifact.ArtifactId)
 			d.Version = artifact.Version

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -349,8 +349,6 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 			return nil, additionalBuiltinConfig, err
 		}
 		config.Location = sourceLocation
-		// for binaries, we fallback to looking at .jar files only for deps
-		config.DependencyPath = depLocation
 		isBinary = true
 
 		if ok && cleanBin {
@@ -822,7 +820,7 @@ func resolveSourcesJarsForMaven(ctx context.Context, log logr.Logger, fernflower
 		log.WithValues("artifact", artifact).Info("sources for artifact not found, decompiling...")
 
 		groupDirs := filepath.Join(strings.Split(artifact.GroupId, ".")...)
-		artifactDirs := filepath.Join(strings.Split(artifact.ArtifactId, ".")...)
+		artifactDirs := artifact.ArtifactId
 		jarName := fmt.Sprintf("%s-%s.jar", artifact.ArtifactId, artifact.Version)
 		decompileJobs = append(decompileJobs, decompileJob{
 			artifact: artifact,
@@ -902,7 +900,7 @@ func parseUnresolvedSources(output io.Reader) ([]javaArtifact, error) {
 	scanner := bufio.NewScanner(output)
 
 	unresolvedRegex := regexp.MustCompile(`\[WARNING] The following artifacts could not be resolved`)
-	artifactRegex := regexp.MustCompile(`([\w\.]+):([\w\-]+):\w+:([\w\.]+):?([\w\.]+)?`)
+	artifactRegex := regexp.MustCompile(`([\w\.]+):([\w\-\.]+):\w+:([\w\.]+):?([\w\.\-]+)?`)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -225,9 +225,9 @@ func (p *javaServiceClient) Stop() {
 		p.log.Info("stopping java provider", "error", err)
 	}
 	if len(p.cleanExplodedBins) > 0 {
-		for _, explodedPath := range p.cleanExplodedBins {
-			os.RemoveAll(explodedPath)
-		}
+		//for _, explodedPath := range p.cleanExplodedBins {
+		//os.RemoveAll(explodedPath)
+		//}
 	}
 }
 


### PR DESCRIPTION
* Removed searching for dep by SHA from maven search
* Attempt to build up the dependency information from well known MANIFEST.MF headers, handle OSGI and base jar headers.
* Added a fallback to handle cases when we are unable to compute, this happens in the case of old JAR files that don't specifiy these values.