### PR TITLE
:bug: Making analyzer-lsp image use non root user

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -199,14 +199,14 @@ jobs:
         if: needs.detect-changes.outputs[matrix.provider] == 'true'
         run: |
           podman volume create test-data
-          podman run --rm -v test-data:/target:Z -v $(pwd)/${{ matrix.test-data }}:/src/:Z --entrypoint=cp alpine -a /src/. /target/
+          podman run --rm -v test-data:/target:U,Z -v $(pwd)/${{ matrix.test-data }}:/src/:U,Z --entrypoint=cp alpine -a /src/. /target/
           podman pod create --name=analyzer-${{ matrix.provider }}
-          podman run --pod analyzer-${{ matrix.provider }} --name ${{ matrix.provider }}-provider -d -v test-data:/analyzer-lsp/examples:Z localhost/${{ matrix.image_name }}:${{ needs.detect-changes.outputs.image_tag }} --port 14651
+          podman run --pod analyzer-${{ matrix.provider }} --name ${{ matrix.provider }}-provider -d -v test-data:/analyzer-lsp/examples:U,Z localhost/${{ matrix.image_name }}:${{ needs.detect-changes.outputs.image_tag }} --port 14651
           podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer-${{ matrix.provider }} \
-            -v test-data:/analyzer-lsp/examples:Z \
-            -v $(pwd)/${{ matrix.demo-output-path }}:/analyzer-lsp/output.yaml:Z \
-            -v $(pwd)/${{ matrix.provider_settings-path }}:/analyzer-lsp/provider_settings.json:Z \
-            -v $(pwd)/${{ matrix.testing-rules }}:/analyzer-lsp/rules:Z \
+            -v test-data:/analyzer-lsp/examples:U,Z \
+            -v $(pwd)/${{ matrix.demo-output-path }}:/analyzer-lsp/output.yaml:U,Z \
+            -v $(pwd)/${{ matrix.provider_settings-path }}:/analyzer-lsp/provider_settings.json:U,Z \
+            -v $(pwd)/${{ matrix.testing-rules }}:/analyzer-lsp/rules:U,Z \
             localhost/konveyor-analyzer-lsp:${{ needs.detect-changes.outputs.image_tag }} \
             --output-file=/analyzer-lsp/output.yaml \
             --rules=/analyzer-lsp/rules \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,6 @@ RUN chgrp -R 0 /analyzer-lsp && chmod -R g=u /analyzer-lsp
 
 EXPOSE 16686
 
+USER 1001
+
 ENTRYPOINT ["sh", "-c", "all-in-one-linux &> /dev/null & sleep 5 && konveyor-analyzer"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OS := $(shell uname -s)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
-MOUNT_OPT := :z
+MOUNT_OPT := :U,z
 
 build-dir:
 	mkdir -p build
@@ -94,7 +94,7 @@ run-external-providers-pod:
 	podman run --pod analyzer --name python -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14655 --name pylsp
 
 run-demo-image:
-	podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) -v $(PWD)/demo-dep-output.yaml:/analyzer-lsp/demo-dep-output.yaml:Z -v $(PWD)/demo-output.yaml:/analyzer-lsp/output.yaml:Z -v $(PWD)/rule-example.yaml:/analyzer-lsp/rule-example.yaml:Z -v $(PWD)/provider_pod_local_settings.json:/analyzer-lsp/provider_settings.json:Z $(IMG_ANALYZER) --output-file=/analyzer-lsp/output.yaml --dep-output-file=/analyzer-lsp/demo-dep-output.yaml --dep-label-selector='!konveyor.io/dep-source=open-source' --rules=/analyzer-lsp/rule-example.yaml --provider-settings=/analyzer-lsp/provider_settings.json
+	podman run --entrypoint /usr/local/bin/konveyor-analyzer --pod=analyzer -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) -v $(PWD)/demo-dep-output.yaml:/analyzer-lsp/demo-dep-output.yaml${MOUNT_OPT} -v $(PWD)/demo-output.yaml:/analyzer-lsp/output.yaml${MOUNT_OPT} -v $(PWD)/rule-example.yaml:/analyzer-lsp/rule-example.yaml${MOUNT_OPT} -v $(PWD)/provider_pod_local_settings.json:/analyzer-lsp/provider_settings.json${MOUNT_OPT} $(IMG_ANALYZER) --output-file=/analyzer-lsp/output.yaml --dep-output-file=/analyzer-lsp/demo-dep-output.yaml --dep-label-selector='!konveyor.io/dep-source=open-source' --rules=/analyzer-lsp/rule-example.yaml --provider-settings=/analyzer-lsp/provider_settings.json
 
 # Provider-specific test targets
 run-java-provider-pod:

--- a/provider_pod_local_settings.json
+++ b/provider_pod_local_settings.json
@@ -137,8 +137,8 @@
                 "analysisMode": "source-only",
                 "location": "/analyzer-lsp/examples/c-sharp-dummy-example",
                 "providerSpecificConfig": {
-                    "ilspy_cmd": "/root/.dotnet/tools/ilspycmd",
-                    "paket_cmd": "/root/.dotnet/tools/paket"
+                    "ilspy_cmd": "/usr/local/bin/ilspycmd",
+                    "paket_cmd": "/usr/local/bin/paket"
                 }
             }
         ]


### PR DESCRIPTION
* Updating testing to use the non-root user for the test-data mount
* Updating provider_pod_local_settings for working with https://github.com/konveyor/c-sharp-analyzer-provider/pull/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container startup to launch a supporting service before the analyzer starts, ensuring initialization order
  * Changed container runtime user for improved security and resource handling
  * Adjusted container mount options for more reliable host-to-container file access
  * Updated C# provider tool paths to use standardized system locations
  * Port 16686 remains accessible for monitoring and troubleshooting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->