### PR TITLE
:seedling: simplify the build workflow and artifact creation

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -1,4 +1,4 @@
-name: Testing Engine
+name: Build and Test
 
 on: ["push", "pull_request"]
 
@@ -44,28 +44,20 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: make build
 
-      - name: Upload analyzer-lsp binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: analyzer-lsp.${{ matrix.artifact_name }}-${{ github.sha }}
-          path: konveyor-analyzer${{ matrix.goos == 'windows' && '.exe' || '' }}
-          retention-days: 30
+      - name: Create binary archive (Windows)
+        if: matrix.goos == 'windows'
+        run: |
+          cd build
+          Compress-Archive -Path * -DestinationPath ../konveyor-analyzer-binaries-${{ matrix.goos }}-${{ matrix.goarch }}.zip
 
-      - name: Upload analyzer-lsp deps binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: analyzer-lsp-deps.${{ matrix.artifact_name }}-${{ github.sha }}
-          path: konveyor-analyzer-dep${{ matrix.goos == 'windows' && '.exe' || '' }}
-          retention-days: 30
+      - name: Create binary archive (Unix)
+        if: matrix.goos != 'windows'
+        run: tar -czf konveyor-analyzer-binaries-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz -C build .
 
-      - name: Upload external-providers binaries
+      - name: Upload binary archive
         uses: actions/upload-artifact@v4
         with:
-          name: external-providers.${{ matrix.artifact_name }}-${{ github.sha }}
-          path: |
-            external-providers/generic-external-provider/generic-external-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
-            external-providers/golang-dependency-provider/golang-dependency-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
-            external-providers/yq-external-provider/yq-external-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
-            external-providers/java-external-provider/java-external-provider${{ matrix.goos == 'windows' && '.exe' || '' }}
+          name: konveyor-analyzer-binaries-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
+          path: konveyor-analyzer-binaries-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
           retention-days: 30
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ org.eclipse.core*
 org.eclipse.osgi*
 org.eclipse.equinox*
 provider_settings.json
+build/
 konveyor-analyzer
 konveyor-analyzer-dep
 go.work

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,25 @@ Java provider uses Eclipse JDTLS which is bundled in the container image.
 Build the main analyzer binary:
 
 ```bash
-go build -o analyzer-lsp main.go
+make analyzer
 ```
+
+This creates `build/konveyor-analyzer` in the project root.
+
+Alternatively, build all components at once:
+
+```bash
+make build
+```
+
+This creates all binaries in the `build/` directory:
+- `build/konveyor-analyzer` - Main analyzer binary
+- `build/konveyor-analyzer-dep` - Dependency analyzer
+- `build/generic-external-provider`
+- `build/golang-dependency-provider`
+- `build/yq-external-provider`
+- `build/java-external-provider`
+- `build/dotnet-external-provider`
 
 ### Building External Providers
 
