### PR TITLE
:bug: Get full match in perl command

### DIFF
--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -916,7 +916,7 @@ func (b *builtinServiceClient) performGrepSearch(pattern, trimmedPattern string,
 					fileList.WriteByte('\x00')
 				}
 				cmdStr := fmt.Sprintf(
-					`xargs -0 perl -ne 'if (/%v/) { print "$ARGV:$.:$1\n" } close ARGV if eof;'`,
+					`xargs -0 perl -ne 'if (/%v/) { print "$ARGV:$.:$&\n" } close ARGV if eof;'`,
 					escapedPattern,
 				)
 				b.log.V(7).Info("running perl", "cmd", cmdStr)


### PR DESCRIPTION
Fixes #1069 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search result parsing on macOS where only partial match content was being returned. Search now correctly captures and displays complete matched text for results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->