### PR TITLE
:sparkles: move open source library exclusion to the bundle

### DIFF
--- a/engine/labels/labels.go
+++ b/engine/labels/labels.go
@@ -77,6 +77,10 @@ func (l *LabelSelector[T]) MatchList(list []T) ([]T, error) {
 	return newList, nil
 }
 
+func (l *LabelSelector[T]) Expression() string {
+	return l.expr
+}
+
 type Labeled interface {
 	GetLabels() []string
 }

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -121,7 +121,7 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 		"project":                    "java",
 		"location":                   fmt.Sprintf("%v", locationToCode[strings.ToLower(c.Referenced.Location)]),
 		"analysisMode":               string(p.config.AnalysisMode),
-		"includeOpenSourceLibraries": false,
+		"includeOpenSourceLibraries": true,
 	}
 
 	depLabelSelector, err := labels.NewLabelSelector[*openSourceLabels](condCTX.DepLabelSelector, nil)
@@ -132,8 +132,10 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 		m, err := depLabelSelector.Matches(&matcher)
 		if err != nil {
 			p.log.Error(err, "could not construct dep label selector from condition context, search scope will not be limited")
-		} else if m {
-			argumentsMap["includeOpenSourceLibraries"] = true
+		} else if !m {
+			// only set to false, when explicitely set to exclude oss libraries
+			// this makes it backward compatible
+			argumentsMap["includeOpenSourceLibraries"] = false
 		}
 	}
 

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -165,7 +165,7 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 	// If it takes us 5 min to complete a request, then we are in trouble
 	timeout := 5 * time.Minute
 	// certain wildcard queries are known to perform worse especially in containers
-	if strings.HasSuffix(c.Referenced.Pattern, "*") {
+	if strings.HasSuffix(c.Referenced.Pattern, "*") || strings.HasSuffix(c.Referenced.Pattern, "*)") {
 		timeout = 10 * time.Minute
 	}
 	timeOutCtx, _ := context.WithTimeout(ctx, timeout)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -337,9 +337,10 @@ type ExternalLinks struct {
 }
 
 type ProviderContext struct {
-	Tags     map[string]interface{}          `yaml:"tags"`
-	Template map[string]engine.ChainTemplate `yaml:"template"`
-	RuleID   string                          `yaml:"ruleID"`
+	Tags             map[string]interface{}          `yaml:"tags"`
+	Template         map[string]engine.ChainTemplate `yaml:"template"`
+	RuleID           string                          `yaml:"ruleID"`
+	DepLabelSelector string                          `yaml:"depLabelSelector,omitempty"`
 }
 
 // GetScopedFilepaths returns a list of filepaths based on either included or excluded paths in context
@@ -535,6 +536,10 @@ func (p ProviderCondition) Evaluate(ctx context.Context, log logr.Logger, condCt
 		Capability: map[string]interface{}{
 			p.Capability: p.ConditionInfo,
 		},
+	}
+
+	if p.DepLabelSelector != nil {
+		providerInfo.ProviderContext.DepLabelSelector = p.DepLabelSelector.Expression()
 	}
 
 	serializedInfo, err := yaml.Marshal(providerInfo)


### PR DESCRIPTION
Bundle PR: 129

Needs https://github.com/konveyor/java-analyzer-bundle/pull/129

This moves the dep exclusion to the bundle