### PR TITLE
:ghost: show-failing

### DIFF
--- a/provider/internal/builtin/service_client_test.go
+++ b/provider/internal/builtin/service_client_test.go
@@ -192,6 +192,20 @@ func Test_builtinServiceClient_Evaluate_InclusionExclusion(t *testing.T) {
 			},
 		},
 		{
+			name:       "(XML) Include using the config (legacy inclusion), no exclude",
+			capability: "xml",
+			includedPathsFromConfig: []string{
+				"dir_b",
+			},
+			condition: builtinCondition{
+				XML: xmlCondition{
+					XPath: "//*/b:simple[text()=matches(self::node(), '*property*')]",
+				},
+			},
+			chainTemplate: engine.ChainTemplate{},
+			wantFilePaths: []string{},
+		},
+		{
 			name:       "(JSON) Include using the config (legacy inclusion), no exclude",
 			capability: "json",
 			includedPathsFromConfig: []string{


### PR DESCRIPTION
This is meant as a demonstration that this query was failing on release 0.8 as well. 