### PR TITLE
:bug: The hardcoded  makes it impossible to set the image correctly 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 TAG ?= latest
-IMG_ANALYZER ?= analyzer-lsp:$(TAG)
+IMG_ANALYZER ?= localhost/analyzer-lsp:$(TAG)
 TAG_JAVA_BUNDLE ?= latest
-IMG_JAVA_PROVIDER ?= java-provider:$(TAG)
-IMG_GENERIC_PROVIDER ?= generic-provider:$(TAG)
-IMG_GO_DEP_PROVIDER ?= golang-dep-provider:$(TAG)
-IMG_YQ_PROVIDER ?= yq-provider:$(TAG)
+IMG_JAVA_PROVIDER ?= localhost/java-provider:$(TAG)
+IMG_GENERIC_PROVIDER ?= localhost/generic-provider:$(TAG)
+IMG_GO_DEP_PROVIDER ?= localhost/golang-dep-provider:$(TAG)
+IMG_YQ_PROVIDER ?= localhost/yq-provider:$(TAG)
 IMG_C_SHARP_PROVIDER ?= quay.io/konveyor/c-sharp-provider:$(TAG)
 OS := $(shell uname -s)
 GOOS ?= $(shell go env GOOS)
@@ -59,11 +59,11 @@ build-yq-provider:
 	podman build -f external-providers/yq-external-provider/Dockerfile -t $(IMG_YQ_PROVIDER) .
 
 run-external-providers-local:
-	podman run --name java-provider -d -p 14651:14651 -v $(PWD)/external-providers/java-external-provider/examples:/examples$(MOUNT_OPT) localhost/$(IMG_JAVA_PROVIDER) --port 14651
-	podman run --name yq -d -p 14652:14652 -v $(PWD)/examples:/examples $(MOUNT_OPT) localhost/$(IMG_YQ_PROVIDER) --port 14652
-	podman run --entrypoint /usr/local/bin/entrypoint.sh --name golang-provider -d -p 14653:14653 -v $(PWD)/examples:/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14653
-	podman run --name nodejs -d -p 14654:14654 -v $(PWD)/examples:/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14654 --name nodejs
-	podman run --name python -d -p 14655:14655 -v $(PWD)/examples:/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14655 --name pylsp
+	podman run --name java-provider -d -p 14651:14651 -v $(PWD)/external-providers/java-external-provider/examples:/examples$(MOUNT_OPT) $(IMG_JAVA_PROVIDER) --port 14651
+	podman run --name yq -d -p 14652:14652 -v $(PWD)/examples:/examples $(MOUNT_OPT) $(IMG_YQ_PROVIDER) --port 14652
+	podman run --entrypoint /usr/local/bin/entrypoint.sh --name golang-provider -d -p 14653:14653 -v $(PWD)/examples:/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14653
+	podman run --name nodejs -d -p 14654:14654 -v $(PWD)/examples:/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14654 --name nodejs
+	podman run --name python -d -p 14655:14655 -v $(PWD)/examples:/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14655 --name pylsp
 
 stop-external-providers:
 	podman kill java-provider || true
@@ -86,12 +86,12 @@ run-external-providers-pod:
 	podman run --rm -v test-data:/target$(MOUNT_OPT) -v $(PWD)/external-providers/java-external-provider/examples:/src/$(MOUNT_OPT) --entrypoint=cp alpine -a /src/. /target/
 	# run pods w/ defined ports for the test volumes
 	podman pod create --name=analyzer
-	podman run --pod analyzer --name java-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_JAVA_PROVIDER) --port 14651
-	podman run --pod analyzer --name yq -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_YQ_PROVIDER) --port 14652
+	podman run --pod analyzer --name java-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_JAVA_PROVIDER) --port 14651
+	podman run --pod analyzer --name yq -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_YQ_PROVIDER) --port 14652
 	podman run --pod analyzer --name c-sharp -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_C_SHARP_PROVIDER) --port 14656
-	podman run --entrypoint /usr/local/bin/entrypoint.sh --pod analyzer --name golang-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14653
-	podman run --pod analyzer --name nodejs -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14654 --name nodejs
-	podman run --pod analyzer --name python -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14655 --name pylsp
+	podman run --entrypoint /usr/local/bin/entrypoint.sh --pod analyzer --name golang-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14653
+	podman run --pod analyzer --name nodejs -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14654 --name nodejs
+	podman run --pod analyzer --name python -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14655 --name pylsp
 
 run-demo-image:
 	podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) -v $(PWD)/demo-dep-output.yaml:/analyzer-lsp/demo-dep-output.yaml:Z -v $(PWD)/demo-output.yaml:/analyzer-lsp/output.yaml:Z -v $(PWD)/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z -v $(PWD)/provider_pod_local_settings.json:/analyzer-lsp/provider_settings.json:Z $(IMG_ANALYZER) --output-file=/analyzer-lsp/output.yaml --dep-output-file=/analyzer-lsp/demo-dep-output.yaml --dep-label-selector='!konveyor.io/dep-source=open-source' --rules=/analyzer-lsp/rule-example.yaml --provider-settings=/analyzer-lsp/provider_settings.json
@@ -101,7 +101,7 @@ run-java-provider-pod:
 	podman volume create test-data
 	podman run --rm -v test-data:/target$(MOUNT_OPT) -v $(PWD)/external-providers/java-external-provider/examples:/src/$(MOUNT_OPT) --entrypoint=cp alpine -a /src/. /target/
 	podman pod create --name=analyzer-java
-	podman run --pod analyzer-java --name java-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_JAVA_PROVIDER) --port 14651
+	podman run --pod analyzer-java --name java-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_JAVA_PROVIDER) --port 14651
 
 run-demo-java:
 	podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer-java \
