### PR TITLE
:sparkles:Add Prepare() caching to builtin provider for filesystem walk optimization

### DIFF
--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -43,6 +43,11 @@ type builtinServiceClient struct {
 	encoding      string
 
 	workingCopyMgr *workingCopyManager
+
+	// fileIndex is the cached list of all file paths under the base path
+	fileIndex []string
+	// prepared indicates Prepare() completed successfully and fileIndex is valid
+	prepared bool
 }
 
 type fileTemplateContext struct {
@@ -52,7 +57,75 @@ type fileTemplateContext struct {
 var _ provider.ServiceClient = &builtinServiceClient{}
 
 func (b *builtinServiceClient) Prepare(ctx context.Context, conditionsByCap []provider.ConditionsByCap) error {
+	ctx, span := tracing.StartNewSpan(ctx, "builtin.Prepare")
+	defer span.End()
+
+	// Parse all conditions to collect the union of include/exclude scopes
+	var allIncluded, allExcluded []string
+	for _, cbc := range conditionsByCap {
+		for _, condBytes := range cbc.Conditions {
+			var cond builtinCondition
+			if err := yaml.Unmarshal(condBytes, &cond); err != nil {
+				b.log.V(5).Error(err, "failed to unmarshal condition in Prepare, skipping")
+				continue
+			}
+			inc, exc := cond.ProviderContext.GetScopedFilepaths()
+			allIncluded = append(allIncluded, inc...)
+			allExcluded = append(allExcluded, exc...)
+		}
+	}
+
+	// Build a single FileSearcher with the union of all scopes
+	searcher := provider.FileSearcher{
+		BasePath: b.config.Location,
+		ProviderConfigConstraints: provider.IncludeExcludeConstraints{
+			IncludePathsOrPatterns: b.includedPaths,
+			ExcludePathsOrPatterns: b.excludedDirs,
+		},
+		RuleScopeConstraints: provider.IncludeExcludeConstraints{
+			IncludePathsOrPatterns: allIncluded,
+			ExcludePathsOrPatterns: allExcluded,
+		},
+		FailFast: true,
+		Log:      b.log,
+	}
+
+	// Single filesystem walk
+	files, err := searcher.Search(provider.SearchCriteria{})
+	if err != nil {
+		b.log.Error(err, "failed to build file index in Prepare, falling back to per-Evaluate walks")
+		return nil
+	}
+
+	b.fileIndex = files
+	b.prepared = true
+	b.log.V(5).Info("file index built during Prepare", "fileCount", len(files))
 	return nil
+}
+
+// filterCachedFiles applies per-rule scope constraints and search criteria
+// against the cached file index, returning matching files.
+func (b *builtinServiceClient) filterCachedFiles(cond builtinCondition, criteria provider.SearchCriteria) ([]string, error) {
+	wcIncludedPaths, wcExcludedPaths := b.getWorkingCopies()
+	includedPaths, excludedPaths := cond.ProviderContext.GetScopedFilepaths()
+	excludedPaths = append(excludedPaths, wcExcludedPaths...)
+
+	searcher := provider.FileSearcher{
+		BasePath:        b.config.Location,
+		AdditionalPaths: wcIncludedPaths,
+		ProviderConfigConstraints: provider.IncludeExcludeConstraints{
+			IncludePathsOrPatterns: b.includedPaths,
+			ExcludePathsOrPatterns: b.excludedDirs,
+		},
+		RuleScopeConstraints: provider.IncludeExcludeConstraints{
+			IncludePathsOrPatterns: includedPaths,
+			ExcludePathsOrPatterns: excludedPaths,
+		},
+		FailFast: true,
+		Log:      b.log,
+	}
+
+	return searcher.SearchFromIndex(b.fileIndex, criteria)
 }
 
 func (b *builtinServiceClient) openFileWithEncoding(filePath string) (io.Reader, error) {
@@ -103,26 +176,31 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 	log.V(5).Info("builtin condition context", "condition", cond, "provider context", cond.ProviderContext)
 	response := provider.ProviderEvaluateResponse{Matched: false}
 
-	// in addition to base location, we have to look at working copies too
-	wcIncludedPaths, wcExcludedPaths := p.getWorkingCopies()
-	// get paths from providerContext
-	includedPaths, excludedPaths := cond.ProviderContext.GetScopedFilepaths()
-	excludedPaths = append(excludedPaths, wcExcludedPaths...)
-
-	fileSearcher := provider.FileSearcher{
-		BasePath:        p.config.Location,
-		AdditionalPaths: wcIncludedPaths,
-		// get global include / exclude paths from provider config
-		ProviderConfigConstraints: provider.IncludeExcludeConstraints{
-			IncludePathsOrPatterns: p.includedPaths,
-			ExcludePathsOrPatterns: p.excludedDirs,
-		},
-		RuleScopeConstraints: provider.IncludeExcludeConstraints{
-			IncludePathsOrPatterns: includedPaths,
-			ExcludePathsOrPatterns: excludedPaths,
-		},
-		FailFast: true,
-		Log:      p.log,
+	// searchFiles resolves file lists either from the cached index (if Prepare()
+	// was called) or by creating a fresh FileSearcher and walking the filesystem.
+	searchFiles := func(criteria provider.SearchCriteria) ([]string, error) {
+		if p.prepared {
+			return p.filterCachedFiles(cond, criteria)
+		}
+		// Fallback: create FileSearcher per call (original behavior)
+		wcIncludedPaths, wcExcludedPaths := p.getWorkingCopies()
+		includedPaths, excludedPaths := cond.ProviderContext.GetScopedFilepaths()
+		excludedPaths = append(excludedPaths, wcExcludedPaths...)
+		fileSearcher := provider.FileSearcher{
+			BasePath:        p.config.Location,
+			AdditionalPaths: wcIncludedPaths,
+			ProviderConfigConstraints: provider.IncludeExcludeConstraints{
+				IncludePathsOrPatterns: p.includedPaths,
+				ExcludePathsOrPatterns: p.excludedDirs,
+			},
+			RuleScopeConstraints: provider.IncludeExcludeConstraints{
+				IncludePathsOrPatterns: includedPaths,
+				ExcludePathsOrPatterns: excludedPaths,
+			},
+			FailFast: true,
+			Log:      p.log,
+		}
+		return fileSearcher.Search(criteria)
 	}
 
 	switch cap {
@@ -131,7 +209,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 		if c.Pattern == "" {
 			return response, fmt.Errorf("could not parse provided file pattern as string: %v", conditionInfo)
 		}
-		matchingFiles, err := fileSearcher.Search(provider.SearchCriteria{
+		matchingFiles, err := searchFiles(provider.SearchCriteria{
 			Patterns: []string{c.Pattern},
 		})
 		if err != nil {
@@ -164,7 +242,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 		if c.FilePattern != "" {
 			patterns = append(patterns, c.FilePattern)
 		}
-		filePaths, err := fileSearcher.Search(provider.SearchCriteria{
+		filePaths, err := searchFiles(provider.SearchCriteria{
 			Patterns:           patterns,
 			ConditionFilepaths: c.Filepaths,
 		})
@@ -202,7 +280,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 		if query == nil || err != nil {
 			return response, fmt.Errorf("could not parse provided xpath query '%s': %v", cond.XML.XPath, err)
 		}
-		xmlFiles, err := fileSearcher.Search(provider.SearchCriteria{
+		xmlFiles, err := searchFiles(provider.SearchCriteria{
 			Patterns:           []string{"*.xml", "*.xhtml"},
 			ConditionFilepaths: cond.XML.Filepaths,
 		})
@@ -258,7 +336,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 		if query == nil || err != nil {
 			return response, fmt.Errorf("could not parse public-id xml query '%s': %v", cond.XML.XPath, err)
 		}
-		xmlFiles, err := fileSearcher.Search(provider.SearchCriteria{
+		xmlFiles, err := searchFiles(provider.SearchCriteria{
 			Patterns:           []string{"*.xml", "*.xhtml"},
 			ConditionFilepaths: cond.XMLPublicID.Filepaths,
 		})
@@ -303,7 +381,7 @@ func (p *builtinServiceClient) Evaluate(ctx context.Context, cap string, conditi
 		if query == "" {
 			return response, fmt.Errorf("could not parse provided xpath query as string: %v", conditionInfo)
 		}
-		jsonFiles, err := fileSearcher.Search(provider.SearchCriteria{
+		jsonFiles, err := searchFiles(provider.SearchCriteria{
 			Patterns:           []string{"*.json"},
 			ConditionFilepaths: cond.JSON.Filepaths,
 		})

--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -60,8 +60,11 @@ func (b *builtinServiceClient) Prepare(ctx context.Context, conditionsByCap []pr
 	ctx, span := tracing.StartNewSpan(ctx, "builtin.Prepare")
 	defer span.End()
 
-	// Parse all conditions to collect the union of include/exclude scopes
-	var allIncluded, allExcluded []string
+	// Parse all conditions to collect the union of include scopes only.
+	// Per-rule excludes must be applied at Evaluate-time via filterCachedFiles,
+	// not here — unioning excludes across rules would permanently drop files
+	// from the index that other rules need.
+	var allIncluded []string
 	for _, cbc := range conditionsByCap {
 		for _, condBytes := range cbc.Conditions {
 			var cond builtinCondition
@@ -69,13 +72,12 @@ func (b *builtinServiceClient) Prepare(ctx context.Context, conditionsByCap []pr
 				b.log.V(5).Error(err, "failed to unmarshal condition in Prepare, skipping")
 				continue
 			}
-			inc, exc := cond.ProviderContext.GetScopedFilepaths()
+			inc, _ := cond.ProviderContext.GetScopedFilepaths()
 			allIncluded = append(allIncluded, inc...)
-			allExcluded = append(allExcluded, exc...)
 		}
 	}
 
-	// Build a single FileSearcher with the union of all scopes
+	// Build a single FileSearcher with the union of all include scopes
 	searcher := provider.FileSearcher{
 		BasePath: b.config.Location,
 		ProviderConfigConstraints: provider.IncludeExcludeConstraints{
@@ -84,7 +86,6 @@ func (b *builtinServiceClient) Prepare(ctx context.Context, conditionsByCap []pr
 		},
 		RuleScopeConstraints: provider.IncludeExcludeConstraints{
 			IncludePathsOrPatterns: allIncluded,
-			ExcludePathsOrPatterns: allExcluded,
 		},
 		FailFast: true,
 		Log:      b.log,

--- a/provider/internal/builtin/service_client_test.go
+++ b/provider/internal/builtin/service_client_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1366,5 +1367,452 @@ func Test_builtinServiceClient_performFileContentSearch_Multiline(t *testing.T) 
 				t.Errorf("%s: got line numbers %v, want %v", tt.description, gotLineNums, tt.wantLineNums)
 			}
 		})
+	}
+}
+
+func Test_builtinServiceClient_Prepare_BuildsFileIndex(t *testing.T) {
+	baseLocation, err := filepath.Abs(filepath.Join(".", "testdata", "search_scopes"))
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	sc := &builtinServiceClient{
+		config: provider.InitConfig{
+			Location: baseLocation,
+		},
+		log:            testr.NewWithOptions(t, testr.Options{Verbosity: 10}),
+		locationCache:  map[string]float64{},
+		cacheMutex:     sync.RWMutex{},
+		workingCopyMgr: NewTempFileWorkingCopyManger(testr.New(t)),
+	}
+	sc.workingCopyMgr.init()
+	defer sc.workingCopyMgr.stop()
+
+	// Build a simple condition
+	cond := builtinCondition{
+		File: fileCondition{
+			Pattern: "*.txt",
+		},
+	}
+	condBytes, err := yaml.Marshal(&cond)
+	if err != nil {
+		t.Fatalf("failed to marshal condition: %v", err)
+	}
+
+	conditionsByCap := []provider.ConditionsByCap{
+		{
+			Cap:        "file",
+			Conditions: [][]byte{condBytes},
+		},
+	}
+
+	err = sc.Prepare(context.TODO(), conditionsByCap)
+	if err != nil {
+		t.Fatalf("Prepare() returned error: %v", err)
+	}
+
+	if !sc.prepared {
+		t.Error("expected prepared to be true after successful Prepare()")
+	}
+
+	if len(sc.fileIndex) == 0 {
+		t.Error("expected fileIndex to be non-empty after Prepare()")
+	}
+
+	// Verify all files in the testdata directory are indexed
+	expectedFiles := []string{
+		"dir_a/a.json", "dir_a/a.properties", "dir_a/a.txt", "dir_a/a.xml",
+		"dir_a/dir_b/ab.json", "dir_a/dir_b/ab.properties", "dir_a/dir_b/ab.txt", "dir_a/dir_b/ab.xml",
+		"dir_b/b.json", "dir_b/b.properties", "dir_b/b.txt", "dir_b/b.xml",
+		"dir_b/dir_a/ba.json", "dir_b/dir_a/ba.properties", "dir_b/dir_a/ba.txt", "dir_b/dir_a/ba.xml",
+	}
+	for _, expected := range expectedFiles {
+		absExpected := filepath.Join(baseLocation, expected)
+		found := false
+		for _, f := range sc.fileIndex {
+			if f == absExpected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected file %q in fileIndex but not found", absExpected)
+		}
+	}
+}
+
+func Test_builtinServiceClient_Prepare_FailureFallback(t *testing.T) {
+	sc := &builtinServiceClient{
+		config: provider.InitConfig{
+			Location: "/nonexistent/path/that/should/not/exist",
+		},
+		log:            testr.NewWithOptions(t, testr.Options{Verbosity: 10}),
+		locationCache:  map[string]float64{},
+		cacheMutex:     sync.RWMutex{},
+		workingCopyMgr: NewTempFileWorkingCopyManger(testr.New(t)),
+	}
+	sc.workingCopyMgr.init()
+	defer sc.workingCopyMgr.stop()
+
+	err := sc.Prepare(context.TODO(), []provider.ConditionsByCap{})
+	if err != nil {
+		t.Errorf("Prepare() returned error: %v, expected nil for graceful fallback", err)
+	}
+
+	// prepared should remain false
+	if sc.prepared {
+		t.Error("expected prepared to be false after Prepare() with invalid path")
+	}
+}
+
+func Test_builtinServiceClient_Prepare_UnionOfScopes(t *testing.T) {
+	baseLocation, err := filepath.Abs(filepath.Join(".", "testdata", "search_scopes"))
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	sc := &builtinServiceClient{
+		config: provider.InitConfig{
+			Location: baseLocation,
+		},
+		log:            testr.NewWithOptions(t, testr.Options{Verbosity: 10}),
+		locationCache:  map[string]float64{},
+		cacheMutex:     sync.RWMutex{},
+		workingCopyMgr: NewTempFileWorkingCopyManger(testr.New(t)),
+	}
+	sc.workingCopyMgr.init()
+	defer sc.workingCopyMgr.stop()
+
+	// Create conditions scoped to different directories
+	condA := builtinCondition{
+		File: fileCondition{Pattern: "*.txt"},
+		ProviderContext: provider.ProviderContext{
+			Template: map[string]engine.ChainTemplate{
+				engine.TemplateContextPathScopeKey: {
+					Filepaths: []string{filepath.Join(baseLocation, "dir_a")},
+				},
+			},
+		},
+	}
+	condB := builtinCondition{
+		File: fileCondition{Pattern: "*.xml"},
+		ProviderContext: provider.ProviderContext{
+			Template: map[string]engine.ChainTemplate{
+				engine.TemplateContextPathScopeKey: {
+					Filepaths: []string{filepath.Join(baseLocation, "dir_b")},
+				},
+			},
+		},
+	}
+
+	condABytes, _ := yaml.Marshal(&condA)
+	condBBytes, _ := yaml.Marshal(&condB)
+
+	conditionsByCap := []provider.ConditionsByCap{
+		{Cap: "file", Conditions: [][]byte{condABytes}},
+		{Cap: "file", Conditions: [][]byte{condBBytes}},
+	}
+
+	err = sc.Prepare(context.TODO(), conditionsByCap)
+	if err != nil {
+		t.Fatalf("Prepare() returned error: %v", err)
+	}
+
+	if !sc.prepared {
+		t.Error("expected prepared to be true")
+	}
+
+	// The union of scopes should include files from both dir_a and dir_b
+	hasDirA := false
+	hasDirB := false
+	for _, f := range sc.fileIndex {
+		if strings.Contains(f, "dir_a") {
+			hasDirA = true
+		}
+		if strings.Contains(f, "dir_b") {
+			hasDirB = true
+		}
+	}
+
+	if !hasDirA {
+		t.Error("expected fileIndex to contain files from dir_a (union of scopes)")
+	}
+	if !hasDirB {
+		t.Error("expected fileIndex to contain files from dir_b (union of scopes)")
+	}
+}
+
+// Test_builtinServiceClient_Evaluate_WithCache verifies that Evaluate() produces
+// identical results when using the cached file index (after Prepare()) vs the
+// traditional per-call FileSearcher walk. Tests all filesystem-accessing capabilities.
+func Test_builtinServiceClient_Evaluate_WithCache(t *testing.T) {
+	baseLocation, err := filepath.Abs(filepath.Join(".", "testdata", "search_scopes"))
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		capability string
+		condition  builtinCondition
+	}{
+		{
+			name:       "file — match .properties files",
+			capability: "file",
+			condition: builtinCondition{
+				File: fileCondition{Pattern: ".*.properties"},
+			},
+		},
+		{
+			name:       "file — match .txt files",
+			capability: "file",
+			condition: builtinCondition{
+				File: fileCondition{Pattern: "*.txt"},
+			},
+		},
+		{
+			name:       "filecontent — match content pattern",
+			capability: "filecontent",
+			condition: builtinCondition{
+				Filecontent: fileContentCondition{
+					Pattern: "(fox|app.config.property = .*)",
+				},
+			},
+		},
+		{
+			name:       "filecontent — with filePattern filter",
+			capability: "filecontent",
+			condition: builtinCondition{
+				Filecontent: fileContentCondition{
+					Pattern:     "(fox|app.config.property = .*)",
+					FilePattern: "*.txt",
+				},
+			},
+		},
+		{
+			name:       "xml — XPath query",
+			capability: "xml",
+			condition: builtinCondition{
+				XML: xmlCondition{
+					XPath: "//name[text()='Test name']",
+				},
+			},
+		},
+		{
+			name:       "json — XPath query",
+			capability: "json",
+			condition: builtinCondition{
+				JSON: jsonCondition{
+					XPath: "//name",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := testr.NewWithOptions(t, testr.Options{Verbosity: 10})
+
+			newClient := func() *builtinServiceClient {
+				sc := &builtinServiceClient{
+					config: provider.InitConfig{
+						Location: baseLocation,
+					},
+					log:            log,
+					locationCache:  map[string]float64{},
+					cacheMutex:     sync.RWMutex{},
+					workingCopyMgr: NewTempFileWorkingCopyManger(log),
+				}
+				sc.workingCopyMgr.init()
+				return sc
+			}
+
+			// Run WITHOUT Prepare (fallback path)
+			clientNoPrepare := newClient()
+			defer clientNoPrepare.workingCopyMgr.stop()
+
+			condBytes, err := yaml.Marshal(&tt.condition)
+			if err != nil {
+				t.Fatalf("failed to marshal condition: %v", err)
+			}
+			resultNoPrepare, errNoPrepare := clientNoPrepare.Evaluate(
+				context.TODO(), tt.capability, condBytes)
+
+			// Run WITH Prepare (cached path)
+			clientWithPrepare := newClient()
+			defer clientWithPrepare.workingCopyMgr.stop()
+
+			conditionsByCap := []provider.ConditionsByCap{
+				{Cap: tt.capability, Conditions: [][]byte{condBytes}},
+			}
+			if err := clientWithPrepare.Prepare(context.TODO(), conditionsByCap); err != nil {
+				t.Fatalf("Prepare() failed: %v", err)
+			}
+			if !clientWithPrepare.prepared {
+				t.Fatal("expected prepared to be true")
+			}
+
+			resultWithPrepare, errWithPrepare := clientWithPrepare.Evaluate(
+				context.TODO(), tt.capability, condBytes)
+
+			// Compare errors
+			if (errNoPrepare != nil) != (errWithPrepare != nil) {
+				t.Fatalf("error mismatch: noPrepare=%v, withPrepare=%v",
+					errNoPrepare, errWithPrepare)
+			}
+
+			// Compare matched
+			if resultNoPrepare.Matched != resultWithPrepare.Matched {
+				t.Errorf("Matched mismatch: noPrepare=%v, withPrepare=%v",
+					resultNoPrepare.Matched, resultWithPrepare.Matched)
+			}
+
+			// Compare incident file paths
+			getFilePaths := func(resp provider.ProviderEvaluateResponse) []string {
+				paths := []string{}
+				for _, inc := range resp.Incidents {
+					paths = append(paths, inc.FileURI.Filename())
+				}
+				sort.Strings(paths)
+				return paths
+			}
+
+			pathsNoPrepare := getFilePaths(resultNoPrepare)
+			pathsWithPrepare := getFilePaths(resultWithPrepare)
+
+			if !reflect.DeepEqual(pathsNoPrepare, pathsWithPrepare) {
+				t.Errorf("incident file paths mismatch:\n  noPrepare:   %v\n  withPrepare: %v",
+					pathsNoPrepare, pathsWithPrepare)
+			}
+
+			// Compare incident count
+			if len(resultNoPrepare.Incidents) != len(resultWithPrepare.Incidents) {
+				t.Errorf("incident count mismatch: noPrepare=%d, withPrepare=%d",
+					len(resultNoPrepare.Incidents), len(resultWithPrepare.Incidents))
+			}
+		})
+	}
+}
+
+// Test_builtinServiceClient_Evaluate_NoPrepare_Fallback confirms Evaluate() works
+// correctly when Prepare() was never called (backward compatibility).
+func Test_builtinServiceClient_Evaluate_NoPrepare_Fallback(t *testing.T) {
+	baseLocation, err := filepath.Abs(filepath.Join(".", "testdata", "search_scopes"))
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	sc := &builtinServiceClient{
+		config: provider.InitConfig{
+			Location: baseLocation,
+		},
+		log:            testr.NewWithOptions(t, testr.Options{Verbosity: 10}),
+		locationCache:  map[string]float64{},
+		cacheMutex:     sync.RWMutex{},
+		workingCopyMgr: NewTempFileWorkingCopyManger(testr.New(t)),
+	}
+	sc.workingCopyMgr.init()
+	defer sc.workingCopyMgr.stop()
+
+	// Verify prepared is false (Prepare() never called)
+	if sc.prepared {
+		t.Fatal("expected prepared to be false when Prepare() was never called")
+	}
+
+	cond := builtinCondition{
+		File: fileCondition{Pattern: "*.txt"},
+	}
+	condBytes, err := yaml.Marshal(&cond)
+	if err != nil {
+		t.Fatalf("failed to marshal condition: %v", err)
+	}
+
+	result, err := sc.Evaluate(context.TODO(), "file", condBytes)
+	if err != nil {
+		t.Fatalf("Evaluate() returned error: %v", err)
+	}
+
+	if !result.Matched {
+		t.Error("expected Matched to be true — .txt files exist in testdata")
+	}
+
+	if len(result.Incidents) == 0 {
+		t.Error("expected incidents for .txt file matches")
+	}
+}
+
+// Test_builtinServiceClient_Prepare_EmptyConditions verifies Prepare() with
+// an empty conditionsByCap still walks and caches all files.
+func Test_builtinServiceClient_Prepare_EmptyConditions(t *testing.T) {
+	baseLocation, err := filepath.Abs(filepath.Join(".", "testdata", "search_scopes"))
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	sc := &builtinServiceClient{
+		config:         provider.InitConfig{Location: baseLocation},
+		log:            testr.NewWithOptions(t, testr.Options{Verbosity: 10}),
+		locationCache:  map[string]float64{},
+		cacheMutex:     sync.RWMutex{},
+		workingCopyMgr: NewTempFileWorkingCopyManger(testr.New(t)),
+	}
+	sc.workingCopyMgr.init()
+	defer sc.workingCopyMgr.stop()
+
+	err = sc.Prepare(context.TODO(), []provider.ConditionsByCap{})
+	if err != nil {
+		t.Fatalf("Prepare() returned error: %v", err)
+	}
+
+	if !sc.prepared {
+		t.Error("expected prepared to be true even with empty conditions")
+	}
+
+	if len(sc.fileIndex) == 0 {
+		t.Error("expected fileIndex to contain files from base path even with empty conditions")
+	}
+}
+
+// Test_builtinServiceClient_Prepare_EmptyBaseDir verifies Prepare() with an empty
+// directory sets prepared=true with an empty fileIndex.
+func Test_builtinServiceClient_Prepare_EmptyBaseDir(t *testing.T) {
+	emptyDir := t.TempDir()
+
+	sc := &builtinServiceClient{
+		config:         provider.InitConfig{Location: emptyDir},
+		log:            testr.NewWithOptions(t, testr.Options{Verbosity: 10}),
+		locationCache:  map[string]float64{},
+		cacheMutex:     sync.RWMutex{},
+		workingCopyMgr: NewTempFileWorkingCopyManger(testr.New(t)),
+	}
+	sc.workingCopyMgr.init()
+	defer sc.workingCopyMgr.stop()
+
+	err := sc.Prepare(context.TODO(), []provider.ConditionsByCap{})
+	if err != nil {
+		t.Fatalf("Prepare() returned error: %v", err)
+	}
+
+	if !sc.prepared {
+		t.Error("expected prepared to be true for empty directory")
+	}
+
+	if len(sc.fileIndex) != 0 {
+		t.Errorf("expected empty fileIndex for empty directory, got %d files", len(sc.fileIndex))
+	}
+
+	// Evaluate should return no matches
+	cond := builtinCondition{
+		File: fileCondition{Pattern: "*.txt"},
+	}
+	condBytes, _ := yaml.Marshal(&cond)
+
+	result, err := sc.Evaluate(context.TODO(), "file", condBytes)
+	if err != nil {
+		t.Fatalf("Evaluate() returned error: %v", err)
+	}
+
+	if result.Matched {
+		t.Error("expected no matches from empty directory")
 	}
 }

--- a/provider/internal/builtin/service_client_test.go
+++ b/provider/internal/builtin/service_client_test.go
@@ -1505,8 +1505,14 @@ func Test_builtinServiceClient_Prepare_UnionOfScopes(t *testing.T) {
 		},
 	}
 
-	condABytes, _ := yaml.Marshal(&condA)
-	condBBytes, _ := yaml.Marshal(&condB)
+	condABytes, err := yaml.Marshal(&condA)
+	if err != nil {
+		t.Fatalf("failed to marshal condA: %v", err)
+	}
+	condBBytes, err := yaml.Marshal(&condB)
+	if err != nil {
+		t.Fatalf("failed to marshal condB: %v", err)
+	}
 
 	conditionsByCap := []provider.ConditionsByCap{
 		{Cap: "file", Conditions: [][]byte{condABytes}},
@@ -1805,7 +1811,10 @@ func Test_builtinServiceClient_Prepare_EmptyBaseDir(t *testing.T) {
 	cond := builtinCondition{
 		File: fileCondition{Pattern: "*.txt"},
 	}
-	condBytes, _ := yaml.Marshal(&cond)
+	condBytes, err := yaml.Marshal(&cond)
+	if err != nil {
+		t.Fatalf("failed to marshal condition: %v", err)
+	}
 
 	result, err := sc.Evaluate(context.TODO(), "file", condBytes)
 	if err != nil {

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -52,6 +52,17 @@ func (f *FileSearcher) Search(s SearchCriteria) ([]string, error) {
 	return f.search(s, newCachedWalkDir())
 }
 
+// isWithinBase returns true if targetPath is at or under basePath.
+// Uses filepath.Rel for correct boundary checks (avoids false positives
+// where e.g. "/repo/app2" would match prefix "/repo/app").
+func isWithinBase(basePath, targetPath string) bool {
+	rel, err := filepath.Rel(filepath.Clean(basePath), filepath.Clean(targetPath))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
 // SearchFromIndex applies the same filtering logic as Search but against
 // a pre-built file index instead of walking the filesystem. AdditionalPaths
 // are still walked on the real filesystem since they may contain files
@@ -63,7 +74,7 @@ func (f *FileSearcher) SearchFromIndex(index []string, s SearchCriteria) ([]stri
 		// Use the index for paths under the base path (where the index was built).
 		// Fall back to real filesystem walk for paths outside the base path
 		// (e.g., working copy temp directories set via AdditionalPaths).
-		if strings.HasPrefix(path, f.BasePath) {
+		if isWithinBase(f.BasePath, path) {
 			return indexWalk(path, excludedDirs, excludedPatterns)
 		}
 		return fsWalk(path, excludedDirs, excludedPatterns)
@@ -241,7 +252,7 @@ func (f *FileSearcher) filterFilesByPathsOrPatterns(statFunc cachedOsStat, patte
 				absPath = filepath.Join(f.BasePath, pattern)
 			}
 			if stat, statErr := statFunc(absPath); statErr == nil {
-				if stat.IsDir() && strings.HasPrefix(file, absPath) {
+				if stat.IsDir() && isWithinBase(absPath, file) {
 					patternMatched = true
 				} else if !stat.IsDir() {
 					if absPath == file {
@@ -259,7 +270,7 @@ func (f *FileSearcher) filterFilesByPathsOrPatterns(statFunc cachedOsStat, patte
 				}
 				// try matching as go regex pattern
 				var relPath string
-				if strings.HasPrefix(file, f.BasePath) {
+				if isWithinBase(f.BasePath, file) {
 					// This is not in a working copy manager or some other additional path
 					// We want to just search for matches within the base path.
 					var err error
@@ -407,7 +418,7 @@ func newIndexWalkFunc(index []string) cachedWalkDir {
 	return func(basePath string, excludedDirs []string, excludedPatterns []string) ([]string, error) {
 		var files []string
 		for _, file := range index {
-			if !strings.HasPrefix(file, basePath) {
+			if !isWithinBase(basePath, file) {
 				continue
 			}
 			excluded := false

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -49,8 +49,33 @@ type IncludeExcludeConstraints struct {
 // 2. Rule scope constraints
 // 3. Provider config level constraints
 func (f *FileSearcher) Search(s SearchCriteria) ([]string, error) {
+	return f.search(s, newCachedWalkDir())
+}
+
+// SearchFromIndex applies the same filtering logic as Search but against
+// a pre-built file index instead of walking the filesystem. AdditionalPaths
+// are still walked on the real filesystem since they may contain files
+// outside the index (e.g., working copy temp directories).
+func (f *FileSearcher) SearchFromIndex(index []string, s SearchCriteria) ([]string, error) {
+	indexWalk := newIndexWalkFunc(index)
+	fsWalk := newCachedWalkDir()
+	compositeWalk := func(path string, excludedDirs []string, excludedPatterns []string) ([]string, error) {
+		// Use the index for paths under the base path (where the index was built).
+		// Fall back to real filesystem walk for paths outside the base path
+		// (e.g., working copy temp directories set via AdditionalPaths).
+		if strings.HasPrefix(path, f.BasePath) {
+			return indexWalk(path, excludedDirs, excludedPatterns)
+		}
+		return fsWalk(path, excludedDirs, excludedPatterns)
+	}
+	return f.search(s, compositeWalk)
+}
+
+// search is the internal implementation shared by Search and SearchFromIndex.
+// The walkDirFunc parameter controls how files are discovered — either via
+// filesystem walk (Search) or by filtering a pre-built index (SearchFromIndex).
+func (f *FileSearcher) search(s SearchCriteria, walkDirFunc cachedWalkDir) ([]string, error) {
 	statFunc := newCachedOsStat()
-	walkDirFunc := newCachedWalkDir()
 	walkErrors := []error{}
 
 	f.Log.V(5).Info("searching for files", "criteria", s, "additionalPaths", f.AdditionalPaths,
@@ -372,6 +397,52 @@ func newCachedWalkDir() cachedWalkDir {
 			return files, err
 		}
 		return val.files, val.err
+	}
+}
+
+// newIndexWalkFunc returns a cachedWalkDir that filters a pre-built file index
+// instead of walking the filesystem. For a given base path, it returns all files
+// from the index that are under that path and not in excluded dirs/patterns.
+func newIndexWalkFunc(index []string) cachedWalkDir {
+	return func(basePath string, excludedDirs []string, excludedPatterns []string) ([]string, error) {
+		var files []string
+		for _, file := range index {
+			if !strings.HasPrefix(file, basePath) {
+				continue
+			}
+			excluded := false
+			for _, excludedDir := range excludedDirs {
+				relPath, err := filepath.Rel(basePath, file)
+				if err == nil {
+					dir := filepath.Dir(relPath)
+					if dir == excludedDir || strings.HasPrefix(dir, excludedDir+string(os.PathSeparator)) ||
+						strings.HasPrefix(relPath, excludedDir+string(os.PathSeparator)) || relPath == excludedDir {
+						excluded = true
+						break
+					}
+				}
+			}
+			if excluded {
+				continue
+			}
+			for _, excludedPattern := range excludedPatterns {
+				if !strings.Contains(excludedPattern, "*") {
+					continue
+				}
+				regex, err := regexp.Compile(excludedPattern)
+				if err != nil {
+					continue
+				}
+				if regex.MatchString(file) || regex.MatchString(filepath.Base(file)) {
+					excluded = true
+					break
+				}
+			}
+			if !excluded {
+				files = append(files, file)
+			}
+		}
+		return files, nil
 	}
 }
 

--- a/provider/lib_test.go
+++ b/provider/lib_test.go
@@ -264,7 +264,7 @@ func TestFileSearcher_SearchFromIndex(t *testing.T) {
 
 	// Build a full file index by walking the test directory (simulating Prepare)
 	var fullIndex []string
-	filepath.WalkDir(testBasePath, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(testBasePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -273,6 +273,9 @@ func TestFileSearcher_SearchFromIndex(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Fatalf("failed to build full index: %v", err)
+	}
 
 	tests := []struct {
 		name                      string
@@ -446,7 +449,7 @@ func TestSearchFromIndex_AdditionalPathsWalkedFromFilesystem(t *testing.T) {
 
 	// Build index from base path only (does not include temp dir)
 	var index []string
-	filepath.WalkDir(testBasePath, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(testBasePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -455,6 +458,9 @@ func TestSearchFromIndex_AdditionalPathsWalkedFromFilesystem(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Fatalf("failed to build index: %v", err)
+	}
 
 	log := testr.NewWithOptions(t, testr.Options{Verbosity: 10})
 	searcher := &FileSearcher{

--- a/provider/lib_test.go
+++ b/provider/lib_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -251,6 +253,252 @@ func TestNormalizePathForComparison(t *testing.T) {
 				t.Errorf("NormalizePathForComparison(%q) = %q, want %q", tt.input, result, expected)
 			}
 		})
+	}
+}
+
+func TestFileSearcher_SearchFromIndex(t *testing.T) {
+	testBasePath, err := filepath.Abs("./testdata/file-search")
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	// Build a full file index by walking the test directory (simulating Prepare)
+	var fullIndex []string
+	filepath.WalkDir(testBasePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			fullIndex = append(fullIndex, path)
+		}
+		return nil
+	})
+
+	tests := []struct {
+		name                      string
+		basePath                  string
+		providerConfigConstraints IncludeExcludeConstraints
+		ruleScopeConstraints      IncludeExcludeConstraints
+		searchCriteria            SearchCriteria
+	}{
+		{
+			name:     "no constraints — all files",
+			basePath: testBasePath,
+			searchCriteria: SearchCriteria{
+				Patterns:           []string{},
+				ConditionFilepaths: []string{},
+			},
+		},
+		{
+			name:     "pattern for .go files",
+			basePath: testBasePath,
+			searchCriteria: SearchCriteria{
+				Patterns:           []string{`.*\.go$`},
+				ConditionFilepaths: []string{},
+			},
+		},
+		{
+			name:     "wildcard pattern *.yaml",
+			basePath: testBasePath,
+			searchCriteria: SearchCriteria{
+				Patterns:           []string{"*.yaml"},
+				ConditionFilepaths: []string{},
+			},
+		},
+		{
+			name:     "provider config include path",
+			basePath: testBasePath,
+			providerConfigConstraints: IncludeExcludeConstraints{
+				IncludePathsOrPatterns: []string{filepath.Join(testBasePath, "src")},
+			},
+			searchCriteria: SearchCriteria{},
+		},
+		{
+			name:     "provider config exclude dirs",
+			basePath: testBasePath,
+			providerConfigConstraints: IncludeExcludeConstraints{
+				ExcludePathsOrPatterns: []string{"vendor", "node_modules"},
+			},
+			searchCriteria: SearchCriteria{},
+		},
+		{
+			name:     "rule scope overrides provider include",
+			basePath: testBasePath,
+			providerConfigConstraints: IncludeExcludeConstraints{
+				IncludePathsOrPatterns: []string{filepath.Join(testBasePath, "src")},
+			},
+			ruleScopeConstraints: IncludeExcludeConstraints{
+				IncludePathsOrPatterns: []string{filepath.Join(testBasePath, "lib")},
+			},
+			searchCriteria: SearchCriteria{},
+		},
+		{
+			name:     "search criteria patterns with include constraint",
+			basePath: testBasePath,
+			providerConfigConstraints: IncludeExcludeConstraints{
+				IncludePathsOrPatterns: []string{filepath.Join(testBasePath, "src")},
+			},
+			searchCriteria: SearchCriteria{
+				Patterns: []string{`.*\.go$`},
+			},
+		},
+		{
+			name:     "condition filepaths (chained)",
+			basePath: testBasePath,
+			searchCriteria: SearchCriteria{
+				ConditionFilepaths: []string{"*.go"},
+			},
+		},
+		{
+			name:     "include pattern with wildcard",
+			basePath: testBasePath,
+			providerConfigConstraints: IncludeExcludeConstraints{
+				IncludePathsOrPatterns: []string{"*.md"},
+			},
+			searchCriteria: SearchCriteria{},
+		},
+		{
+			name:     "multiple patterns in search criteria",
+			basePath: testBasePath,
+			searchCriteria: SearchCriteria{
+				Patterns: []string{`.*\.go$`, `.*\.txt$`},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := testr.NewWithOptions(t, testr.Options{Verbosity: 10})
+			searcher := &FileSearcher{
+				BasePath:                  tt.basePath,
+				ProviderConfigConstraints: tt.providerConfigConstraints,
+				RuleScopeConstraints:      tt.ruleScopeConstraints,
+				FailFast:                  true,
+				Log:                       log,
+			}
+
+			// Get results from Search (filesystem walk)
+			searchResult, searchErr := searcher.Search(tt.searchCriteria)
+
+			// Get results from SearchFromIndex (pre-built index)
+			indexResult, indexErr := searcher.SearchFromIndex(fullIndex, tt.searchCriteria)
+
+			// Both should have same error behavior
+			if (searchErr != nil) != (indexErr != nil) {
+				t.Fatalf("error mismatch: Search err=%v, SearchFromIndex err=%v", searchErr, indexErr)
+			}
+
+			// Sort both for comparison
+			slices.Sort(searchResult)
+			slices.Sort(indexResult)
+
+			if len(searchResult) != len(indexResult) {
+				t.Errorf("result count mismatch: Search=%d, SearchFromIndex=%d", len(searchResult), len(indexResult))
+				t.Errorf("Search result: %v", searchResult)
+				t.Errorf("SearchFromIndex result: %v", indexResult)
+				return
+			}
+
+			for i := range searchResult {
+				if searchResult[i] != indexResult[i] {
+					t.Errorf("result mismatch at index %d: Search=%q, SearchFromIndex=%q", i, searchResult[i], indexResult[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSearchFromIndex_EmptyIndex(t *testing.T) {
+	testBasePath, err := filepath.Abs("./testdata/file-search")
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+	log := testr.NewWithOptions(t, testr.Options{Verbosity: 10})
+	searcher := &FileSearcher{
+		BasePath: testBasePath,
+		FailFast: true,
+		Log:      log,
+	}
+
+	result, err := searcher.SearchFromIndex([]string{}, SearchCriteria{
+		Patterns: []string{`.*\.go$`},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result from empty index, got %v", result)
+	}
+}
+
+func TestSearchFromIndex_AdditionalPathsWalkedFromFilesystem(t *testing.T) {
+	testBasePath, err := filepath.Abs("./testdata/file-search")
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	// Create a temp directory simulating a working copy (outside base path)
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "working-copy.go")
+	if err := os.WriteFile(tempFile, []byte("package wc"), 0644); err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	// Build index from base path only (does not include temp dir)
+	var index []string
+	filepath.WalkDir(testBasePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			index = append(index, path)
+		}
+		return nil
+	})
+
+	log := testr.NewWithOptions(t, testr.Options{Verbosity: 10})
+	searcher := &FileSearcher{
+		BasePath:        testBasePath,
+		AdditionalPaths: []string{tempDir},
+		FailFast:        true,
+		Log:             log,
+	}
+
+	// SearchFromIndex should include files from AdditionalPaths
+	// even though they're not in the index
+	result, err := searcher.SearchFromIndex(index, SearchCriteria{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundTempFile := false
+	for _, f := range result {
+		if f == tempFile {
+			foundTempFile = true
+			break
+		}
+	}
+
+	if !foundTempFile {
+		t.Errorf("SearchFromIndex should include files from AdditionalPaths (working copies) "+
+			"via filesystem walk, but %q was not found in results: %v", tempFile, result)
+	}
+
+	// Verify Search() also includes the temp file (baseline comparison)
+	searchResult, err := searcher.Search(SearchCriteria{})
+	if err != nil {
+		t.Fatalf("Search() unexpected error: %v", err)
+	}
+
+	foundInSearch := false
+	for _, f := range searchResult {
+		if f == tempFile {
+			foundInSearch = true
+			break
+		}
+	}
+	if !foundInSearch {
+		t.Errorf("Search() should include files from AdditionalPaths, but %q was not found", tempFile)
 	}
 }
 


### PR DESCRIPTION
Add Prepare() caching to builtin provider for filesystem walk optimization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a single-pass file indexing and cached search path to speed repeated evaluations and unify global vs per-rule scope handling.
  * Search now supports mixing index-based and filesystem walks for additional paths.

* **Tests**
  * Added extensive tests covering index creation, cached vs non-cached evaluation parity, empty/invalid index cases, scope unions, and additional-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->