### PR TITLE
:bug: A bug was introduced where we no longer used the opensource labels index

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -278,11 +278,12 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		gradleTaskFile = ""
 	}
 
-	mavenIndexPath, ok := config.ProviderSpecificConfig[MAVEN_INDEX_PATH].(string)
+	mavenSHASearchIndex, ok := config.ProviderSpecificConfig[MAVEN_INDEX_PATH].(string)
 	if !ok {
 		log.Info("unable to find the maven index path in the provider specific config")
 	}
 
+	mavenOpenSourceIndex, ok := config.ProviderSpecificConfig[labels.ProviderSpecificConfigOpenSourceDepListKey].(string)
 	// each service client should have their own context
 	downloadCtx, cancelFunc := context.WithCancel(ctx)
 	// location can be a coordinate to a remote mvn artifact
@@ -309,7 +310,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		Config:          config,
 		MvnSettingsFile: mavenSettingsFile,
 		MvnInsecure:     mavenInsecure,
-		MavenIndexPath:  mavenIndexPath,
+		MavenIndexPath:  mavenSHASearchIndex,
 		Labeler:         openSourceLabeler,
 		GradleTaskFile:  gradleTaskFile,
 	}, log)
@@ -341,7 +342,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 			depsLocationCache: make(map[string]int),
 			includedPaths:     provider.GetIncludedPathsFromConfig(config, false),
 			buildTool:         buildTool,
-			mvnIndexPath:      mavenIndexPath,
+			mvnIndexPath:      mavenOpenSourceIndex,
 			mvnSettingsFile:   mavenSettingsFile,
 		}, provider.InitConfig{}, nil
 	} else if lspServerPath == "" {
@@ -481,7 +482,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		depsLocationCache: make(map[string]int),
 		includedPaths:     provider.GetIncludedPathsFromConfig(config, false),
 		buildTool:         buildTool,
-		mvnIndexPath:      mavenIndexPath,
+		mvnIndexPath:      mavenOpenSourceIndex,
 		mvnSettingsFile:   mavenSettingsFile,
 	}
 


### PR DESCRIPTION
* There are two index's one for the maven sha search and one for the opensource labels.
* The maven SHA search is used by bldtools/decompiler to get the artifact information
* the Opensource labels is used by the java-analzyer-bundle to filter out scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Maven index configuration to separately manage search and open source index paths for better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->