### PR TITLE
:sparkles: Support optional ruleset metadata via Extras field

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -59,6 +59,29 @@ For every rule that is matched, the analyzer engine creates a _Violation_ in the
 
 * **effort**: Integer indicating story points for each incident as determined by the rule author. (See [Rule Metadata](./rules.md#rule-metadata))
 
+* **extras**: A JSON field containing any optional/custom metadata from the rule that is not part of the core schema. This field enables rules to include additional context without requiring changes to analyzer-lsp. The value is a JSON object that can be unmarshaled to access custom fields. (See [Optional Metadata Fields](./rules.md#optional-metadata-fields))
+
+#### Example with Extras
+
+```yaml
+violations:
+  example-rule-001:
+    description: "Example violation"
+    category: mandatory
+    effort: 3
+    labels:
+    - "example"
+    extras:
+      custom_field: "value"
+      additional_metadata:
+        key1: "value1"
+        key2: "value2"
+    incidents:
+    - uri: "file:///path/to/file.java"
+      lineNumber: 42
+      message: "Example issue found"
+```
+
 ### User Interface for Analysis Output
 
 There is a standalone user interface available to visualize the YAML output in a static UI that runs in the browser. Check it out [here](https://github.com/konveyor/static-report). The [README](https://github.com/konveyor/static-report#readme) explains how it works with the YAML output.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -39,6 +39,28 @@ category: mandatory (4)
 3. **effort**: Effort is an integer value that indicates the level of effort needed to fix this issue.
 4. **category**: Category describes severity of the issue for migration. Values can be one of _mandatory_, _potential_ or _optional_. (See [Categories](#rule-categories))
 
+#### Optional Metadata Fields
+
+Rules can include additional custom metadata fields beyond the core schema. Any fields not explicitly defined above will be automatically passed through to the violation analysis report via the `extras` field. This provides a flexible mechanism for extending rule metadata without requiring code changes to analyzer-lsp.
+
+For example:
+
+```yaml
+ruleID: "example-rule"
+labels: ["label1"]
+effort: 3
+category: mandatory
+# Custom optional fields
+custom_field: "value"
+additional_metadata:
+  key1: "value1"
+  key2: "value2"
+when:
+  <condition>
+```
+
+All custom fields will be collected and included in the violation output's `extras` field as JSON. See [Violation Extras](./output.md#extras) for details on how to access these fields in the analysis output.
+
 #### Rule Categories
 
 * mandatory

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -59,7 +59,7 @@ when:
   <condition>
 ```
 
-All custom fields will be collected and included in the violation output's `extras` field as JSON. See [Violation Extras](./output.md#extras) for details on how to access these fields in the analysis output.
+All custom fields will be collected and included in the violation output's `extras` field as JSON. See [Violation Extras](./output.md#example-with-extras) for details on how to access these fields in the analysis output.
 
 #### Rule Categories
 

--- a/engine/conditions.go
+++ b/engine/conditions.go
@@ -113,6 +113,7 @@ type RuleMeta struct {
 	Labels      []string           `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Effort      *int               `json:"effort,omitempty"`
 	UsesHasTags bool
+	Extras      map[string]interface{} `yaml:"extras,omitempty" json:"extras,omitempty"`
 }
 
 func (r *RuleMeta) GetLabels() []string {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net/url"
@@ -732,12 +733,19 @@ func (r *ruleEngine) createViolation(ctx context.Context, conditionResponse Cond
 
 	rule.Labels = deduplicateLabels(rule.Labels)
 
+	extrasJSON := []byte{}
+	if len(rule.Extras) > 0 {
+		if data, err := json.Marshal(rule.Extras); err == nil {
+			extrasJSON = data
+		}
+	}
+
 	return konveyor.Violation{
 		Description: rule.Description,
 		Labels:      rule.Labels,
 		Category:    rule.Category,
 		Incidents:   incidents,
-		Extras:      []byte{},
+		Extras:      extrasJSON,
 		Effort:      rule.Effort,
 		Links:       rule.Perform.Message.Links,
 	}, nil

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -737,6 +737,8 @@ func (r *ruleEngine) createViolation(ctx context.Context, conditionResponse Cond
 	if len(rule.Extras) > 0 {
 		if data, err := json.Marshal(rule.Extras); err == nil {
 			extrasJSON = data
+		} else {
+			r.logger.Error(err, "failed to marshal rule extras to JSON", "ruleID", rule.RuleID)
 		}
 	}
 

--- a/parser/extras_test.go
+++ b/parser/extras_test.go
@@ -1,0 +1,129 @@
+package parser_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/bombsimon/logrusr/v3"
+	"github.com/konveyor/analyzer-lsp/output/v1/konveyor"
+	ruleparser "github.com/konveyor/analyzer-lsp/parser"
+	"github.com/konveyor/analyzer-lsp/provider"
+	"github.com/sirupsen/logrus"
+)
+
+func TestRuleExtrasPassthrough(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.Level(5))
+	logger := logrusr.New(log)
+
+	parser := ruleparser.RuleParser{
+		ProviderNameToClient: map[string]provider.InternalProviderClient{
+			"builtin": testProvider{
+				caps: []provider.Capability{{
+					Name: "file",
+				}},
+			},
+		},
+		Log: logger,
+	}
+
+	// Load the test rule with extras
+	testFile := filepath.Join("testdata", "rule-with-extras.yaml")
+	rules, _, _, err := parser.LoadRule(testFile)
+	if err != nil {
+		t.Fatalf("Failed to load rule: %v", err)
+	}
+
+	if len(rules) != 1 {
+		t.Fatalf("Expected 1 rule, got %d", len(rules))
+	}
+
+	rule := rules[0]
+
+	// Verify basic fields are still loaded correctly
+	if rule.RuleID != "javax-to-jakarta-00001" {
+		t.Errorf("Expected ruleID 'javax-to-jakarta-00001', got '%s'", rule.RuleID)
+	}
+
+	if rule.Effort == nil || *rule.Effort != 1 {
+		t.Errorf("Expected effort 1, got %v", rule.Effort)
+	}
+
+	// Verify extras field is populated
+	if rule.Extras == nil {
+		t.Fatal("Expected Extras to be populated, got nil")
+	}
+
+	// Check migration_complexity
+	if complexity, ok := rule.Extras["migration_complexity"].(string); ok {
+		if complexity != "trivial" {
+			t.Errorf("Expected migration_complexity 'trivial', got '%s'", complexity)
+		}
+	} else {
+		t.Error("Expected migration_complexity in Extras")
+	}
+
+	// Check domain
+	if domain, ok := rule.Extras["domain"].(string); ok {
+		if domain != "jakarta-migration" {
+			t.Errorf("Expected domain 'jakarta-migration', got '%s'", domain)
+		}
+	} else {
+		t.Error("Expected domain in Extras")
+	}
+
+	// Check metadata
+	if metadata, ok := rule.Extras["metadata"].(map[interface{}]interface{}); ok {
+		if severity, ok := metadata["severity"].(string); ok {
+			if severity != "high" {
+				t.Errorf("Expected metadata.severity 'high', got '%s'", severity)
+			}
+		} else {
+			t.Error("Expected metadata.severity in Extras")
+		}
+	} else {
+		t.Error("Expected metadata in Extras")
+	}
+
+	t.Log("Extras field contents:", rule.Extras)
+}
+
+func TestViolationExtrasJSON(t *testing.T) {
+	// Test that extras are properly marshaled to JSON in a violation
+	extras := map[string]interface{}{
+		"migration_complexity": "trivial",
+		"domain":               "jakarta-migration",
+		"metadata": map[string]interface{}{
+			"severity":      "high",
+			"confidence":    "high",
+			"migrationPath": "automated",
+		},
+	}
+
+	extrasJSON, err := json.Marshal(extras)
+	if err != nil {
+		t.Fatalf("Failed to marshal extras: %v", err)
+	}
+
+	violation := konveyor.Violation{
+		Description: "Test violation",
+		Extras:      extrasJSON,
+	}
+
+	// Verify we can unmarshal the extras from the violation
+	var unmarshaled map[string]interface{}
+	if err := json.Unmarshal(violation.Extras, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal violation extras: %v", err)
+	}
+
+	if complexity, ok := unmarshaled["migration_complexity"].(string); ok {
+		if complexity != "trivial" {
+			t.Errorf("Expected migration_complexity 'trivial', got '%s'", complexity)
+		}
+	} else {
+		t.Error("Expected migration_complexity in unmarshaled extras")
+	}
+
+	t.Log("Successfully marshaled and unmarshaled extras in violation")
+}

--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -582,6 +582,31 @@ func (r *RuleParser) addRuleFields(rule *engine.Rule, ruleMap map[string]interfa
 		}
 		rule.CustomVariables = s
 	}
+
+	// Collect any extra fields not in the core schema
+	knownFields := map[string]bool{
+		"ruleID":          true,
+		"when":            true,
+		"message":         true,
+		"tag":             true,
+		"description":     true,
+		"category":        true,
+		"labels":          true,
+		"effort":          true,
+		"links":           true,
+		"customVariables": true,
+	}
+
+	extras := make(map[string]interface{})
+	for key, value := range ruleMap {
+		if !knownFields[key] {
+			extras[key] = value
+		}
+	}
+
+	if len(extras) > 0 {
+		rule.Extras = extras
+	}
 }
 
 func (r *RuleParser) addCustomVarFields(m map[interface{}]interface{}, customVar *engine.CustomVariable) error {

--- a/parser/testdata/rule-with-extras.yaml
+++ b/parser/testdata/rule-with-extras.yaml
@@ -1,0 +1,19 @@
+---
+- message: Replace javax imports with jakarta
+  ruleID: javax-to-jakarta-00001
+  links:
+  - title: "Jakarta EE Migration"
+    url: "https://jakarta.ee"
+  labels:
+  - "jakarta"
+  - "migration"
+  category: mandatory
+  effort: 1
+  migration_complexity: trivial
+  domain: "jakarta-migration"
+  metadata:
+    severity: "high"
+    confidence: "high"
+    migrationPath: "automated"
+  when:
+    builtin.file: "*.java"


### PR DESCRIPTION
## Description

This PR enables analyzer-lsp to pass through optional/unknown ruleset attributes (such as `migration_complexity`, `domain`, and custom metadata) to violation analysis reports via the existing `Extras` field.

This addresses the need to support evolving ruleset schemas as described in:
- https://github.com/konveyor/enhancements/pull/255 (migration_complexity)
- https://github.com/konveyor/enhancements/issues/254 (domain, metadata, etc.)

## Changes

### Core Implementation
- **engine/conditions.go**: Added `Extras map[string]interface{}` field to `RuleMeta`
- **parser/rule_parser.go**: Enhanced `addRuleFields()` to collect any fields not in the core schema into `Extras`
- **engine/engine.go**: Updated violation construction to marshal extras into `Violation.Extras` JSON field

### Tests
- **parser/extras_test.go**: Added comprehensive tests
  - `TestRuleExtrasPassthrough`: Verifies optional fields are correctly parsed
  - `TestViolationExtrasJSON`: Verifies JSON marshaling/unmarshaling
- **parser/testdata/rule-with-extras.yaml**: Sample test rule with custom metadata

### Documentation
- **docs/rules.md**: Added "Optional Metadata Fields" section
- **docs/output.md**: Documented the `extras` field in violations with examples

## Benefits

- ✅ Flexible: Any new optional fields automatically flow through without code changes
- ✅ Simple: Minimal changes, uses existing infrastructure
- ✅ Backward compatible: Extras remain empty for rules without optional fields
- ✅ Future-proof: Supports the evolving ruleset schema without constant updates
- ✅ Well-tested: All existing tests pass + new tests added

## Testing

All existing tests pass:
```
GOWORK=off go test ./parser -v
```

New tests verify:
1. Optional fields like `migration_complexity`, `domain`, and `metadata` are parsed into `rule.Extras`
2. Extras are properly marshaled to JSON in violations
3. Violations can unmarshal extras for consumption

Fixes #1048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for optional custom "extras" metadata on rules; included in violation output as structured JSON for richer context.

* **Documentation**
  * Added docs and examples demonstrating optional metadata fields and how they appear in violation reports.

* **Tests**
  * Added tests and test data to verify parsing, passthrough, and JSON handling of extras metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->