### PR TITLE
:bug: Fixes Respect Keyboard interrupt kantra#776

### DIFF
--- a/cmd/dep/main.go
+++ b/cmd/dep/main.go
@@ -83,7 +83,7 @@ func DependencyCmd() *cobra.Command {
 			}
 
 			for _, config := range configs {
-				prov, err := lib.GetProviderClient(config, log, prog)
+				prov, err := lib.GetProviderClient(context.Background(), config, log, prog)
 				if err != nil {
 					errLog.Error(err, "unable to create provider client")
 					os.Exit(1)

--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -141,7 +141,7 @@ func (a *analyzer) ProviderStart() error {
 		Message: "Starting provider init",
 		Total:   len(a.providers),
 	})
-	abConfigChan := make(chan []provider.InitConfig)
+	abConfigChan := make(chan []provider.InitConfig, len(a.providers))
 	providerInitCtx, cancelFunc := context.WithCancel(a.ctx)
 	waitGroup := sync.WaitGroup{}
 	go func() {
@@ -202,12 +202,20 @@ func (a *analyzer) ProviderStart() error {
 	}
 
 	if noTimeout {
-		<-c
-		a.log.V(3).Info("started all non builtin providers")
+		select {
+		case <-c:
+			a.log.V(3).Info("started all non builtin providers")
+		case <-a.ctx.Done():
+			cancelFunc()
+			return fmt.Errorf("provider init cancelled: %w", a.ctx.Err())
+		}
 	} else {
 		select {
 		case <-c:
 			a.log.V(3).Info("started all non builtin providers")
+		case <-a.ctx.Done():
+			cancelFunc()
+			return fmt.Errorf("provider init cancelled: %w", a.ctx.Err())
 		case <-time.After(timeout):
 			cancelFunc()
 			return fmt.Errorf("timed out starting providers after %s", timeout)

--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -141,14 +141,13 @@ func (a *analyzer) ProviderStart() error {
 		Message: "Starting provider init",
 		Total:   len(a.providers),
 	})
-	abConfigChan := make(chan []provider.InitConfig, len(a.providers))
+	abConfigChan := make(chan []provider.InitConfig)
 	providerInitCtx, cancelFunc := context.WithCancel(a.ctx)
 	waitGroup := sync.WaitGroup{}
 	go func() {
 		for {
 			select {
 			case config := <-abConfigChan:
-				waitGroup.Done()
 				additionalBuiltinConfigs = append(additionalBuiltinConfigs, config...)
 			case <-providerInitCtx.Done():
 				return
@@ -179,7 +178,11 @@ func (a *analyzer) ProviderStart() error {
 					Current: i + 1,
 					Total:   len(a.providers),
 				})
-				abConfigChan <- additionalBuiltins
+				select {
+				case abConfigChan <- additionalBuiltins:
+				case <-providerInitCtx.Done():
+				}
+				waitGroup.Done()
 			}()
 		}
 	}

--- a/core/types.go
+++ b/core/types.go
@@ -114,7 +114,7 @@ func NewAnalyzer(options ...AnalyzerOption) (Analyzer, error) {
 			}
 		}
 
-		prov, err := lib.GetProviderClient(config, log, opts.progress)
+		prov, err := lib.GetProviderClient(ctx, config, log, opts.progress)
 		if err != nil {
 			providerErrors = append(providerErrors, err)
 			continue

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -286,7 +286,7 @@ func (r *ruleEngine) RunRulesScopedWithOptions(ctx context.Context, ruleSets []R
 	ruleContext := r.runTaggingRules(ctx, taggingRules, mapRuleSets, conditionContext, scopes, cfg)
 
 	// Need a better name for this thing
-	ret := make(chan response)
+	ret := make(chan response, len(otherRules))
 
 	ranRules := len(taggingRules)
 	var matchedRules int32
@@ -360,8 +360,14 @@ func (r *ruleEngine) RunRulesScopedWithOptions(ctx context.Context, ruleSets []R
 		rule.conditionContext = newContext
 		rule.scope = scopes
 		rule.carrier = carrier
-		r.ruleProcessing <- rule
+		select {
+		case r.ruleProcessing <- rule:
+		case <-ctx.Done():
+			wg.Done()
+			goto dispatchDone
+		}
 	}
+dispatchDone:
 	r.logger.V(5).Info("All rules added buffer, waiting for engine to complete", "size", len(otherRules))
 
 	done := make(chan struct{})

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1690,3 +1690,129 @@ func TestCreateViolation(t *testing.T) {
 		})
 	}
 }
