### PR TITLE
Attempting to break apart and encapsulate logic in java provider/svcclient and dependency

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/flow_of_init.md
+++ b/external-providers/java-external-provider/pkg/java_external_provider/flow_of_init.md
@@ -1,0 +1,154 @@
+# Init Flow Write Up
+
+## Getting all the Config
+
+The first thing that we do is get all of the config, and the provider specifics
+into variables and set the defaults if not present.
+
+## If location is mvn://
+
+If the location is a something to download from maven then we will start there by
+downloading from maven. This process takes about 60 lines of code all in. This probably
+should be encapsulated by something.
+
+## Load the opensource dep labels (Func)
+
+Here we pull the maven index file and load the groups into a hashmap for 
+easy look up.
+
+## If .jar, .war, .ear then decompile
+
+This will decompile and update the config based on that docmpilation. 
+
+**Note: that this uses a switch with a single case**
+
+### Decompile Java (Func)
+
+Creates the new java-project that we will use.
+
+#### Expload the archive (Func)
+
+Expload will open the archive zip and loop through the files, copying them out to the a new "exploaded" dir.
+
+##### Determine what to do with the file
+
+###### Class file in WEB-INF or META-INF
+
+here we create a decompile job to decompile the class file and put it in the correct source code directory.
+
+###### Class file not in WEB-INF or META-INF
+
+here we create a decompile job to put the code in the java project, but we also create a "dependency" for it.
+
+**NOTE: this is a bug, because jar Files don't have user code in META-INF or WEB-INF**
+
+###### If it is a java file
+
+Then we copy the java file from the exploaded path to the correct source code location
+
+###### If it is a War File
+
+Then we will recursivally call expload
+
+###### If it is a Jar File
+
+We try and create a dependency for that jar
+
+####### Maven Search
+
+If allowed will try and use maven.search.org
+
+####### From Pom
+
+If maven search is not allowed or if it fails, we will try and find the 
+pom.properties and use that
+
+####### From Directory Structure
+
+If these don't work, then we will try to get a group id from the maven index and set the artificat ID to the jar name
+
+After trying to get the dependnecy info, if we fail with error, we will decompile it and add to the source code repo
+
+If we did find the dependency in maven.search we will copy the jar to .m2 cache
+
+If we didn't we will create a decompile job that will create a *-sources.jar
+
+if we fail with no error and no dep then we will copy the jar file .m2 repo
+
+###### Default case
+
+We move the file from the exploaded path to the project to the same directory.
+
+#### Create Java Prject
+
+This will take the found dependencies and create a new pom.xml file from them.
+
+## Set up Proxy env vars
+
+There is a bug here, because the proxy is set after the attempt to download the jar from
+maven and this means it won't use the configured proxy.
+
+## Set Up and Start JDTLS
+
+Next we do all the things that are needed to get the jdtls started
+
+## Next we create the javaServiceClient Struct
+
+Just putting all the values into the struct
+
+## Next we determine if we need to resolve sources
+
+Resolving sources for either Maven or Gradle
+
+### Resolving Maven Sources
+
+We will call the specific maven command to resolve deps and download sources
+
+If any of the deps sources are not found, then we will decompile them
+
+#### Decompile
+
+takes a list of jobs, creates workers and then starts to decompile.
+
+##### Expload if Java Archive was decompiled
+
+See Exploaded Funcion Above
+
+### Resolving Gradle Sources
+
+We use a builtin gradle task installed at /root/.gradle/task.gradle
+
+This is responsible for resolving deps and then downloading sources.
+
+If sources are not found then we will decompile them See Decompile above.
+
+## Initialize the svc client
+
+## Set Dep labels on the svc client
+
+## Init Exluded Dep Labels
+
+and set that on the svcClient.
+
+## Set up JDTLS log forwarder
+
+we have a 20 line piece of code, that starts a log follow on .metadata.log
+and then will add a log if it contains the text "KONVEYOR_LOG"
+
+
+## Issues with flow
+
+1. It is disjointed, hard to follow and has lots of caveats and side effects.
+2. Is slow because we are decompile individual files, rather then whole things.
+3. It is not clear what goes where and when and why, this leads to lots of overhead when debugging because you have to keep track of it all
+and the code that determines it is a bunch of string manipulation that isn't clear IMO.
+4. There are genuine differences in War, Ear, Jar that are not captured by the flow.
+5. It is not clear, that resolving dependencies is used by decompiling the binary, to pull dependencies
+6. resolving dependencies uses the same exlpoadsion code, when I am pretty sure that we don't need to do this.
+Once fern-flower decompiles the full jar, it is a sources jar. 
+7. We end up putting things into the source tree that shouldn't be.
+8. the decompile jobs are run twice, but have worker fan-out/fan-in arch. This is kind of confusing.
+
+
+### Thoughts on how to make it better
+

