### PR TITLE
:bug: Gracefully skip rules requiring unavailable providers

### DIFF
--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -23,6 +23,15 @@ var defaultRuleSet = &engine.RuleSet{
 	Name: "konveyor-analysis",
 }
 
+// MissingProviderError indicates a rule requires a provider that is not available
+type MissingProviderError struct {
+	Provider string
+}
+
+func (e MissingProviderError) Error() string {
+	return fmt.Sprintf("unable to find provider for: %v", e.Provider)
+}
+
 type parserErrors struct {
 	errs []error
 }
@@ -348,7 +357,10 @@ func (r *RuleParser) LoadRule(filepath string) ([]engine.Rule, map[string]provid
 				}
 				conditions, provs, err := r.getConditions(m)
 				if err != nil {
-					r.Log.V(8).Error(err, "failed parsing conditions in or clause", "ruleID", ruleID, "file", filepath)
+					// Skip logging for missing provider errors - they're already logged at debug level
+					if _, ok := err.(MissingProviderError); !ok {
+						r.Log.V(8).Error(err, "failed parsing conditions in or clause", "ruleID", ruleID, "file", filepath)
+					}
 					return nil, nil, err
 				}
 				if len(conditions) == 0 {
@@ -377,7 +389,10 @@ func (r *RuleParser) LoadRule(filepath string) ([]engine.Rule, map[string]provid
 				}
 				conditions, provs, err := r.getConditions(m)
 				if err != nil {
-					r.Log.V(8).Error(err, "failed parsing conditions in and clause", "ruleID", ruleID, "file", filepath)
+					// Skip logging for missing provider errors - they're already logged at debug level
+					if _, ok := err.(MissingProviderError); !ok {
+						r.Log.V(8).Error(err, "failed parsing conditions in and clause", "ruleID", ruleID, "file", filepath)
+					}
 					return nil, nil, err
 				}
 				if len(conditions) == 0 {
@@ -410,6 +425,12 @@ func (r *RuleParser) LoadRule(filepath string) ([]engine.Rule, map[string]provid
 
 				condition, provider, err := r.getConditionForProvider(providerKey, capability, value)
 				if err != nil {
+					// If provider is missing, log at debug level and skip this rule
+					if _, ok := err.(MissingProviderError); ok {
+						r.Log.V(5).Info("skipping rule for unavailable provider", "provider", providerKey, "capability", capability, "ruleID", ruleID)
+						continue
+					}
+					// For other errors, log and return as before
 					r.Log.V(8).Error(err, "failed parsing conditions for provider",
 						"provider", providerKey, "capability", capability, "ruleID", ruleID, "file", filepath)
 					return nil, nil, err
@@ -694,6 +715,12 @@ func (r *RuleParser) getConditions(conditionsInterface []interface{}) ([]engine.
 
 				condition, provider, err := r.getConditionForProvider(providerKey, capability, v)
 				if err != nil {
+					// If provider is missing, log at debug level and skip this condition
+					if _, ok := err.(MissingProviderError); ok {
+						r.Log.V(5).Info("skipping condition for unavailable provider", "provider", providerKey, "capability", capability)
+						continue
+					}
+					// For other errors, return as before
 					return nil, nil, err
 				}
 				if condition == nil {
@@ -744,7 +771,7 @@ func (r *RuleParser) getConditionForProvider(langProvider, capability string, va
 	// Here there can only be a single provider.
 	client, ok := r.ProviderNameToClient[langProvider]
 	if !ok {
-		return nil, nil, fmt.Errorf("unable to find provider for: %v", langProvider)
+		return nil, nil, MissingProviderError{Provider: langProvider}
 	}
 
 	if !provider.HasCapability(client.Capabilities(), capability) {

--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -357,10 +357,13 @@ func (r *RuleParser) LoadRule(filepath string) ([]engine.Rule, map[string]provid
 				}
 				conditions, provs, err := r.getConditions(m)
 				if err != nil {
-					// Skip logging for missing provider errors - they're already logged at debug level
-					if _, ok := err.(MissingProviderError); !ok {
-						r.Log.V(8).Error(err, "failed parsing conditions in or clause", "ruleID", ruleID, "file", filepath)
+					// If provider is missing, treat as no conditions and skip the rule
+					if _, ok := err.(MissingProviderError); ok {
+						noConditions = true
+						break
 					}
+					// For other errors, log and return as before
+					r.Log.V(8).Error(err, "failed parsing conditions in or clause", "ruleID", ruleID, "file", filepath)
 					return nil, nil, err
 				}
 				if len(conditions) == 0 {
@@ -389,10 +392,13 @@ func (r *RuleParser) LoadRule(filepath string) ([]engine.Rule, map[string]provid
 				}
 				conditions, provs, err := r.getConditions(m)
 				if err != nil {
-					// Skip logging for missing provider errors - they're already logged at debug level
-					if _, ok := err.(MissingProviderError); !ok {
-						r.Log.V(8).Error(err, "failed parsing conditions in and clause", "ruleID", ruleID, "file", filepath)
+					// If provider is missing, treat as no conditions and skip the rule
+					if _, ok := err.(MissingProviderError); ok {
+						noConditions = true
+						break
 					}
+					// For other errors, log and return as before
+					r.Log.V(8).Error(err, "failed parsing conditions in and clause", "ruleID", ruleID, "file", filepath)
 					return nil, nil, err
 				}
 				if len(conditions) == 0 {

--- a/parser/rule_parser_test.go
+++ b/parser/rule_parser_test.go
@@ -361,8 +361,10 @@ func TestLoadRules(t *testing.T) {
 					}},
 				},
 			},
-			ShouldErr:    true,
-			ErrorMessage: "unable to find provider for: builtin",
+			// With the fix, missing providers are gracefully skipped, not errors
+			// The rule will be skipped since provider is unavailable
+			ShouldErr:    false,
+			ErrorMessage: "",
 		},
 		{
 			Name:         "rule no conditions",


### PR DESCRIPTION
When analyzing a codebase with a subset of providers (e.g., analyzing TypeScript code with only nodejs and builtin providers), rules that require unavailable providers (e.g., Java provider) would generate hundreds of error log messages like:

  "unable to find provider for: java"

This polluted logs and made it difficult to identify real issues.

This commit introduces a MissingProviderError type that allows the rule parser to distinguish between "provider not available" (which is expected and should be handled gracefully) and actual parsing errors (which should be logged).

Changes:
- Add MissingProviderError custom error type
- Update getConditionForProvider to return MissingProviderError
- Update getConditions and LoadRule to catch MissingProviderError and skip conditions/rules gracefully with debug-level logging
- Update "rule no provider" test to expect success (rule skipped) instead of error

Before: 217 error messages when analyzing tackle2-ui with nodejs
After: 0 error messages - rules are silently skipped at debug level

Fixes: konveyor/analyzer-lsp#956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rules referencing unavailable providers are now detected and skipped with non-fatal logging instead of causing errors, improving resilience so other rules continue processing.
* **Tests**
  * Test suite updated to expect graceful skipping of rules when providers are missing rather than failing, reflecting the new non-fatal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->