### PR TITLE
:ghost: migrate from ttl.sh to quay.io/konveyor

### DIFF
--- a/.github/workflows/cleanup-temp-images.yml
+++ b/.github/workflows/cleanup-temp-images.yml
@@ -1,0 +1,98 @@
+name: Cleanup Temporary Images
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run - only list images without deleting'
+        required: false
+        default: 'false'
+        type: boolean
+      max_age_hours:
+        description: 'Maximum age of images to keep (in hours)'
+        required: false
+        # images will be deleted if they are older than 6 hours
+        default: '6'
+        type: string
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository:
+          - konveyor/java-external-provider
+          - konveyor/dotnet-external-provider
+          - konveyor/generic-external-provider
+          - konveyor/tackle2-addon-analyzer
+          - konveyor/tackle2-operator-bundle
+    steps:
+      - name: Set up environment
+        run: |
+          echo "DRY_RUN=${{ github.event.inputs.dry_run || 'false' }}" >> $GITHUB_ENV
+          echo "MAX_AGE_HOURS=${{ github.event.inputs.max_age_hours || '6' }}" >> $GITHUB_ENV
+          echo "CUTOFF_DATETIME=$(date -d '${{ github.event.inputs.max_age_hours || '6' }} hours ago' +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+          registry: quay.io
+
+      - name: List and cleanup temporary images
+        run: |
+          REPOSITORY="quay.io/${{ matrix.repository }}"
+          echo "Processing repository: $REPOSITORY"
+          
+          # Get all tags for the repository
+          TAGS=$(skopeo list-tags docker://$REPOSITORY | jq -r '.Tags[]' | grep '^ci-' || true)
+          
+          if [ -z "$TAGS" ]; then
+            echo "No temporary tags found for $REPOSITORY"
+            exit 0
+          fi
+          
+          echo "Found temporary tags:"
+          echo "$TAGS"
+          
+          # Process each tag
+          for TAG in $TAGS; do
+            # Extract datetime from tag (format: ci-YYYYMMDD-HHMMSS-sha)
+            TAG_DATETIME=$(echo "$TAG" | sed -n 's/^ci-\([0-9]\{8\}-[0-9]\{6\}\)-.*$/\1/p')
+            
+            if [ -z "$TAG_DATETIME" ]; then
+              echo "Skipping tag $TAG - doesn't match expected format"
+              continue
+            fi
+            
+            # Compare with cutoff datetime
+            if [ "$TAG_DATETIME" \< "$CUTOFF_DATETIME" ]; then
+              echo "Tag $TAG is older than $MAX_AGE_HOURS hours (created: $TAG_DATETIME, cutoff: $CUTOFF_DATETIME)"
+              
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "[DRY RUN] Would delete: $REPOSITORY:$TAG"
+              else
+                echo "Deleting: $REPOSITORY:$TAG"
+                # Use skopeo to delete the image
+                skopeo delete docker://$REPOSITORY:$TAG || echo "Failed to delete $REPOSITORY:$TAG"
+              fi
+            else
+              echo "Tag $TAG is recent (created: $TAG_DATETIME), keeping it"
+            fi
+          done
+
+      - name: Summary
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run completed for ${{ matrix.repository }}. Check logs above for images that would be deleted."
+          else
+            echo "Cleanup completed for ${{ matrix.repository }}."
+          fi 

--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -14,15 +14,20 @@ jobs:
     outputs:
       api_tests_ref: ${{ steps.extract-info.outputs.API_TESTS_REF }}
       tackle2_hub_tag: ${{ steps.extract-info.outputs.TACKLE2_HUB_TAG }}
+      timestamp_tag: ${{ steps.extract-info.outputs.TIMESTAMP_TAG }}
     steps:
       - name: Extract pull request number from inputs or PR description
         id: extract-info
         env:
           PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}
         run: |