--- a/external-providers/java-external-provider/pkg/java_external_provider/jdtls.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/jdtls.go
@@ -1,0 +1,174 @@
+package java
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+func (p *javaProvider) StartJDTLS(ctx context.Context, lspServerPath, workspace, jvmMaxMem string) (io.Reader, io.Writer, chan (error), error) {
+	jdtlsBasePath, err := filepath.Abs(filepath.Dir(filepath.Dir(lspServerPath)))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed finding jdtls base path - %w", err)
+	}
+
+	sharedConfigPath, err := getSharedConfigPath(jdtlsBasePath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get shared config path - %w", err)
+	}
+
+	jarPath, err := findEquinoxLauncher(jdtlsBasePath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to find equinox launcher - %w", err)
+	}
+
+	javaExec, err := getJavaExecutable(true)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed getting java executable - %v", err)
+	}
+
+	jdtlsArgs := []string{
+		"-Declipse.application=org.eclipse.jdt.ls.core.id1",
+		"-Dosgi.bundles.defaultStartLevel=4",
+		"-Declipse.product=org.eclipse.jdt.ls.core.product",
+		"-Dosgi.checkConfiguration=true",
+		fmt.Sprintf("-Dosgi.sharedConfiguration.area=%s", sharedConfigPath),
+		"-Dosgi.sharedConfiguration.area.readOnly=true",
+		//"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:1044",
+		"-Dosgi.configuration.cascaded=true",
+		"-Xms1g",
+		"-XX:MaxRAMPercentage=70.0",
+		"--add-modules=ALL-SYSTEM",
+		"--add-opens", "java.base/java.util=ALL-UNNAMED",
+		"--add-opens", "java.base/java.lang=ALL-UNNAMED",
+		"-jar", jarPath,
+		"-Djava.net.useSystemProxies=true",
+		"-configuration", "./",
+		"-data", workspace,
+	}
+
+	if jvmMaxMem != "" {
+		jdtlsArgs = append(jdtlsArgs, fmt.Sprintf("-Xmx%s", jvmMaxMem))
+	}
+	cmd := exec.CommandContext(ctx, javaExec, jdtlsArgs...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	waitErrorChannel := make(chan error)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	var returnErr error
+	go func() {
+		err := cmd.Start()
+		wg.Done()
+		if err != nil {
+			returnErr = err
+			p.Log.Error(err, "unable to  start lsp command")
+			return
+		}
+		// Here we need to wait for the command to finish or if the ctx is cancelled,
+		// To close the pipes.
+		select {
+		case err := <-waitErrorChannel:
+			// language server has not started - don't error yet
+			if err != nil && cmd.ProcessState == nil {
+				p.Log.Info("retrying language server start")
+			} else {
+				p.Log.Error(err, "language server stopped with error")
+			}
+			p.Log.V(5).Info("language server stopped")
+		case <-ctx.Done():
+			p.Log.Info("language server context cancelled closing pipes")
+			stdin.Close()
+			stdout.Close()
+		}
+	}()
+
+	// This will close the go routine above when wait has completed.
+	go func() {
+		waitErrorChannel <- cmd.Wait()
+	}()
+
+	wg.Wait()
+
+	return stdout, stdin, waitErrorChannel, returnErr
+}
+
+func getSharedConfigPath(jdtlsBaseDir string) (string, error) {
+	var configDir string
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		configDir = "config_linux"
+	case "darwin":
+		configDir = "config_mac"
+	case "windows":
+		configDir = "config_win"
+	default:
+		return "", fmt.Errorf("unknown platform %s detected", runtime.GOOS)
+	}
+	return filepath.Join(jdtlsBaseDir, configDir), nil
+}
+
+func findEquinoxLauncher(jdtlsBaseDir string) (string, error) {
+	pluginsDir := filepath.Join(jdtlsBaseDir, "plugins")
+	files, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read plugins directory: %w", err)
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "org.eclipse.equinox.launcher_") && strings.HasSuffix(file.Name(), ".jar") {
+			return filepath.Join(pluginsDir, file.Name()), nil
+		}
+	}
+
+	return "", errors.New("cannot find equinox launcher")
+}
+
+func getJavaExecutable(validateJavaVersion bool) (string, error) {
+	javaExecutable := "java"
+	if javaHome, exists := os.LookupEnv("JAVA_HOME"); exists {
+		javaExecToTest := filepath.Join(javaHome, "bin", "java")
+		if runtime.GOOS == "windows" {
+			javaExecToTest += ".exe"
+		}
+		if _, err := os.Stat(javaExecToTest); err == nil {
+			javaExecutable = javaExecToTest
+		}
+	}
+
+	if !validateJavaVersion {
+		return javaExecutable, nil
+	}
+
+	out, err := exec.Command(javaExecutable, "-version").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to run %s -version: %w", javaExecutable, err)
+	}
+
+	re := regexp.MustCompile(`version\s"(\d+)[.\d]*"`)
+	matches := re.FindStringSubmatch(string(out))
+	if len(matches) > 1 {
+		javaVersion := matches[1]
+		if majorVersion := javaVersion; majorVersion < "17" {
+			return "", errors.New("jdtls requires at least Java 17")
+		}
+		return javaExecutable, nil
+	}
+
+	return "", errors.New("could not determine Java version")
+}