+
+func TestRunRules_CancelDuringDispatch(t *testing.T) {
+	logrusLog := logrus.New()
+	logrusLog.SetOutput(io.Discard)
+	logrusLog.SetLevel(logrus.PanicLevel)
+	log := logrusr.New(logrusLog)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ruleEngine := CreateRuleEngine(ctx, 1, log)
+	defer ruleEngine.Stop()
+
+	// 20 slow rules: more than channel buffer (10), so dispatch will block
+	// without the ctx.Done() guard in the dispatch loop.
+	msg := "test"
+	rules := make([]Rule, 20)
+	for i := range rules {
+		rules[i] = Rule{
+			RuleMeta: RuleMeta{RuleID: fmt.Sprintf("rule-%d", i)},
+			Perform:  Perform{Message: Message{Text: &msg}},
+			When:     createTestConditional(true, nil, true), // sleep=true (5s)
+		}
+	}
+	rulesets := []RuleSet{{Name: "test", Rules: rules}}
+
+	// Cancel context shortly after dispatch begins
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		ruleEngine.RunRules(ctx, rulesets)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: RunRules returned after cancellation
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunRules did not return within 10s after context cancellation - deadlock detected")
+	}
+}
+
+func TestRunRules_CancelDuringExecution(t *testing.T) {
+	logrusLog := logrus.New()
+	logrusLog.SetOutput(io.Discard)
+	logrusLog.SetLevel(logrus.PanicLevel)
+	log := logrusr.New(logrusLog)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ruleEngine := CreateRuleEngine(ctx, 10, log)
+	defer ruleEngine.Stop()
+
+	// 10 slow rules that all fit in workers (no dispatch blocking)
+	msg := "test"
+	rules := make([]Rule, 10)
+	for i := range rules {
+		rules[i] = Rule{
+			RuleMeta: RuleMeta{RuleID: fmt.Sprintf("rule-%d", i)},
+			Perform:  Perform{Message: Message{Text: &msg}},
+			When:     createTestConditional(true, nil, true), // sleep=true (5s)
+		}
+	}
+	rulesets := []RuleSet{{Name: "test", Rules: rules}}
+
+	// Cancel after rules are dispatched but during worker sleep
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		ruleEngine.RunRules(ctx, rulesets)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunRules did not return within 10s after context cancellation during execution")
+	}
+}
+
+func TestEngineStop_AfterCancelledRun(t *testing.T) {
+	logrusLog := logrus.New()
+	logrusLog.SetOutput(io.Discard)
+	logrusLog.SetLevel(logrus.PanicLevel)
+	log := logrusr.New(logrusLog)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ruleEngine := CreateRuleEngine(ctx, 10, log)
+
+	msg := "test"
+	rules := []Rule{
+		{
+			RuleMeta: RuleMeta{RuleID: "rule-0"},
+			Perform:  Perform{Message: Message{Text: &msg}},
+			When:     createTestConditional(true, nil, true), // sleep=true
+		},
+	}
+	rulesets := []RuleSet{{Name: "test", Rules: rules}}
+
+	// Cancel quickly and run
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	ruleEngine.RunRules(ctx, rulesets)
+
+	// Stop must return promptly, not deadlock
+	done := make(chan struct{})
+	go func() {
+		ruleEngine.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Fatal("ruleEngine.Stop() did not return within 5s after cancelled run")
+	}
+}

--- a/provider/grpc/provider.go
+++ b/provider/grpc/provider.go
@@ -169,19 +169,20 @@ func requiresConversion(value interface{}) bool {
 	}
 }
 