@@ -109,7 +109,7 @@ run-demo-java:
 		-v $(PWD)/external-providers/java-external-provider/e2e-tests/demo-output.yaml:/analyzer-lsp/output.yaml:Z \
 		-v $(PWD)/external-providers/java-external-provider/e2e-tests/provider_settings.json:/analyzer-lsp/provider_settings.json:Z \
 		-v $(PWD)/external-providers/java-external-provider/e2e-tests/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z \
-		localhost/$(IMG_ANALYZER) \
+		$(IMG_ANALYZER) \
 		--output-file=/analyzer-lsp/output.yaml \
 		--rules=/analyzer-lsp/rule-example.yaml \
 		--provider-settings=/analyzer-lsp/provider_settings.json \
@@ -124,17 +124,17 @@ run-generic-golang-provider-pod:
 	podman volume create test-data
 	podman run --rm -v test-data:/target$(MOUNT_OPT) -v $(PWD)/examples:/src/$(MOUNT_OPT) --entrypoint=cp alpine -a /src/. /target/
 	podman pod create --name=analyzer-generic-golang
-	podman run --pod analyzer-generic-golang --name golang -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14651 --name generic
+	podman run --pod analyzer-generic-golang --name golang -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14651 --name generic
 run-generic-python-provider-pod:
 	podman volume create test-data
 	podman run --rm -v test-data:/target$(MOUNT_OPT) -v $(PWD)/examples:/src/$(MOUNT_OPT) --entrypoint=cp alpine -a /src/. /target/
 	podman pod create --name=analyzer-generic-python
-	podman run --pod analyzer-generic-python --name python -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14651 --name pylsp
+	podman run --pod analyzer-generic-python --name python -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14651 --name pylsp
 run-generic-nodejs-provider-pod:
 	podman volume create test-data
 	podman run --rm -v test-data:/target$(MOUNT_OPT) -v $(PWD)/examples:/src/$(MOUNT_OPT) --entrypoint=cp alpine -a /src/. /target/
 	podman pod create --name=analyzer-generic-nodejs
-	podman run --pod analyzer-generic-nodejs --name nodejs -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_GENERIC_PROVIDER) --port 14651 --name nodejs
+	podman run --pod analyzer-generic-nodejs --name nodejs -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14651 --name nodejs
 
 run-demo-generic-golang:
 	podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer-generic-golang \
@@ -142,7 +142,7 @@ run-demo-generic-golang:
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/golang-e2e/demo-output.yaml:/analyzer-lsp/output.yaml:Z \
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/golang-e2e/provider_settings.json:/analyzer-lsp/provider_settings.json:Z \
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/golang-e2e/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z \
-		localhost/$(IMG_ANALYZER) \
+		$(IMG_ANALYZER) \
 		--output-file=/analyzer-lsp/output.yaml \
 		--rules=/analyzer-lsp/rule-example.yaml \
 		--provider-settings=/analyzer-lsp/provider_settings.json
@@ -152,7 +152,7 @@ run-demo-generic-python:
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/python-e2e/demo-output.yaml:/analyzer-lsp/output.yaml:Z \
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/python-e2e/provider_settings.json:/analyzer-lsp/provider_settings.json:Z \
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/python-e2e/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z \
-		localhost/$(IMG_ANALYZER) \
+		$(IMG_ANALYZER) \
 		--output-file=/analyzer-lsp/output.yaml \
 		--rules=/analyzer-lsp/rule-example.yaml \
 		--provider-settings=/analyzer-lsp/provider_settings.json
@@ -162,7 +162,7 @@ run-demo-generic-nodejs:
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/nodejs-e2e/demo-output.yaml:/analyzer-lsp/output.yaml:Z \
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/nodejs-e2e/provider_settings.json:/analyzer-lsp/provider_settings.json:Z \
 		-v $(PWD)/external-providers/generic-external-provider/e2e-tests/nodejs-e2e/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z \
-		localhost/$(IMG_ANALYZER) \
+		$(IMG_ANALYZER) \
 		--output-file=/analyzer-lsp/output.yaml \
 		--rules=/analyzer-lsp/rule-example.yaml \
 		--provider-settings=/analyzer-lsp/provider_settings.json
@@ -186,7 +186,7 @@ run-yaml-provider-pod:
 	podman volume create test-data
 	podman run --rm -v test-data:/target$(MOUNT_OPT) -v $(PWD)/examples:/src/$(MOUNT_OPT) --entrypoint=cp alpine -a /src/. /target/
 	podman pod create --name=analyzer-yaml
-	podman run --pod analyzer-yaml --name yq -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) localhost/$(IMG_YQ_PROVIDER) --port 14651
+	podman run --pod analyzer-yaml --name yq -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_YQ_PROVIDER) --port 14651
 
 run-demo-yaml:
 	podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer-yaml \
@@ -194,7 +194,7 @@ run-demo-yaml:
 		-v $(PWD)/external-providers/yq-external-provider/e2e-tests/demo-output.yaml:/analyzer-lsp/output.yaml:Z \
 		-v $(PWD)/external-providers/yq-external-provider/e2e-tests/provider_settings.json:/analyzer-lsp/provider_settings.json:Z \
 		-v $(PWD)/external-providers/yq-external-provider/e2e-tests/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z \
-		localhost/$(IMG_ANALYZER) \
+		$(IMG_ANALYZER) \
 		--output-file=/analyzer-lsp/output.yaml \
 		--rules=/analyzer-lsp/rule-example.yaml \
 		--provider-settings=/analyzer-lsp/provider_settings.json


### PR DESCRIPTION
One should be able to use a full pull spec such as `quay.io/konvelyor/<image>:<tag>` as an IMG env var and it should be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references to use localhost-prefixed naming conventions for local development and testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->