--- a/external-providers/java-external-provider/pkg/java_external_provider/source.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/source.go
@@ -1,0 +1,127 @@
+package java
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+type Source interface {
+	GetLocation() string
+	Decompile(context.Context) error
+	SourceResolver
+}
+
+type sourceArgs struct {
+	location            string
+	fernflower          string
+	mavenSettingsFiles  string
+	m2Repo              string
+	dependencyPath      string
+	openSourceDepLabels map[string]*depLabelItem
+	disableMavenSearch  bool
+	mvnInsecure         bool
+	log                 logr.Logger
+}
+
+func NewSource(args sourceArgs) (Source, error) {
+	if args.dependencyPath == "" {
+		args.dependencyPath = "pom.xml"
+	}
+	args.m2Repo = getMavenLocalRepoPath(args.mavenSettingsFiles)
+
+	extension := strings.ToLower(path.Ext(args.location))
+	switch extension {
+	case JavaArchive:
+		return javaArchiveSource{args}
+	case WebArchive:
+		return webArchiveSource{args}, nil
+	case EnterpriseArchive:
+		return enterpriseArchiveSource{args}, nil
+	default:
+		resolver := getSourceResolver(args)
+		if resolver == nil {
+			return nil, fmt.Errorf("unable to find build tool for location: %s", args.location)
+		}
+		return &sourceCodeSource{sourceArgs: args, SourceResolver: resolver}, nil
+	}
+}
+
+func getMavenLocalRepoPath(mvnSettingsFile string) string {
+	args := []string{
+		"help:evaluate", "-Dexpression=settings.localRepository", "-q", "-DforceStdout",
+	}
+	if mvnSettingsFile != "" {
+		args = append(args, "-s", mvnSettingsFile)
+	}
+	cmd := exec.Command("mvn", args...)
+	var outb bytes.Buffer
+	cmd.Stdout = &outb
+	err := cmd.Run()
+	if err != nil {
+		return ""
+	}
+
+	// check errors
+	return outb.String()
+}
+
+// TODO if this gets too long, then we need to break it out.
+type javaArchiveSource struct {
+	sourceArgs
+	// SourceResolver must be set, once we decompile and determine the build tool
+	SourceResolver
+}
+
+func (j *javaArchiveSource) Decompile(ctx context.Context) error {
+
+}
+
+type webArchiveSource struct {
+	sourceArgs
+	SourceResolver
+}
+
+type enterpriseArchiveSource struct {
+	sourceArgs
+	SourceResolver
+}
+
+type sourceCodeSource struct {
+	sourceArgs
+	SourceResolver
+}
+
+// Decompile does not need to happen if the source is sourse code.
+func (s *sourceCodeSource) Decompile(context.Context) error {
+	return nil
+}
+
+func (s sourceArgs) GetLocation() string {
+	return s.location
+}
+
+// This will decompile the entire archive, which will
+func decompileArchive(ctx context.Context, location, fernflower string) (string, error) {
+	// multiple java versions may be installed - chose $JAVA_HOME one
+	java := filepath.Join(os.Getenv("JAVA_HOME"), "bin", "java")
+	// -mpm (max processing method) is required to keep decomp time low
+	tempDir, err := os.MkdirTemp("", "decompile-archive")
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.CommandContext(
+		ctx, java, "-jar", fernflower, "-mpm=30", location, tempDir)
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return tempDir, nil
+}

