### PR TITLE
:bug: Fix JVM proxy args passing

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -397,8 +397,8 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		"--add-modules=ALL-SYSTEM",
 		"--add-opens", "java.base/java.util=ALL-UNNAMED",
 		"--add-opens", "java.base/java.lang=ALL-UNNAMED",
-		"-jar", jarPath,
 		"-Djava.net.useSystemProxies=true",
+		"-jar", jarPath,
 		"-configuration", "./",
 		"-data", workspace,
 	}


### PR DESCRIPTION
Proxy setting with `-Djava...Proxies=true` was placed in args after `jar` which was most likely ignored by JVM.

Changing its order to ensure its understood correctly by JVM running jdtls.

Replaces https://github.com/konveyor/java-analyzer-bundle/pull/173

Fixes: https://github.com/konveyor/java-analyzer-bundle/issues/172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Java application launcher argument ordering to ensure system proxy settings are correctly applied before the application runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->