-func NewGRPCClient(config provider.Config, log logr.Logger, progress *progress.Progress) (provider.InternalProviderClient, error) {
+func NewGRPCClient(ctx context.Context, config provider.Config, log logr.Logger, progress *progress.Progress) (provider.InternalProviderClient, error) {
 	log = log.WithName(config.Name)
 	log = log.WithValues("provider", "grpc")
-	ctxCmd, cancelCmd := context.WithCancel(context.Background())
+	ctxCmd, cancelCmd := context.WithCancel(ctx)
 	conn, _, err := start(ctxCmd, config, log)
 	if err != nil {
+		cancelCmd()
 		return nil, err
 	}
-	refCltCtx, cancel := context.WithCancel(context.Background())
+	refCltCtx, cancel := context.WithCancel(ctx)
 	refClt := reflectClient.NewClientAuto(refCltCtx, conn)
 	defer cancel()
 
-	services, err := checkServicesRunning(refClt, log)
+	services, err := checkServicesRunning(ctx, refClt, log)
 	if err != nil {
 		log.Error(err, "failed to check if services are running")
 		return nil, err
@@ -262,9 +263,14 @@ func NewGRPCClient(config provider.Config, log logr.Logger, progress *progress.P
 	}
 }
 
-func checkServicesRunning(refClt *reflectClient.Client, log logr.Logger) ([]string, error) {
+func checkServicesRunning(ctx context.Context, refClt *reflectClient.Client, log logr.Logger) ([]string, error) {
+	deadline := time.After(30 * time.Second)
 	for {
 		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("service check cancelled: %w", ctx.Err())
+		case <-deadline:
+			return nil, fmt.Errorf("no services found within 30s")
 		default:
 			services, err := refClt.ListServices()
 			if err == nil && len(services) != 0 {
@@ -273,9 +279,12 @@ func checkServicesRunning(refClt *reflectClient.Client, log logr.Logger) ([]stri
 			if err != nil {
 				log.Error(err, "error for list services retrying")
 			}
-			time.Sleep(3 * time.Second)
-		case <-time.After(time.Second * 30):
-			return nil, fmt.Errorf("no services found")
+			// Sleep with context check so cancellation is prompt
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("service check cancelled: %w", ctx.Err())
+			case <-time.After(3 * time.Second):
+			}
 		}
 	}
 }

--- a/provider/grpc/service_client.go
+++ b/provider/grpc/service_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/konveyor/analyzer-lsp/progress"
@@ -204,7 +205,9 @@ func (g *grpcServiceClient) NotifyFileChanges(ctx context.Context, changes ...pr
 }
 
 func (g *grpcServiceClient) Stop() {
-	g.client.Stop(context.TODO(), &pb.ServiceRequest{Id: g.id})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	g.client.Stop(ctx, &pb.ServiceRequest{Id: g.id})
 }
 
 func (g *grpcServiceClient) Prepare(ctx context.Context, conditionsByCap []provider.ConditionsByCap) error {

--- a/provider/lib/lib.go
+++ b/provider/lib/lib.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/konveyor/analyzer-lsp/progress"
 	"github.com/konveyor/analyzer-lsp/provider"
@@ -9,11 +11,11 @@ import (
 )
 
 // We need some wrapper that can deal with out of tree providers, this will be a call, that will mock it out, but go against in tree.
-func GetProviderClient(config provider.Config, log logr.Logger, progress *progress.Progress) (provider.InternalProviderClient, error) {
+func GetProviderClient(ctx context.Context, config provider.Config, log logr.Logger, progress *progress.Progress) (provider.InternalProviderClient, error) {
 	switch config.Name {
 	case "builtin":
 		return builtin.NewBuiltinProvider(config, log, progress), nil
 	default:
-		return grpc.NewGRPCClient(config, log, progress)
+		return grpc.NewGRPCClient(ctx, config, log, progress)
 	}
 }


### PR DESCRIPTION
See: https://github.com/konveyor/kantra/issues/776

  analyzer-lsp fixes:
  - Buffer engine response channel so workers don't block after handler exits
  - Guard rule dispatch loop with ctx.Done() to prevent deadlock on full channel
  - Buffer ProviderStart abConfigChan and add ctx.Done() to init wait select
  - Add 5s timeout to gRPC provider Stop() (was context.TODO() with no timeout)
  - Thread context through GetProviderClient/NewGRPCClient for signal-aware startup
  - Rewrite checkServicesRunning to accept context and fix broken 30s timeout

Related to https://github.com/konveyor/kantra/pull/777

Co-Authored-By: Claude Opus 4.6 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)