### PR TITLE
:sparkles: Increase verbosity for file search result

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -384,7 +384,7 @@ func AnalysisCmd() *cobra.Command {
 	rootCmd.Flags().StringVar(&labelSelector, "label-selector", "", "an expression to select rules based on labels")
 	rootCmd.Flags().StringVar(&depLabelSelector, "dep-label-selector", "", "an expression to select dependencies based on labels. This will filter out the violations from these dependencies as well these dependencies when matching dependency conditions")
 	rootCmd.Flags().StringVar(&incidentSelector, "incident-selector", "", "an expression to select incidents based on custom variables. ex: (!package=io.konveyor.demo.config-utils)")
-	rootCmd.Flags().IntVar(&logLevel, "verbose", 9, "level for logging output")
+	rootCmd.Flags().IntVar(&logLevel, "verbose", 5, "level for logging output")
 	rootCmd.Flags().BoolVar(&enableJaeger, "enable-jaeger", false, "enable tracer exports to jaeger endpoint")
 	rootCmd.Flags().StringVar(&jaegerEndpoint, "jaeger-endpoint", "http://localhost:14268/api/traces", "jaeger endpoint to collect tracing data")
 	rootCmd.Flags().IntVar(&limitIncidents, "limit-incidents", 1500, "Set this to the limit incidents that a given rule can give, zero means no limit")

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -188,7 +188,7 @@ func (f *FileSearcher) Search(s SearchCriteria) ([]string, error) {
 			statFunc, f.ProviderConfigConstraints.ExcludePathsOrPatterns, finalSearchResult, true)
 	}
 
-	f.Log.V(10).Info("returning file search result", "files", finalSearchResult)
+	f.Log.V(7).Info("returning file search result", "files", finalSearchResult)
 	return finalSearchResult, errors.Join(walkErrors...)
 }
 

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -188,7 +188,7 @@ func (f *FileSearcher) Search(s SearchCriteria) ([]string, error) {
 			statFunc, f.ProviderConfigConstraints.ExcludePathsOrPatterns, finalSearchResult, true)
 	}
 
-	f.Log.V(5).Info("returning file search result", "files", finalSearchResult)
+	f.Log.V(10).Info("returning file search result", "files", finalSearchResult)
 	return finalSearchResult, errors.Join(walkErrors...)
 }
 


### PR DESCRIPTION
Increased above the default value for less noise in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity: lowered the default verbosity to be less noisy and raised the level of a specific log statement to reduce routine log output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->