### PR TITLE
:sparkles: Handle Java provider shutdown logs

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -470,7 +470,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 			if err != nil && cmd.ProcessState == nil {
 				log.Info("retrying language server start")
 			} else if err != nil {
-				log.Info("language server process terminated", "error", err)
+				log.Error(err, "language server process terminated")
 			}
 			log.Info("language server stopped")
 

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -469,12 +469,13 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 			// language server has not started - don't error yet
 			if err != nil && cmd.ProcessState == nil {
 				log.Info("retrying language server start")
-			} else {
-				log.Error(err, "language server stopped with error")
+			} else if err != nil {
+				log.Info("language server process terminated", "error", err)
 			}
-			log.V(5).Info("language server stopped")
+			log.Info("language server stopped")
+
 		case <-ctx.Done():
-			log.Info("language server context cancelled closing pipes")
+			log.Info("language server context cancelled, closing pipes")
 			stdin.Close()
 			stdout.Close()
 		}

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -275,10 +275,10 @@ func (p *javaServiceClient) Stop() {
 	p.cancelFunc()
 	err = p.cmd.Wait()
 	if err != nil {
-		if isErrExpected(err) {
+		if isSafeErr(err) {
 			p.log.Info("java provider stopped")
 		} else {
-			p.log.Info("java provider stopped with error", "error", err)
+			p.log.Error(err, "java provider stopped with error")
 		}
 	} else {
 		p.log.Info("java provider stopped")
@@ -322,7 +322,8 @@ func (p *javaServiceClient) shutdown() error {
 	}
 	return nil
 }
-func isErrExpected(err error) bool {
+
+func isSafeErr(err error) bool {
 	if errors.Is(err, context.Canceled) {
 		return true
 	}

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -272,7 +272,6 @@ func (p *javaServiceClient) Stop() {
 	if err != nil {
 		p.log.Error(err, "failed to gracefully shutdown java provider")
 	}
-	p.cancelFunc()
 	err = p.cmd.Wait()
 	if err != nil {
 		if isSafeErr(err) {
@@ -334,11 +333,6 @@ func isSafeErr(err error) bool {
 				return true
 			}
 		}
-	}
-	// to prevent log msg="stopping java provider" error="{\"Stderr\":null}" provider=java
-	errStr := err.Error()
-	if errStr == "{\"Stderr\":null}" {
-		return true
 	}
 
 	return false


### PR DESCRIPTION
resolves #871 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified and simplified logging for the Java language server and provider: distinct messages for normal vs. error terminations, adjusted log levels, and improved punctuation.
  * Reduced noisy logs by classifying termination scenarios as "safe" (e.g., context cancellation or SIGTERM/SIGKILL) and logging accordingly.
  * Refined shutdown handling to avoid unconditional cancellation during stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->