### PR TITLE
:bug: Fallback dependency mechanism should not require version

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/dependency.go
@@ -309,7 +309,7 @@ func (p *javaServiceClient) GetDependenciesFallback(ctx context.Context, locatio
 
 	// add each dependency found
 	for _, d := range pomDeps {
-		if d.GroupID == nil || d.Version == nil || d.ArtifactID == nil {
+		if d.GroupID == nil || d.ArtifactID == nil {
 			continue
 		}
 		dep := provider.Dep{}


### PR DESCRIPTION
Dependencies without version in the pom.xml should also be included

Fixes https://github.com/konveyor/analyzer-lsp/issues/884 / https://issues.redhat.com/browse/MTA-5979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fallback dependency collection now includes dependencies even when version information is missing, improving completeness of results.
  * Non-version fields (such as name and additional metadata) are still populated; version and related file link may be absent for those entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->