### PR TITLE
:bug: Add cmd for gradle version

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -487,6 +487,8 @@ func (s *javaServiceClient) GetGradleVersion(ctx context.Context) (version.Versi
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// if executing with 8 we get an error, try with 17
+		cmd = exec.CommandContext(ctx, exe, args...)
+		cmd.Dir = s.config.Location
 		cmd.Env = append(cmd.Env, fmt.Sprintf("JAVA_HOME=%s", os.Getenv("JAVA_HOME")))
 		output, err = cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gradle version detection by retrying with an alternative Java runtime while preserving the working directory.
  * Reduces false negatives and intermittent failures during environment checks, leading to more reliable project analysis and setup for Gradle-based Java projects, especially on systems where the default Java 8 environment is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->