### PR TITLE
:bug: Pass extra-args to build-push-images

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -61,7 +61,7 @@ jobs:
       registry: "quay.io/konveyor"
       image_name: ${{ matrix.images.name }}
       containerfile: ${{ matrix.images.containerfile }}
-      extra-args: ${{ matrix.images.extra-args }}
+      extra-args: ${{ matrix.images['extra-args'] || '' }}
       pre_build_cmd: ${{ matrix.images.pre_build_cmd }}
       architectures: ${{ matrix.images.architectures }}
       context: ${{ matrix.images.context }}


### PR DESCRIPTION
We must pass the `extra-args` argument [to the build-push-images job](https://github.com/konveyor/release-tools/blob/main/.github/workflows/build-push-images.yaml#L27).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build configuration updated to forward per-image extra arguments into the image build process, allowing custom build flags per image. This improves flexibility for image builds while preserving existing build behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->