### PR TITLE
:bug: Do not err on unexpected jar path

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/filter.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/filter.go
@@ -218,6 +218,11 @@ func (p *javaServiceClient) getURI(refURI string) (string, uri.URI, error) {
 		// attempt to decompile when directory for the expected java file doesn't exist
 		// if directory exists, assume .java file is present within, this avoids decompiling every Jar
 		if _, err := os.Stat(filepath.Dir(javaFileAbsolutePath)); err != nil {
+			jarFilePath := filepath.Join(filepath.Dir(jarPath), filepath.Base(jarPath))
+			if _, err := os.Stat(jarFilePath); os.IsNotExist(err) {
+				p.log.V(7).Info("jar not found", "jarPath", jarPath)
+				return "", "", nil
+			}
 			cmd := exec.Command("jar", "xf", filepath.Base(jarPath))
 			cmd.Dir = filepath.Dir(jarPath)
 			err := cmd.Run()
@@ -247,6 +252,11 @@ func (p *javaServiceClient) getURI(refURI string) (string, uri.URI, error) {
 		javaFileAbsolutePath = filepath.Join(filepath.Dir(sourcesFile), filepath.Dir(path), javaFileName)
 
 		if _, err := os.Stat(filepath.Dir(javaFileAbsolutePath)); err != nil {
+			jarFilePath := filepath.Join(filepath.Dir(jarPath), filepath.Base(jarPath))
+			if _, err := os.Stat(jarFilePath); os.IsNotExist(err) {
+				p.log.V(7).Info("jar not found", "jarPath", jarPath)
+				return "", "", nil
+			}
 			cmd := exec.Command("jar", "xf", filepath.Base(sourcesFile))
 			cmd.Dir = filepath.Dir(sourcesFile)
 			err = cmd.Run()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents decompilation attempts when the JAR is missing in Maven/Gradle paths, avoiding confusing errors.

* **Performance**
  * Skips unnecessary processing when artifacts are absent, improving scan speed and efficiency.

* **Logging**
  * Adds a clear verbose message when a JAR is not found, aiding diagnostics without interrupting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->