### PR TITLE
:seedling: analyzer + provider workflow artifacts

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -6,18 +6,66 @@ jobs:
   test:
     strategy:
       matrix:
-        runs_on:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        include:
+        - runs_on: ubuntu-latest
+          goos: linux
+          goarch: amd64
+          artifact_name: linux-x86_64
+        - runs_on: ubuntu-latest
+          goos: linux
+          goarch: arm64
+          artifact_name: linux-aarch64
+        - runs_on: macos-latest
+          goos: darwin
+          goarch: amd64
+          artifact_name: macos-x86_64
+        - runs_on: macos-latest
+          goos: darwin
+          goarch: arm64
+          artifact_name: macos-arm64
+        - runs_on: windows-latest
+          goos: windows
+          goarch: amd64
+          artifact_name: windows-X64
     runs-on: ${{ matrix.runs_on }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23.9'
 
       - name: Test
         run: go test -v ./...
+
+      - name: Build binaries
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: make build
+
+      - name: Upload analyzer-lsp binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: analyzer-lsp.${{ matrix.artifact_name }}-${{ github.sha }}
+          path: konveyor-analyzer${{ matrix.goos == 'windows' && '.exe' || '' }}
+          retention-days: 30
+
+      - name: Upload analyzer-lsp deps binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: analyzer-lsp-deps.${{ matrix.artifact_name }}-${{ github.sha }}
+          path: konveyor-analyzer-dep${{ matrix.goos == 'windows' && '.exe' || '' }}
+          retention-days: 30
+
+      - name: Upload external-providers binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-providers.${{ matrix.artifact_name }}-${{ github.sha }}
+          path: |
+            external-providers/generic-external-provider/generic-external-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
+            external-providers/golang-dependency-provider/golang-dependency-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
+            external-providers/yq-external-provider/yq-external-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
+            external-providers/java-external-provider/java-external-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
+          retention-days: 30
 


### PR DESCRIPTION
Make it possible to develop with `npm run collect-assets:dev` from konveyor/editor-extension (specifically in the distributed language extension feature branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI build and artifact management to support multiple OSes and architectures (Linux, macOS, Windows on x64 and ARM64).
  * Updated workflow tooling versions and added a cross-platform build step that produces platform-specific binaries.
  * Added per-target artifact uploads (including multiple executables), platform-aware naming (Windows .exe suffix) and conditional publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->