@@ -212,7 +229,7 @@ Example provider settings file for Node.js:
 [
   {
     "name": "nodejs",
-    "binaryPath": "./external-providers/generic-external-provider/generic-external-provider",
+    "binaryPath": "./build/generic-external-provider",
     "initConfig": [{
       "analysisMode": "full",
       "providerSpecificConfig": {
@@ -235,7 +252,7 @@ Example provider settings file for Node.js:
 Run analysis:
 
 ```bash
-./analyzer-lsp \
+./build/konveyor-analyzer \
   --provider-settings=provider_settings.json \
   --rules=rule-example.yaml \
   --output-file=output.yaml \
@@ -531,7 +548,7 @@ RUN cd examples/nodejs && npm install
 
 ### Before Submitting
 
-1. **Build all providers:** `make build-external`
+1. **Build all components:** `make build`
 2. **Run tests:** `go test ./...`
 3. **Test with containers:** Follow container-based development workflow
 4. **Regenerate demo output:** If you added/changed rules or provider behavior
@@ -578,7 +595,7 @@ git commit -s -m ":book: Add comprehensive contributor guide"
 
 ```bash
 # 1. Build everything
-make build-external
+make build
 podman build -t quay.io/konveyor/analyzer-lsp:latest -f Dockerfile .
 
 # 2. Run providers
@@ -598,7 +615,7 @@ git commit -s -m "Regenerate demo output with [your changes]"
 
 ### PR Checklist
 
-- [ ] Code builds successfully (`make build-external`)
+- [ ] Code builds successfully (`make build`)
 - [ ] Tests pass (`go test ./...`)
 - [ ] Added test rules for new functionality
 - [ ] Regenerated `demo-output.yaml` if needed

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,12 +44,12 @@ RUN npm install -g typescript-language-server typescript
 
 COPY --from=jaeger-builder /go/bin/all-in-one-linux /usr/local/bin/all-in-one-linux
 COPY --from=yq-builder /usr/bin/yq /usr/local/bin/yq
-COPY --from=builder /analyzer-lsp/konveyor-analyzer /usr/local/bin/konveyor-analyzer
-COPY --from=builder /analyzer-lsp/konveyor-analyzer-dep /usr/local/bin/konveyor-analyzer-dep
-COPY --from=builder /analyzer-lsp/external-providers/generic-external-provider/generic-external-provider /usr/local/bin/generic-external-provider
-COPY --from=builder /analyzer-lsp/external-providers/yq-external-provider/yq-external-provider /usr/local/bin/yq-external-provider
-COPY --from=builder /analyzer-lsp/external-providers/golang-dependency-provider/golang-dependency-provider /usr/local/bin/golang-dependency-provider
-COPY --from=builder /analyzer-lsp/external-providers/java-external-provider/java-external-provider /usr/local/bin/java-external-provider
+COPY --from=builder /analyzer-lsp/build/konveyor-analyzer /usr/local/bin/konveyor-analyzer
+COPY --from=builder /analyzer-lsp/build/konveyor-analyzer-dep /usr/local/bin/konveyor-analyzer-dep
+COPY --from=builder /analyzer-lsp/build/generic-external-provider /usr/local/bin/generic-external-provider
+COPY --from=builder /analyzer-lsp/build/yq-external-provider /usr/local/bin/yq-external-provider
+COPY --from=builder /analyzer-lsp/build/golang-dependency-provider /usr/local/bin/golang-dependency-provider
+COPY --from=builder /analyzer-lsp/build/java-external-provider /usr/local/bin/java-external-provider
 
 COPY provider_container_settings.json /analyzer-lsp/provider_settings.json
 RUN ln -s /root/go/bin/gopls /usr/local/bin/gopls

--- a/Makefile
+++ b/Makefile
@@ -12,25 +12,31 @@ else
 	MOUNT_OPT := 
 endif
 
-build: analyzer deps golang-dependency-provider external-generic yq-external-provider java-external-provider
+build-dir:
+	mkdir -p build
 
-analyzer:
-	go build -o konveyor-analyzer ./cmd/analyzer/main.go
+build: build-dir analyzer deps golang-dependency-provider external-generic yq-external-provider java-external-provider dotnet-external-provider
 
-external-generic:
-	( cd external-providers/generic-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o generic-external-provider main.go)
+analyzer: build-dir
+	go build -o build/konveyor-analyzer ./cmd/analyzer/main.go
 
-golang-dependency-provider:
-	( cd external-providers/golang-dependency-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o golang-dependency-provider main.go)
+external-generic: build-dir
+	( cd external-providers/generic-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o ../../build/generic-external-provider main.go)
 
-yq-external-provider:
-	( cd external-providers/yq-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o yq-external-provider main.go)
+golang-dependency-provider: build-dir
+	( cd external-providers/golang-dependency-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o ../../build/golang-dependency-provider main.go)
 
-java-external-provider:
-	( cd external-providers/java-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o java-external-provider main.go)
+yq-external-provider: build-dir
+	( cd external-providers/yq-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o ../../build/yq-external-provider main.go)
 
-deps:
-	go build -o konveyor-analyzer-dep ./cmd/dep/main.go
+java-external-provider: build-dir
+	( cd external-providers/java-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o ../../build/java-external-provider main.go)
+
+dotnet-external-provider: build-dir
+	( cd external-providers/dotnet-external-provider && go mod edit -replace=github.com/konveyor/analyzer-lsp=../../ && go mod tidy -go=1.23.9 && go build -o ../../build/dotnet-external-provider main.go)
+
+deps: build-dir
+	go build -o build/konveyor-analyzer-dep ./cmd/dep/main.go
 
 image-build:
 	docker build --build-arg=JAVA_BUNDLE_TAG=$(TAG_JAVA_BUNDLE) -f Dockerfile . -t $(DOCKER_IMAGE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated build outputs into a build/ directory and unified make targets to produce main and provider binaries there.
  * CI renamed the workflow and now creates platform-specific consolidated archives (ZIP for Windows, tar.gz for others) instead of multiple per-artifact uploads.
  * Added build/ to .gitignore to avoid tracking generated artifacts.
  * Container build updated to copy prebuilt artifacts and streamline startup.

* **Documentation**
  * Updated contributor guide and examples to use Make-based build commands and the new binary locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->