### PR TITLE
:bug: Increase Gradle compatibility

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -455,7 +456,11 @@ func createProjectAndClasspathFiles(basePath string, projectName string) error {
 }
 
 func (s *javaServiceClient) GetGradleWrapper() (string, error) {
-	exe, err := filepath.Abs(filepath.Join(s.config.Location, "gradlew"))
+	wrapper := "gradlew"
+	if runtime.GOOS == "windows" {
+		wrapper = "gradlew.bat"
+	}
+	exe, err := filepath.Abs(filepath.Join(s.config.Location, wrapper))
 	if err != nil {
 		return "", fmt.Errorf("error calculating gradle wrapper path")
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-5907

Requires:
- https://github.com/konveyor/java-analyzer-bundle/pull/142

Fixes:
- https://github.com/konveyor/analyzer-lsp/issues/878

Bundle PR: 142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Gradle 9 support when resolving source JARs.
  - Automatic detection of the Gradle wrapper and Gradle version.
  - Automatic JAVA_HOME selection based on detected Gradle version and per-run resolution.

- Bug Fixes
  - Exclude Gradle “constraint” entries from dependency results.
  - More robust Gradle dependency parsing and version extraction.
  - Context-aware Gradle execution with per-invocation environment and clearer errors when Java home or wrapper are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->