### PR TITLE
:bug: Sorting artifact's returned during decompile to make consistent

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/dependency/decompile.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/dependency/decompile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -254,6 +255,16 @@ func (d *decompiler) Decompile(ctx context.Context, artifactPath string) ([]Java
 	if len(errs) != 0 {
 		return artifacts, errs[0]
 	}
+	slices.SortFunc(artifacts, func(a, b JavaArtifact) int {
+		if n := strings.Compare(a.GroupId, b.GroupId); n != 0 {
+			return n
+		}
+		if n := strings.Compare(a.ArtifactId, b.ArtifactId); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Version, b.Version)
+
+	})
 	return artifacts, nil
 }
 
@@ -310,6 +321,16 @@ func (d *decompiler) DecompileIntoProject(ctx context.Context, artifactPath, pro
 		return artifacts, errs[0]
 	}
 
+	slices.SortFunc(artifacts, func(a, b JavaArtifact) int {
+		if n := strings.Compare(a.GroupId, b.GroupId); n != 0 {
+			return n
+		}
+		if n := strings.Compare(a.ArtifactId, b.ArtifactId); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Version, b.Version)
+
+	})
 	return artifacts, nil
 }
 


### PR DESCRIPTION
When decompiling, we can get different pom files which can break koncur validation for incident locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured deterministic ordering of artifacts in decompilation results for consistent and reproducible outcomes across multiple operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->