### PR TITLE
:bug: Quote filepaths when passing them to yaml processing during cha…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 target/
 *.metadata*
 jdt.ls-java-project
+examples/c-sharp-dummy-example/obj/
 examples/java/*.project
 examples/python/.venv
 examples/python/__pycache__

--- a/engine/conditions.go
+++ b/engine/conditions.go
@@ -319,12 +319,45 @@ type ChainTemplate struct {
 // ToMap converts the ChainTemplate to a map suitable for mustache template rendering.
 // All fields are always exposed (even if empty) to ensure templates can reliably
 // reference them without worrying about undefined values.
+// Filepaths and ExcludedPaths are rendered as YAML flow-sequence strings so that
+// paths containing special characters (e.g. [Content_Types].xml, spaces) remain
+// valid when the rendered condition is parsed by the builtin provider.
 func (c *ChainTemplate) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"filepaths":     c.Filepaths,
-		"excludedPaths": c.ExcludedPaths,
+		"filepaths":     sliceToYAMLFlowString(c.Filepaths),
+		"excludedPaths": sliceToYAMLFlowString(c.ExcludedPaths),
 		"extras":        c.Extras,
 	}
+}
+
+// sliceToYAMLFlowString formats a string slice as a YAML flow sequence (e.g. ["a", "path with space"])
+// so that the result is valid YAML when substituted into a condition and parsed by yaml.Unmarshal.
+// Paths containing special characters are single-quoted; single quotes inside are escaped as ''.
+func sliceToYAMLFlowString(paths []string) string {
+	if len(paths) == 0 {
+		return "[]"
+	}
+	parts := make([]string, len(paths))
+	for i, p := range paths {
+		parts[i] = quoteYAMLFlowScalar(p)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// quoteYAMLFlowScalar returns a YAML flow scalar that can be used inside a flow sequence.
+// If the string contains no special characters it is returned as-is; otherwise it is
+// wrapped in single quotes with internal single quotes escaped as ''.
+func quoteYAMLFlowScalar(s string) string {
+	if s == "" {
+		return "''"
+	}
+	for _, r := range s {
+		switch r {
+		case ' ', '[', ']', ':', '#', ',', '{', '}', '\'', '"', '\n', '\t', '&', '*', '!', '|', '>', '%', '@', '`':
+			return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+		}
+	}
+	return s
 }
 
 func (c *ChainTemplate) FilterIncidentsByFilePaths(incidents []IncidentContext) []IncidentContext {

--- a/engine/conditions_test.go
+++ b/engine/conditions_test.go
@@ -248,3 +248,75 @@ func Test_sortConditionEntries(t *testing.T) {
 		})
 	}
 }
+
+func TestChainTemplate_ToMap_YAMLFlowStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		template ChainTemplate
+		want     map[string]string // filepaths and excludedPaths as strings for assertion
+	}{
+		{
+			name:     "empty filepaths and excludedPaths",
+			template: ChainTemplate{},
+			want: map[string]string{
+				"filepaths":     "[]",
+				"excludedPaths": "[]",
+			},
+		},
+		{
+			name: "simple paths without special chars",
+			template: ChainTemplate{
+				Filepaths: []string{"pom.xml", "subdir/pom.xml"},
+			},
+			want: map[string]string{
+				"filepaths":     "[pom.xml, subdir/pom.xml]",
+				"excludedPaths": "[]",
+			},
+		},
+		{
+			name: "paths with spaces and brackets (Content_Types)",
+			template: ChainTemplate{
+				Filepaths: []string{"/path/to/[Content_Types].xml", "path/with spaces/file.xml"},
+			},
+			want: map[string]string{
+				"filepaths":     "['/path/to/[Content_Types].xml', 'path/with spaces/file.xml']",
+				"excludedPaths": "[]",
+			},
+		},
+		{
+			name: "excludedPaths with trailing slashes",
+			template: ChainTemplate{
+				Filepaths:     []string{"pom.xml"},
+				ExcludedPaths: []string{"target/", "build/"},
+			},
+			want: map[string]string{
+				"filepaths":     "[pom.xml]",
+				"excludedPaths": "[target/, build/]",
+			},
+		},
+		{
+			name: "path with single quote",
+			template: ChainTemplate{
+				Filepaths: []string{"path/with'quote/file.xml"},
+			},
+			want: map[string]string{
+				"filepaths": "['path/with''quote/file.xml']",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.template.ToMap()
+			for key, wantStr := range tt.want {
+				got, ok := m[key].(string)
+				if !ok {
+					t.Errorf("ToMap()[%q] = %T, want string", key, m[key])
+					continue
+				}
+				if got != wantStr {
+					t.Errorf("ToMap()[%q] = %q, want %q", key, got, wantStr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
…ining (#1122)

When passing around filepaths for condition chaining, if any of the files has special characters (for instance, `]`), the generated yaml is not valid. We need to quote the filepaths to prevent this from happening.

Fixes https://github.com/konveyor/analyzer-lsp/issues/1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Bug Fixes**
* Enhanced serialization of file paths in conditions to properly handle special characters, spaces, and quotes.

* **Tests**
* Added comprehensive test coverage for edge cases involving special characters in file path formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->