### PR TITLE
:sparkles: Decoding for builtin and Java providers

### DIFF
--- a/engine/encoding.go
+++ b/engine/encoding.go
@@ -1,4 +1,4 @@
-package provider
+package engine
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/text/transform"
 )
 
-// TODO: support more encodings
+// TODO: add more encodings
 func GetEncodingFromName(encodingName string) (encoding.Encoding, error) {
 	switch strings.ToLower(strings.ReplaceAll(encodingName, "-", "")) {
 	case "shiftjis", "shift_jis", "sjis":

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,6 +62,7 @@ type ruleEngine struct {
 	contextLines     int
 	incidentSelector string
 	locationPrefixes []string
+	encoding         string
 }
 
 type Option func(engine *ruleEngine)
@@ -93,6 +94,12 @@ func WithIncidentSelector(selector string) Option {
 func WithLocationPrefixes(location []string) Option {
 	return func(engine *ruleEngine) {
 		engine.locationPrefixes = location
+	}
+}
+
+func WithEncoding(encoding string) Option {
+	return func(engine *ruleEngine) {
+		engine.encoding = encoding
 	}
 }
 
@@ -670,14 +677,25 @@ func (r *ruleEngine) getCodeLocation(_ context.Context, m IncidentContext, rule 
 
 	if strings.HasPrefix(string(m.FileURI), uri.FileScheme) {
 		//Find the file, open it in a buffer.
-		readFile, err := os.Open(m.FileURI.Filename())
-		if err != nil {
-			r.logger.V(5).Error(err, "Unable to read file")
-			return "", err
+		var content []byte
+		var err error
+		if r.encoding != "" {
+			content, err = OpenFileWithEncoding(m.FileURI.Filename(), r.encoding)
+			if err != nil {
+				r.logger.V(5).Error(err, "failed to convert file encoding, using original content", "file", m.FileURI.Filename())
+				content, err = os.ReadFile(m.FileURI.Filename())
+				if err != nil {
+					return "", err
+				}
+			}
+		} else {
+			content, err = os.ReadFile(m.FileURI.Filename())
+			if err != nil {
+				return "", err
+			}
 		}
-		defer readFile.Close()
 
-		scanner := bufio.NewScanner(readFile)
+		scanner := bufio.NewScanner(strings.NewReader(string(content)))
 		lineNumber := 0
 		codeSnip := ""
 		paddingSize := len(strconv.Itoa(m.CodeLocation.EndPosition.Line + r.contextLines))

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -77,6 +77,7 @@ type javaProvider struct {
 	config       provider.Config
 	Log          logr.Logger
 	contextLines int
+	encoding     string
 
 	clients []provider.ServiceClient
 
@@ -128,6 +129,7 @@ func NewJavaProvider(log logr.Logger, lspServerName string, contextLines int, co
 		lspServerName:     lspServerName,
 		depsLocationCache: make(map[string]int),
 		contextLines:      contextLines,
+		encoding:          "",
 		logFollow:         sync.Once{},
 	}
 }
@@ -229,6 +231,8 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	} else if !(mode == provider.FullAnalysisMode || mode == provider.SourceOnlyAnalysisMode) {
 		return nil, additionalBuiltinConfig, fmt.Errorf("invalid Analysis Mode")
 	}
+
+	p.encoding = provider.GetEncodingFromConfig(config)
 	log = log.WithValues("provider", "java")
 
 	if config.RPC != nil {

--- a/external-providers/java-external-provider/pkg/java_external_provider/snipper.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/snipper.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/konveyor/analyzer-lsp/engine"
-	"github.com/konveyor/analyzer-lsp/provider"
 	"go.lsp.dev/uri"
 )
 
@@ -33,7 +32,7 @@ func (p *javaProvider) scanFile(path string, loc engine.Location) (string, error
 	var content []byte
 	var err error
 	if p.encoding != "" {
-		content, err = provider.OpenFileWithEncoding(path, p.encoding)
+		content, err = engine.OpenFileWithEncoding(path, p.encoding)
 		if err != nil {
 			p.Log.Error(err, "failed to convert file encoding, using original content", "file", path)
 			content, err = os.ReadFile(path)

--- a/external-providers/java-external-provider/pkg/java_external_provider/snipper.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/snipper.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/konveyor/analyzer-lsp/engine"
+	"github.com/konveyor/analyzer-lsp/provider"
 	"go.lsp.dev/uri"
 )
 
@@ -29,14 +30,25 @@ func (p *javaProvider) GetCodeSnip(u uri.URI, loc engine.Location) (string, erro
 }
 
 func (p *javaProvider) scanFile(path string, loc engine.Location) (string, error) {
-	readFile, err := os.Open(path)
-	if err != nil {
-		p.Log.V(5).Error(err, "Unable to read file")
-		return "", err
+	var content []byte
+	var err error
+	if p.encoding != "" {
+		content, err = provider.OpenFileWithEncoding(path, p.encoding)
+		if err != nil {
+			p.Log.Error(err, "failed to convert file encoding, using original content", "file", path)
+			content, err = os.ReadFile(path)
+			if err != nil {
+				return "", err
+			}
+		}
+	} else {
+		content, err = os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
 	}
-	defer readFile.Close()
 
-	scanner := bufio.NewScanner(readFile)
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
 	lineNumber := 0
 	codeSnip := ""
 	paddingSize := len(strconv.Itoa(loc.EndPosition.Line + p.contextLines))

--- a/provider/encoding.go
+++ b/provider/encoding.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/transform"
+)
+
+// TODO: support more encodings
+func GetEncodingFromName(encodingName string) (encoding.Encoding, error) {
+	switch strings.ToLower(strings.ReplaceAll(encodingName, "-", "")) {
+	case "shiftjis", "shift_jis", "sjis":
+		return japanese.ShiftJIS, nil
+	default:
+		return nil, fmt.Errorf("unsupported encoding: %s", encodingName)
+	}
+}
+
+func ConvertToUTF8(content []byte, encodingName string) ([]byte, error) {
+	if encodingName == "" || strings.ToUpper(encodingName) == "UTF-8" || strings.ToUpper(encodingName) == "UTF8" {
+		return content, nil
+	}
+	enc, err := GetEncodingFromName(encodingName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get encoding for %s: %w", encodingName, err)
+	}
+	decoder := enc.NewDecoder()
+	utf8Content, err := io.ReadAll(transform.NewReader(bytes.NewReader(content), decoder))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert from %s to UTF-8: %w", encodingName, err)
+	}
+
+	return utf8Content, nil
+}
+
+func OpenFileWithEncoding(filePath string, encodingName string) ([]byte, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if encodingName != "" {
+		utf8Content, err := ConvertToUTF8(content, encodingName)
+		if err != nil {
+			return content, err
+		}
+		return utf8Content, nil
+	}
+
+	return content, nil
+}

--- a/provider/internal/builtin/provider.go
+++ b/provider/internal/builtin/provider.go
@@ -161,6 +161,7 @@ func (p *builtinProvider) Init(ctx context.Context, log logr.Logger, config prov
 		log:                                log,
 		includedPaths:                      provider.GetIncludedPathsFromConfig(config, true),
 		excludedDirs:                       provider.GetExcludedDirsFromConfig(config),
+		encoding:                           provider.GetEncodingFromConfig(config),
 		workingCopyMgr:                     wcm,
 	}, provider.InitConfig{}, nil
 }

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -419,3 +419,12 @@ func GetExcludedDirsFromConfig(i InitConfig) []string {
 	}
 	return validatedPaths
 }
+
+func GetEncodingFromConfig(i InitConfig) string {
+	if encodingValue, ok := i.ProviderSpecificConfig[EncodingConfigKey]; ok {
+		if encoding, ok := encodingValue.(string); ok {
+			return encoding
+		}
+	}
+	return ""
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -36,6 +36,7 @@ const (
 	LspServerPathConfigKey = "lspServerPath"
 	IncludedPathsConfigKey = "includedPaths"
 	ExcludedDirsConfigKey  = "excludedDirs"
+	EncodingConfigKey      = "encoding"
 )
 
 // We need to make these Vars, because you can not take a pointer of the constant.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-init encoding support that can be configured and passed to the engine and providers.
  * Files are read with encoding-aware conversion to UTF-8, with safe fallback and logging on conversion failures.
  * Improved parsing and scanning of non-UTF-8 content (e.g., Shift‑JIS) for JSON, XML, and code snippet extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

Fixes #900 