--- a/external-providers/java-external-provider/pkg/java_external_provider/source_resolvers.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/source_resolvers.go
@@ -1,0 +1,439 @@
+package java
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/konveyor/analyzer-lsp/tracing"
+)
+
+const (
+	maven  = "maven"
+	gradle = "gradle"
+)
+
+type SourceResolver interface {
+	Resolve(context.Context) error
+	BuildTool() string
+}
+
+type sourceResolver struct {
+	fernflower         string
+	disableMavenSearch bool
+	mvnSettingsFile    string
+	mvnLocalRepo       string
+	mvnInsecure        bool
+	location           string
+	log                logr.Logger
+	depToLabels        map[string]*depLabelItem
+}
+
+type mavenSourceResolver struct {
+	sourceResolver
+}
+
+var _ SourceResolver = &mavenSourceResolver{}
+
+func (s *mavenSourceResolver) BuildTool() string {
+	return maven
+}
+
+// resolveSourcesJarsForMaven for a given source code location, runs maven to find
+// deps that don't have sources attached and decompiles them
+func (s *mavenSourceResolver) Resolve(ctx context.Context) error {
+	// TODO (pgaikwad): when we move to external provider, inherit context from parent
+	ctx, span := tracing.StartNewSpan(ctx, "resolve-sources")
+	defer span.End()
+
+	if s.mvnLocalRepo == "" {
+		s.log.V(5).Info("unable to discover dependency sources as maven local repo path is unknown")
+		return nil
+	}
+
+	decompileJobs := []decompileJob{}
+
+	s.log.Info("resolving dependency sources")
+
+	args := []string{
+		"-B",
+		"de.qaware.maven:go-offline-maven-plugin:resolve-dependencies",
+		"-DdownloadSources",
+		"-Djava.net.useSystemProxies=true",
+	}
+	if s.mvnSettingsFile != "" {
+		args = append(args, "-s", s.mvnSettingsFile)
+	}
+	if s.mvnInsecure {
+		args = append(args, "-Dmaven.wagon.http.ssl.insecure=true")
+	}
+	cmd := exec.CommandContext(ctx, "mvn", args...)
+	cmd.Dir = s.location
+	mvnOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("maven downloadSources command failed with error %w, maven output: %s", err, string(mvnOutput))
+	}
+
+	reader := bytes.NewReader(mvnOutput)
+	artifacts, err := s.parseUnresolvedSources(reader)
+	if err != nil {
+		return err
+	}
+
+	for _, artifact := range artifacts {
+		s.log.WithValues("artifact", artifact).Info("sources for artifact not found, decompiling...")
+
+		groupDirs := filepath.Join(strings.Split(artifact.GroupId, ".")...)
+		artifactDirs := filepath.Join(strings.Split(artifact.ArtifactId, ".")...)
+		jarName := fmt.Sprintf("%s-%s.jar", artifact.ArtifactId, artifact.Version)
+		decompileJobs = append(decompileJobs, decompileJob{
+			artifact: artifact,
+			inputPath: filepath.Join(
+				s.mvnLocalRepo, groupDirs, artifactDirs, artifact.Version, jarName),
+			outputPath: filepath.Join(
+				s.mvnLocalRepo, groupDirs, artifactDirs, artifact.Version, "decompiled", jarName),
+		})
+	}
+	err = decompile(ctx, s.log, alwaysDecompileFilter(true), 10, decompileJobs, s.fernflower, "", s.depToLabels, s.disableMavenSearch)
+	if err != nil {
+		return err
+	}
+	// move decompiled files to base location of the jar
+	for _, decompileJob := range decompileJobs {
+		jarName := strings.TrimSuffix(filepath.Base(decompileJob.inputPath), ".jar")
+		err = moveFile(decompileJob.outputPath,
+			filepath.Join(filepath.Dir(decompileJob.inputPath),
+				fmt.Sprintf("%s-sources.jar", jarName)))
+		if err != nil {
+			s.log.Error(err, "failed to move decompiled file", "file", decompileJob.outputPath)
+		}
+	}
+	return nil
+}
+
+// parseUnresolvedSources takes the output from the go-offline maven plugin and returns the artifacts whose sources
+// could not be found.
+func (s *mavenSourceResolver) parseUnresolvedSources(output io.Reader) ([]javaArtifact, error) {
+	unresolvedSources := []javaArtifact{}
+	unresolvedArtifacts := []javaArtifact{}
+
+	scanner := bufio.NewScanner(output)
+
+	unresolvedRegex := regexp.MustCompile(`\[WARNING] The following artifacts could not be resolved`)
+	artifactRegex := regexp.MustCompile(`([\w\.]+):([\w\-]+):\w+:([\w\.]+):?([\w\.]+)?`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if unresolvedRegex.Find([]byte(line)) != nil {
+			gavs := artifactRegex.FindAllStringSubmatch(line, -1)
+			for _, gav := range gavs {
+				// dependency jar (not sources) also not found
+				if len(gav) == 5 && gav[3] != "sources" {
+					artifact := javaArtifact{
+						packaging:  JavaArchive,
+						GroupId:    gav[1],
+						ArtifactId: gav[2],
+						Version:    gav[3],
+					}
+					unresolvedArtifacts = append(unresolvedArtifacts, artifact)
+					continue
+				}
+
+				var v string
+				if len(gav) == 4 {
+					v = gav[3]
+				} else {
+					v = gav[4]
+				}
+				artifact := javaArtifact{
+					packaging:  JavaArchive,
+					GroupId:    gav[1],
+					ArtifactId: gav[2],
+					Version:    v,
+				}
+
+				unresolvedSources = append(unresolvedSources, artifact)
+			}
+		}
+	}
+
+	// if we don't have the dependency itself available, we can't even decompile
+	result := []javaArtifact{}
+	for _, artifact := range unresolvedSources {
+		if contains(unresolvedArtifacts, artifact) || contains(result, artifact) {
+			continue
+		}
+		result = append(result, artifact)
+	}
+
+	return result, scanner.Err()
+}
+
+type gradleSourceResolver struct {
+	sourceResolver
+	gradleBuild string
+}
+
+func (s *gradleSourceResolver) BuildTool() string {
+	return gradle
+}
+
+func (g *gradleSourceResolver) Resolve(ctx context.Context) error {
+	ctx, span := tracing.StartNewSpan(ctx, "resolve-sources")
+	defer span.End()
+
+	g.log.V(5).Info("resolving dependency sources for gradle")
+
+	// create a temporary build file to append the task for downloading sources
+	taskgb := filepath.Join(filepath.Dir(g.gradleBuild), "tmp.gradle")
+	err := CopyFile(g.gradleBuild, taskgb)
+	if err != nil {
+		return fmt.Errorf("error copying file %s to %s", g.gradleBuild, taskgb)
+	}
+	defer os.Remove(taskgb)
+
+	// append downloader task
+	taskfile := "/root/.gradle/task.gradle"
+	err = AppendToFile(taskfile, taskgb)
+	if err != nil {
+		return fmt.Errorf("error appending file %s to %s", taskfile, taskgb)
+	}
+
+	tmpgbname := filepath.Join(g.location, "toberenamed.gradle")
+	err = os.Rename(g.gradleBuild, tmpgbname)
+	if err != nil {
+		return fmt.Errorf("error renaming file %s to %s", g.gradleBuild, "toberenamed.gradle")
+	}
+	defer os.Rename(tmpgbname, g.gradleBuild)
+
+	err = os.Rename(taskgb, g.gradleBuild)
+	if err != nil {
+		return fmt.Errorf("error renaming file %s to %s", g.gradleBuild, "toberenamed.gradle")
+	}
+	defer os.Remove(g.gradleBuild)
+
+	// run gradle wrapper with tmp build file
+	exe, err := filepath.Abs(filepath.Join(g.location, "gradlew"))
+	if err != nil {
+		return fmt.Errorf("error calculating gradle wrapper path")
+	}
+	if _, err = os.Stat(exe); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("a gradle wrapper must be present in the project")
+	}
+
+	// gradle must run with java 8 (see compatibility matrix)
+	java8home := os.Getenv("JAVA8_HOME")
+	if java8home == "" {
+		return fmt.Errorf("")
+	}
+
+	args := []string{
+		"konveyorDownloadSources",
+	}
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("JAVA_HOME=%s", java8home))
+	cmd.Dir = g.location
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	g.log.V(8).WithValues("output", output).Info("got gradle output")
+
+	// TODO: what if all sources available
+	reader := bytes.NewReader(output)
+	unresolvedSources, err := g.parseUnresolvedSourcesForGradle(reader)
+	if err != nil {
+		return err
+	}
+
+	g.log.V(5).Info("total unresolved sources", "count", len(unresolvedSources))
+
+	decompileJobs := []decompileJob{}
+	if len(unresolvedSources) > 1 {
+		// Gradle cache dir structure changes over time - we need to find where the actual dependencies are stored
+		cache, err := g.findGradleCache(unresolvedSources[0].GroupId)
+		if err != nil {
+			return err
+		}
+
+		for _, artifact := range unresolvedSources {
+			g.log.V(5).WithValues("artifact", artifact).Info("sources for artifact not found, decompiling...")
+
+			artifactDir := filepath.Join(cache, artifact.GroupId, artifact.ArtifactId)
+			jarName := fmt.Sprintf("%s-%s.jar", artifact.ArtifactId, artifact.Version)
+			artifactPath, err := g.findGradleArtifact(artifactDir, jarName)
+			if err != nil {
+				return err
+			}
+			decompileJobs = append(decompileJobs, decompileJob{
+				artifact:   artifact,
+				inputPath:  artifactPath,
+				outputPath: filepath.Join(filepath.Dir(artifactPath), "decompiled", jarName),
+			})
+		}
+		err = decompile(ctx, g.log, alwaysDecompileFilter(true), 10, decompileJobs, g.fernflower, "", g.depToLabels, g.disableMavenSearch)
+		if err != nil {
+			return err
+		}
+		// move decompiled files to base location of the jar
+		for _, decompileJob := range decompileJobs {
+			jarName := strings.TrimSuffix(filepath.Base(decompileJob.inputPath), ".jar")
+			err = moveFile(decompileJob.outputPath,
+				filepath.Join(filepath.Dir(decompileJob.inputPath),
+					fmt.Sprintf("%s-sources.jar", jarName)))
+			if err != nil {
+				g.log.V(5).Error(err, "failed to move decompiled file", "file", decompileJob.outputPath)
+			}
+		}
+
+	}
+	return nil
+}
+
+// findGradleCache looks for the folder within the Gradle cache where the actual dependencies are stored
+// by walking the cache directory looking for a directory equal to the given sample group id
+func (g *gradleSourceResolver) findGradleCache(sampleGroupId string) (string, error) {
+	// TODO(jmle): atm taking for granted that the cache is going to be here
+	root := "/root/.gradle/caches"
+	cache := ""
+	walker := func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("found error looking for cache directory: %w", err)
+		}
+		if d.IsDir() && d.Name() == sampleGroupId {
+			cache = path
+			return filepath.SkipAll
+		}
+		return nil
+	}
+	err := filepath.WalkDir(root, walker)
+	if err != nil {
+		return "", err
+	}
+	cache = filepath.Dir(cache) // return the parent of the found directory
+	return cache, nil
+}
+
+// findGradleArtifact looks for a given artifact jar within the given root dir
+func (g *gradleSourceResolver) findGradleArtifact(root string, artifactId string) (string, error) {
+	artifactPath := ""
+	walker := func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("found error looking for artifact: %w", err)
+		}
+		if !d.IsDir() && d.Name() == artifactId {
+			artifactPath = path
+			return filepath.SkipAll
+		}
+		return nil
+	}
+	err := filepath.WalkDir(root, walker)
+	if err != nil {
+		return "", err
+	}
+	return artifactPath, nil
+}
+
+// parseUnresolvedSources takes the output from the download sources gradle task and returns the artifacts whose sources
+// could not be found. Sample gradle output:
+// Found 0 sources for :simple-jar:
+// Found 1 sources for com.codevineyard:hello-world:1.0.1
+// Found 1 sources for org.codehaus.groovy:groovy:3.0.21
+func (g *gradleSourceResolver) parseUnresolvedSourcesForGradle(output io.Reader) ([]javaArtifact, error) {
+	unresolvedSources := []javaArtifact{}
+	unresolvedRegex := regexp.MustCompile(`Found 0 sources for (.*)`)
+	artifactRegex := regexp.MustCompile(`(.+):(.+):(.+)|:(.+):`)
+
+	scanner := bufio.NewScanner(output)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if match := unresolvedRegex.FindStringSubmatch(line); len(match) != 0 {
+			gav := artifactRegex.FindStringSubmatch(match[1])
+			if gav[4] != "" { // internal library, unknown group/version
+				artifact := javaArtifact{
+					ArtifactId: match[4],
+				}
+				unresolvedSources = append(unresolvedSources, artifact)
+			} else { // external dependency
+				artifact := javaArtifact{
+					GroupId:    gav[1],
+					ArtifactId: gav[2],
+					Version:    gav[3],
+				}
+				unresolvedSources = append(unresolvedSources, artifact)
+			}
+		}
+	}
+
+	// dedup artifacts
+	result := []javaArtifact{}
+	for _, artifact := range unresolvedSources {
+		if contains(result, artifact) {
+			continue
+		}
+		result = append(result, artifact)
+	}
+
+	return result, scanner.Err()
+}
+
+func getSourceResolver(args sourceArgs) SourceResolver {
+	sResolver := sourceResolver{
+		fernflower:         args.fernflower,
+		disableMavenSearch: args.disableMavenSearch,
+		mvnSettingsFile:    args.mavenSettingsFiles,
+		mvnLocalRepo:       args.m2Repo,
+		mvnInsecure:        args.mvnInsecure,
+		location:           args.location,
+		log:                args.log,
+		depToLabels:        args.openSourceDepLabels,
+	}
+
+	if bf := findPom(args.dependencyPath, args.location); bf != "" {
+		return &mavenSourceResolver{sourceResolver: sResolver}
+	}
+	if bf := findGradleBuild(args.location); bf != "" {
+		return &gradleSourceResolver{}
+	}
+	return nil
+}
+
+// TODO implement this for real
+func findPom(depPath, location string) string {
+	f, err := filepath.Abs(filepath.Join(location, depPath))
+	if err != nil {
+		return ""
+	}
+	if _, err := os.Stat(f); errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	return f
+}
+
+func findGradleBuild(location string) string {
+	if location != "" {
+		path := filepath.Join(location, "build.gradle")
+		_, err := os.Stat(path)
+		if err != nil {
+			return ""
+		}
+		f, err := filepath.Abs(path)
+		if err != nil {
+			return ""
+		}
+		return f
+	}
+	return ""
+}

