### PR TITLE
:bug: Fix nodejs provider counting files twice when Location and workspaceFolders overlap

### DIFF
--- a/external-providers/generic-external-provider/pkg/server_configurations/nodejs/symbol_cache_helper.go
+++ b/external-providers/generic-external-provider/pkg/server_configurations/nodejs/symbol_cache_helper.go
@@ -41,6 +41,10 @@ func (h *nodejsSymbolSearchHelper) GetDocumentUris(conditionsByCap ...provider.C
 				primaryPath = path
 				continue
 			}
+			// Skip workspace folders that duplicate primaryPath to avoid counting files twice
+			if path == primaryPath {
+				continue
+			}
 			additionalPaths = append(additionalPaths, path)
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes the nodejs provider's `GetDocumentUris()` method counting files twice during provider preparation when both `InitConfig.Location` and `ProviderSpecificConfig["workspaceFolders"]` are set to the same directory.

## Changes
- Added deduplication check in `symbol_cache_helper.go` to skip workspace folders that duplicate the primaryPath
- Ensures each directory is only scanned once by FileSearcher

## Impact
- Provider preparation now shows accurate file counts (e.g., 802 files instead of 1604)
- Eliminates duplicate file processing during symbol cache operations
- Improves performance during the preparation phase
- Fixes confusing progress reporting for users

## Testing
- Code compiles successfully
- Logic verified against existing deduplication in service_client.go (lines 75-80)
- Handles edge cases: empty primaryPath, multiple workspace folders

Fixes #1035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate file entries appearing in search results when working with multiple workspace folders, eliminating redundant search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->