### PR TITLE
:ghost: Adding ability to rebuild the java-provider when the jdtls server asks

### DIFF
--- a/.github/workflows/java-provider-image-build.yaml
+++ b/.github/workflows/java-provider-image-build.yaml
@@ -1,0 +1,32 @@
+name: Multiple Architecture Java Provider Image Build
+
+on:
+  repository_dispatch:
+    types: [rebuild-java-provider]
+
+jobs:
+  compute-deps-refs:
+    runs-on: ubuntu-latest
+    outputs:
+      java-bundle-tag: ${{ steps.dep_tag.outputs.java_bundle_tag }}
+    steps:
+      - name: Determine image tags for dependencies
+        id: dep_tag
+        run: |
+          echo "java_bundle_tag=${{ github.event.ref == 'refs/heads/main' && 'latest' || github.event.ref_name }}" >> $GITHUB_OUTPUT
+
+  java-provider-image-build:
+    needs: [compute-deps-refs]
+    uses: konveyor/release-tools/.github/workflows/build-push-images.yaml@main
+    with:
+      registry: "quay.io/konveyor"
+      image_name: java-external-provider
+      containerfile: ".external-providers/java-external-provider/Dockerfile"
+      extra-args: "--build-arg JAVA_BUNDLE_TAG=${{ needs.compute-deps-refs.outputs.java-bundle-tag }}" 
+      architectures: '[ "amd64", "arm64" ]'
+      context: "."
+      ref: ${{ github.event.ref }}
+      tag: ${{ needs.compute-deps-refs.outputs.java-bundle-tag }}
+    secrets:
+      registry_username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+      registry_password: ${{ secrets.QUAY_PUBLISH_TOKEN }}


### PR DESCRIPTION
Currently, you have to manually know to rebuild the analyzer images to pick up the latest changes in the jdtls-server-base. This has caused alot of issues with debugging CI. This will enable the java-analyzer-bundle to ask for the java-provider to be rebuilt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to build and publish multi‑architecture Java external-provider container images (amd64, arm64), with automated tagging for releases, main, and branch refs to streamline image builds and publication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->