--- a/external-providers/java-external-provider/pkg/java_external_provider/war.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/war.go
@@ -1,0 +1,10 @@
+package java
+
+type war struct {
+	// Fields for War file
+
+}
+
+func NewWar() (Source, error) {
+	return &war{}
+}


### PR DESCRIPTION

* We have many different types of run modes and behaviour is subtly
  dependent on each other.
* In this approach, everything will be tied to gether that needs to be
  and all the subtly will be explict, such as resolving sources must
come after decompiling a binary.
* When decompiling we have to take into account each type of archive and
  where they should be putting files
* When resolving sources, we need specific build tool version.
* Right now, during init, we do all of this work with deps, and then
  IIUC re-do it in the dependency code, We shouldn't need to do this I
think.

* I also want to change the decompile behaviour because fernflower can
  decompile the whole archive, we don't have to go file by file and
decompile each class.

Signed-off-by: Shawn Hurley <shawn@hurley.page>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed documentation outlining the initialization flow for the Java external provider.
  * Introduced functionality to start and manage the Eclipse JDT Language Server for Java development.
  * Implemented new abstractions and resolvers for handling and decompiling Java sources, including Maven and Gradle support.
  * Enhanced dependency identification and labeling during Java archive decompilation, including improved fallback mechanisms.

* **Refactor**
  * Simplified and modularized Java provider initialization for better maintainability and concurrency.
  * Improved handling of Maven artifact downloads and proxy configuration.
  * Streamlined service client lifecycle management and dependency label integration.

* **Bug Fixes**
  * Improved fallback and error handling for incomplete or missing Java dependency metadata.

* **Documentation**
  * Added a comprehensive markdown file describing the internal initialization logic and known issues.

* **Chores**
  * Reordered sample rule entries in the demo output for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->