-          echo "IMG_JAVA_PROVIDER=ttl.sh/konveyor-java-external-provider-${GITHUB_SHA}:2h" >>$GITHUB_OUTPUT
-          echo "IMG_DOTNET_PROVIDER=ttl.sh/konveyor-dotnet-external-provider-${GITHUB_SHA}:2h" >>$GITHUB_OUTPUT
-          echo "IMG_GENERIC_PROVIDER=ttl.sh/konveyor-generic-external-provider-${GITHUB_SHA}:2h" >>$GITHUB_OUTPUT
+          # Generate timestamp-based tag for temporary images
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          echo "TIMESTAMP_TAG=ci-${TIMESTAMP}-${GITHUB_SHA:0:7}" >>$GITHUB_OUTPUT
+          
+          echo "IMG_JAVA_PROVIDER=quay.io/konveyor/java-external-provider:ci-${TIMESTAMP}-${GITHUB_SHA:0:7}" >>$GITHUB_OUTPUT
+          echo "IMG_DOTNET_PROVIDER=quay.io/konveyor/dotnet-external-provider:ci-${TIMESTAMP}-${GITHUB_SHA:0:7}" >>$GITHUB_OUTPUT
+          echo "IMG_GENERIC_PROVIDER=quay.io/konveyor/generic-external-provider:ci-${TIMESTAMP}-${GITHUB_SHA:0:7}" >>$GITHUB_OUTPUT
 
           echo "BUILD_BUNDLE=false" >> $GITHUB_OUTPUT
           # if this is a PR, we should use the base branch
@@ -75,6 +80,13 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+          registry: quay.io
+
       # build all provider images and the analyzer-lsp image
       - name: build images
         run: |
@@ -119,8 +131,8 @@ jobs:
       - name: Build addon and push images
         working-directory: tackle2-addon-analyzer
         run: |
-          IMG=ttl.sh/konveyor-tackle2-addon-analyzer-${GITHUB_SHA}:2h make image-podman
-          podman push ttl.sh/konveyor-tackle2-addon-analyzer-${GITHUB_SHA}:2h
+          IMG=quay.io/konveyor/tackle2-addon-analyzer:${{ steps.extract-info.outputs.TIMESTAMP_TAG }} make image-podman
+          podman push quay.io/konveyor/tackle2-addon-analyzer:${{ steps.extract-info.outputs.TIMESTAMP_TAG }}
           podman push ${{steps.extract-info.outputs.IMG_JAVA_PROVIDER }}
           podman push ${{steps.extract-info.outputs.IMG_DOTNET_PROVIDER  }}
           podman push ${{steps.extract-info.outputs.IMG_GENERIC_PROVIDER }}
@@ -128,18 +140,18 @@ jobs:
       - name: Make bundle image
         uses: konveyor/operator/.github/actions/make-bundle@main
         with:
-          operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha}}:2h
-          addon_analyzer: ttl.sh/konveyor-tackle2-addon-analyzer-${{ github.sha}}:2h
+          operator_bundle: quay.io/konveyor/tackle2-operator-bundle:${{ steps.extract-info.outputs.TIMESTAMP_TAG }}
+          addon_analyzer: quay.io/konveyor/tackle2-addon-analyzer:${{ steps.extract-info.outputs.TIMESTAMP_TAG }}
           tackle_hub: "quay.io/konveyor/tackle2-hub:${{ steps.extract-info.outputs.TACKLE2_HUB_TAG }}"
           provider_generic: ${{steps.extract-info.outputs.IMG_GENERIC_PROVIDER }}
           provider_java: ${{steps.extract-info.outputs.IMG_JAVA_PROVIDER }}
-      - name: push bundle image 
+      - name: push bundle image
         run: |
-          docker push ttl.sh/konveyor-operator-bundle-${GITHUB_SHA}:2h
+          podman push quay.io/konveyor/tackle2-operator-bundle:${{ steps.extract-info.outputs.TIMESTAMP_TAG }}
   e2e:
     needs: test
     uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
     with:
-      operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:2h
+      operator_bundle: quay.io/konveyor/tackle2-operator-bundle:${{ needs.test.outputs.timestamp_tag }}
       tackle_hub: "quay.io/konveyor/tackle2-hub:${{ needs.test.outputs.tackle2_hub_tag }}"
       api_tests_ref: "${{ needs.test.outputs.api_tests_ref }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow to regularly clean up temporary container images in multiple repositories, supporting manual runs and dry run mode.
  * Updated testing workflows to unify image hosting on quay.io with timestamp-based tags, replacing previous ttl.sh usage and adding authentication for image pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->