### PR TITLE
:bug: Update the testing so that addon-analyzer is built correctly

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -328,6 +328,7 @@ jobs:
       - name: Build addon and push images
         working-directory: tackle2-addon-analyzer
         run: |
+          sed -i "s,FROM quay.io/konveyor/analyzer-lsp\:latest,FROM localhost/konveyor-analyzer-lsp:${{ needs.detect-changes.outputs.image_tag }}," Dockerfile
           IMG=ttl.sh/konveyor-tackle2-addon-analyzer-${GITHUB_SHA}:2h make image-podman
           podman push ttl.sh/konveyor-tackle2-addon-analyzer-${GITHUB_SHA}:2h
       


### PR DESCRIPTION
Currently, the addon image is built from the latest on all workflows; it should be built from the image under test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration for image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->