### PR TITLE
:bug: Only load .yaml rules (#1099)

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -328,6 +328,7 @@ jobs:
       - name: Build addon and push images
         working-directory: tackle2-addon-analyzer
         run: |
+          sed -i "s,FROM quay.io/konveyor/analyzer-lsp\:latest,FROM localhost/konveyor-analyzer-lsp:${{ needs.detect-changes.outputs.image_tag }}," Dockerfile
           IMG=ttl.sh/konveyor-tackle2-addon-analyzer-${GITHUB_SHA}:2h make image-podman
           podman push ttl.sh/konveyor-tackle2-addon-analyzer-${GITHUB_SHA}:2h
       

--- a/parser/rule_parser.go
+++ b/parser/rule_parser.go
@@ -169,6 +169,12 @@ func (r *RuleParser) LoadRules(filepath string) ([]engine.RuleSet, map[string]pr
 				ruleSet = r.loadRuleSet(filepath)
 				continue
 			}
+			// skip non-yaml files
+			if !strings.HasSuffix(f.Name(), ".yaml") &&
+				!strings.HasSuffix(f.Name(), ".yml") {
+				r.Log.V(7).Info("excluding non-yaml file from parsing", "file", f.Name())
+				continue
+			}
 			// skip rule tests
 			if strings.HasSuffix(f.Name(), ".test.yaml") ||
 				strings.HasSuffix(f.Name(), ".test.yml") {

--- a/parser/rule_parser_test.go
+++ b/parser/rule_parser_test.go
@@ -815,6 +815,39 @@ func TestLoadRules(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "skip valid rule in non-yaml file",
+			testFileName: "folder-with-non-yaml",
+			providerNameClient: map[string]provider.InternalProviderClient{
+				"builtin": testProvider{
+					caps: []provider.Capability{{
+						Name: "file",
+					}},
+				},
+			},
+			ExpectedProvider: map[string]provider.InternalProviderClient{
+				"builtin": testProvider{
+					caps: []provider.Capability{{
+						Name: "file",
+					}},
+				},
+			},
+			ExpectedRuleSet: map[string]engine.RuleSet{
+				"non-yaml-test-ruleset": {
+					Rules: []engine.Rule{
+						{
+							RuleMeta: engine.RuleMeta{
+								RuleID:      "file-001",
+								Description: "",
+								Category:    &konveyor.Potential,
+							},
+							Perform: engine.Perform{Message: engine.Message{Text: &allGoFiles, Links: []konveyor.Link{}}},
+							When:    engine.ConditionEntry{},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/parser/testdata/folder-with-non-yaml/rule-simple.yaml
+++ b/parser/testdata/folder-with-non-yaml/rule-simple.yaml
@@ -1,0 +1,5 @@
+---
+- message: all go files
+  ruleID: file-001
+  when:
+    builtin.file: "*.go"

--- a/parser/testdata/folder-with-non-yaml/ruleset.yaml
+++ b/parser/testdata/folder-with-non-yaml/ruleset.yaml
@@ -1,0 +1,2 @@
+name: "non-yaml-test-ruleset"
+description: "testing that non-yaml files are skipped"

--- a/parser/testdata/folder-with-non-yaml/valid-rule.md
+++ b/parser/testdata/folder-with-non-yaml/valid-rule.md
@@ -1,0 +1,5 @@
+---
+- message: this rule is in a markdown file and should be skipped
+  ruleID: md-rule-001
+  when:
+    builtin.file: "*.md"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Bug Fixes**
* Rule parser now includes guards to filter and exclude non-YAML files from the rule loading pipeline, ensuring only files with .yaml and .yml extensions are processed.

* **Tests**
* Added test case to verify non-YAML files are correctly excluded during rule parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------