### PR TITLE
:sparkles: Fix GRPC provider to use socket helper for passthrough addresses

### DIFF
--- a/provider/grpc/provider.go
+++ b/provider/grpc/provider.go
@@ -308,10 +308,11 @@ func start(ctx context.Context, config provider.Config, log logr.Logger) (*grpc.
 			var conn *grpc.ClientConn
 			var err error
 
-			if config.UseSocket && strings.HasPrefix(config.Address, "unix://") {
+			if config.UseSocket && (strings.HasPrefix(config.Address, "unix://") || strings.HasPrefix(config.Address, "passthrough:")) {
 				// Use socket connection
-				// for windows, we will ise passthrough to connect to the socket
+				// for windows, we will use passthrough to connect to the socket
 				// which is defined in the socket/pipe_windows.go file
+				// Supports: unix://path (Unix) and passthrough:unix://path (Windows)
 				conn, err = socket.ConnectGRPC(config.Address)
 			} else {
 				// Use regular HTTP connection


### PR DESCRIPTION
The provider/grpc/provider.go was only calling socket.ConnectGRPC() for addresses starting with 'unix://', but Windows named pipes use the format 'passthrough:unix://\.\pipe\...' which starts with 'passthrough:'.

This caused Windows connections to fall through to the regular grpc.NewClient() path which doesn't support Windows named pipes, resulting in errors like: 'dial tcp: lookup tcp:///\.\pipe\... unknown port'

Now checks for both 'unix://' and 'passthrough:' prefixes to properly route Windows named pipe connections through the socket helper which has the custom Windows dialer (provider/grpc/socket/pipe_windows.go).

This completes Windows named pipe support for external GRPC providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GRPC socket connection support to handle additional address formats, including passthrough addresses for better connectivity options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->