### PR TITLE
:bug: Cache Maven Search Err & Fix artifactID

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/util.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/util.go
@@ -407,7 +407,7 @@ func explode(ctx context.Context, log logr.Logger, archivePath, projectPath stri
 				dependencies = append(dependencies, dep)
 				// copy this into m2 repo to avoid downloading again
 				groupPath := filepath.Join(strings.Split(dep.GroupId, ".")...)
-				artifactPath := filepath.Join(strings.Split(dep.ArtifactId, ".")...)
+				artifactPath, _ := strings.CutSuffix(filepath.Base(explodedFilePath), ".jar")
 				destPath := filepath.Join(m2Repo, groupPath, artifactPath,
 					dep.Version, filepath.Base(explodedFilePath))
 				if err := CopyFile(explodedFilePath, destPath); err != nil {
@@ -553,6 +553,8 @@ func toDependency(_ context.Context, log logr.Logger, depToLabels map[string]*de
 	return dep, err
 }
 
+var mavenSearchErrorCache error
+
 func constructArtifactFromSHA(log logr.Logger, jarFile string) (javaArtifact, error) {
 	dep := javaArtifact{}
 	// we look up the jar in maven
@@ -570,6 +572,12 @@ func constructArtifactFromSHA(log logr.Logger, jarFile string) (javaArtifact, er
 
 	sha1sum := hex.EncodeToString(hash.Sum(nil))
 
+	// if maven search is down, we do not want to keep trying on each dep
+	if mavenSearchErrorCache != nil {
+		log.Info("maven search is down, returning cached error", "error", mavenSearchErrorCache)
+		return dep, mavenSearchErrorCache
+	}
+
 	// Make an HTTPS request to search.maven.org
 	searchURL := fmt.Sprintf("https://search.maven.org/solrsearch/select?q=1:%s&rows=20&wt=json", sha1sum)
 	resp, err := http.Get(searchURL)
@@ -577,6 +585,15 @@ func constructArtifactFromSHA(log logr.Logger, jarFile string) (javaArtifact, er
 		return dep, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		statusErr := fmt.Errorf("Maven search is unavailable: %s", resp.Status)
+		// cache the server errors
+		if resp.StatusCode >= 500 {
+			mavenSearchErrorCache = statusErr
+		}
+		return dep, statusErr
+	}
 
 	// Read and parse the JSON response
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected artifact path resolution for exploded JARs, ensuring proper local repository layout and copy destinations.
- Reliability
  - More robust handling of Maven search outages and non-OK responses with clearer errors, reducing noisy failures and stabilizing dependency retrieval.
- Performance
  - Caches server-side Maven search errors to avoid repeated lookups, reducing unnecessary network calls and speeding up repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->