### PR TITLE
:bug: Do not add insight for tagging rule with effort

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -435,13 +435,23 @@ func (r *ruleEngine) runTaggingRules(ctx context.Context, infoRules []ruleMessag
 				mapRuleSets[ruleMessage.ruleSetName] = rs
 			}
 			if rs, ok := mapRuleSets[ruleMessage.ruleSetName]; ok {
-				violation.Effort = nil
 				violation.Category = nil
-				// we need to tie these incidents back to tags that created them
-				for tag := range tags {
-					violation.Labels = append(violation.Labels, fmt.Sprintf("tag=%s", tag))
+				if violation.Effort != nil && *violation.Effort > 0 {
+					// we need to tie these incidents back to tags that created them
+					for tag := range tags {
+						violation.Labels = append(violation.Labels, fmt.Sprintf("tag=%s", tag))
+					}
+					// don't create insight for effort > 0
+					rs.Violations[rule.RuleID] = violation
+				} else {
+					violation.Effort = nil
+					// we need to tie these incidents back to tags that created them
+					for tag := range tags {
+						violation.Labels = append(violation.Labels, fmt.Sprintf("tag=%s", tag))
+					}
+					rs.Insights[rule.RuleID] = violation
 				}
-				rs.Insights[rule.RuleID] = violation
+
 			}
 		} else {
 			r.logger.Info("info rule not matched", "rule", rule.RuleID)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -334,6 +334,10 @@ func (r *ruleEngine) filterRules(ruleSets []RuleSet, selectors ...RuleSelector) 
 					ruleSetName: ruleSet.Name,
 				})
 			} else {
+				taggingRules = append(taggingRules, ruleMessage{
+					rule:        rule,
+					ruleSetName: ruleSet.Name,
+				})
 				// if both message and tag are set, split message part into a new rule if effort is non-zero
 				// if effort is zero, we do not want to create a violation but only tag and an insight
 				if rule.Perform.Message.Text != nil && rule.Effort != nil && *rule.Effort != 0 {
@@ -341,12 +345,8 @@ func (r *ruleEngine) filterRules(ruleSets []RuleSet, selectors ...RuleSelector) 
 					for _, tag := range rule.Perform.Tag {
 						rule.Labels = append(rule.Labels, fmt.Sprintf("tag=%s", tag))
 					}
+					rule.Perform.Tag = nil
 					otherRules = append(otherRules, ruleMessage{
-						rule:        rule,
-						ruleSetName: ruleSet.Name,
-					})
-				} else {
-					taggingRules = append(taggingRules, ruleMessage{
 						rule:        rule,
 						ruleSetName: ruleSet.Name,
 					})


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Findings with non-zero effort are now routed to Violations; zero/unspecified effort findings go to Insights. Tags are now attached both to rule metadata and to final findings for improved filtering and reporting.

* **Bug Fixes**
  * Preserves reported effort on findings instead of clearing it, ensuring accurate severity and classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #889 