### PR TITLE
:bug: When we are using a RPC client that is already defined handle empty list

### DIFF
--- a/lsp/base_service_client/base_capabilities.go
+++ b/lsp/base_service_client/base_capabilities.go
@@ -65,7 +65,7 @@ func EvaluateReferenced[T base](t T, ctx ctx, cap string, info []byte) (resp, er
 		for _, ref := range references {
 			// Look for things that are in the location loaded,
 			// Note may need to filter out vendor at some point
-			if !strings.Contains(ref.URI, sc.BaseConfig.WorkspaceFolders[0]) {
+			if len(sc.BaseConfig.WorkspaceFolders) > 0 && !strings.Contains(ref.URI, sc.BaseConfig.WorkspaceFolders[0]) {
 				continue
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash that could occur when evaluating references with an empty workspace folder list. The application now safely handles scenarios where no workspace folders are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->