### PR TITLE
:sparkles: Configurable timeout for Java rule query

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -39,6 +39,7 @@ const (
 	DISABLE_MAVEN_SEARCH          = "disableMavenSearch"
 	GRADLE_SOURCES_TASK_FILE      = "gradleSourcesTaskFile"
 	MAVEN_INDEX_PATH              = "mavenIndexPath"
+	RULE_QUERY_TIMEOUT_OPTION     = "ruleQueryTimeout"
 )
 
 const (
@@ -425,6 +426,11 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		config.DependencyPath = depLocation
 	}
 
+	ruleQueryTimeout, err := parseRuleQueryTimeout(config)
+	if err != nil {
+		return nil, additionalBuiltinConfig, err
+	}
+
 	if config.RPC != nil {
 		// Pre-existing RPC connection — JDTLS is assumed to be already ready
 		alreadyReady := make(chan struct{})
@@ -439,6 +445,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 			mvnIndexPath:      mavenOpenSourceIndex,
 			mvnSettingsFile:   mavenSettingsFile,
 			workspaceReady:    alreadyReady,
+			ruleQueryTimeout:  ruleQueryTimeout,
 		}, provider.InitConfig{}, nil
 	} else if lspServerPath == "" {
 		return nil, additionalBuiltinConfig, fmt.Errorf("invalid lspServerPath provided, unable to init java provider")
@@ -586,6 +593,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 		mvnSettingsFile:     mavenSettingsFile,
 		jdtlsProcessExited:  &jdtlsProcessExited,
 		workspaceReady:      workspaceReady,
+		ruleQueryTimeout:    ruleQueryTimeout,
 	}
 
 	svcClient.initialization(ctx)

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -43,6 +43,7 @@ type javaServiceClient struct {
 	mvnSettingsFile     string
 	jdtlsProcessExited  *chan bool
 	workspaceReady      chan struct{} // closed when JDTLS workspace import is complete
+	ruleQueryTimeout    time.Duration
 }
 
 var _ provider.ServiceClient = &javaServiceClient{}
@@ -238,6 +239,9 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 	if strings.HasSuffix(c.Referenced.Pattern, "*") || strings.HasSuffix(c.Referenced.Pattern, "*)") {
 		timeout = 10 * time.Minute
 	}
+	if p.ruleQueryTimeout > 0 {
+		timeout = p.ruleQueryTimeout
+	}
 	p.activeRPCCalls.Add(1)
 	defer p.activeRPCCalls.Done()
 
@@ -248,10 +252,15 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 		if jsonrpc2.IsRPCClosed(err) {
 			log.Error(err, "connection to the language server is closed, language server is not running")
 			return refs, fmt.Errorf("connection to the language server is closed, language server is not running")
-		} else {
-			log.Error(err, "unable to ask for Konveyor rule entry")
-			return refs, fmt.Errorf("unable to ask for Konveyor rule entry")
 		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(timeOutCtx.Err(), context.DeadlineExceeded) {
+			log.Error(err, "Konveyor rule entry timed out waiting for workspace/executeCommand",
+				"timeout", timeout,
+				"ruleID", condCTX.RuleID)
+			return refs, fmt.Errorf("konveyor rule entry timed out after %s ruleID=%s: %w", timeout, condCTX.RuleID, err)
+		}
+		log.Error(err, "unable to ask for Konveyor rule entry")
+		return refs, fmt.Errorf("unable to ask for Konveyor rule entry: %w", err)
 	}
 
 	// If no additional filtering needed, return language server results as-is
@@ -525,6 +534,30 @@ func (p *javaServiceClient) initialization(ctx context.Context) {
 	}
 	p.log.V(2).Info("java connection initialized")
 
+}
+
+func parseRuleQueryTimeout(cfg provider.InitConfig) (time.Duration, error) {
+	if cfg.ProviderSpecificConfig == nil {
+		return 0, nil
+	}
+	m := cfg.ProviderSpecificConfig
+	v, ok := m[RULE_QUERY_TIMEOUT_OPTION]
+	if !ok || v == nil {
+		return 0, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("providerSpecificConfig.%s must be a string, e.g. '15m'", RULE_QUERY_TIMEOUT_OPTION)
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing rule timeout %s: %w", RULE_QUERY_TIMEOUT_OPTION, err)
+	}
+	return d, nil
 }
 
 func createProjectAndClasspathFiles(basePath string, projectName string) error {


### PR DESCRIPTION
This should help resolve the issue around timeouts with open source dep analysis 
Fixes #1078 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a provider configuration option to customize the timeout used for Java rule query operations.

* **Improvements**
  * Timeout-related failures now return clearer, timeout-specific diagnostics.
  * Non-timeout failures now surface more informative error wrapping for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->