### PR TITLE
:bug: Wait for JDTLS workspace import before evaluation

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/handler.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/handler.go
@@ -1,0 +1,191 @@
+package java
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	jsonrpc2 "github.com/konveyor/analyzer-lsp/jsonrpc2_v2"
+	"github.com/konveyor/analyzer-lsp/lsp/protocol"
+)
+
+// languageStatusParams represents JDTLS-specific language/status notification.
+// This is not part of the LSP standard but is sent by Eclipse JDTLS to indicate
+// workspace readiness.
+type languageStatusParams struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// progressValue is used to determine the kind of a progress notification value.
+// The $/progress notification Value can be WorkDoneProgressBegin, WorkDoneProgressReport,
+// or WorkDoneProgressEnd, distinguished by the "kind" field.
+type progressValue struct {
+	Kind string `json:"kind"`
+}
+
+// jdtlsProgressHandler handles JDTLS progress notifications to track workspace
+// initialization status. It handles three LSP methods:
+//   - window/workDoneProgress/create: acknowledges progress token creation
+//   - $/progress: tracks begin/end of workspace import progress
+//   - language/status: secondary readiness signal from JDTLS
+//
+// When all active progress operations complete (or language/status signals "Started"),
+// the workspaceReady channel is closed, unblocking Prepare().
+type jdtlsProgressHandler struct {
+	log            logr.Logger
+	workspaceReady chan struct{}
+	closeOnce      sync.Once
+
+	mu             sync.Mutex
+	activeProgress map[string]string // token (stringified) -> title from WorkDoneProgressBegin
+	sawProgress    bool              // true once at least one WorkDoneProgressBegin has been seen
+}
+
+func newJDTLSProgressHandler(log logr.Logger, workspaceReady chan struct{}) *jdtlsProgressHandler {
+	return &jdtlsProgressHandler{
+		log:            log,
+		workspaceReady: workspaceReady,
+		activeProgress: make(map[string]string),
+	}
+}
+
+// signalReady closes the workspaceReady channel exactly once.
+// It is safe to call even if the channel was already closed externally
+// (e.g., the no-build-tool case where the channel is pre-closed).
+func (h *jdtlsProgressHandler) signalReady() {
+	h.closeOnce.Do(func() {
+		select {
+		case <-h.workspaceReady:
+			// Channel is already closed (e.g., pre-closed for no-build-tool case)
+		default:
+			close(h.workspaceReady)
+		}
+	})
+}
+
+func (h *jdtlsProgressHandler) Handle(ctx context.Context, req *jsonrpc2.Request) (interface{}, error) {
+	switch req.Method {
+	case "window/workDoneProgress/create":
+		return h.handleWorkDoneProgressCreate(req)
+	case "$/progress":
+		return h.handleProgress(req)
+	case "language/status":
+		return h.handleLanguageStatus(req)
+	default:
+		return nil, jsonrpc2.ErrNotHandled
+	}
+}
+
+// handleWorkDoneProgressCreate acknowledges a progress token creation request from JDTLS.
+// JDTLS sends this as a request (with an ID) that requires a response.
+// Returning nil acknowledges the token so JDTLS will send $/progress notifications for it.
+func (h *jdtlsProgressHandler) handleWorkDoneProgressCreate(req *jsonrpc2.Request) (interface{}, error) {
+	if req.Params != nil {
+		var params protocol.WorkDoneProgressCreateParams
+		if err := json.Unmarshal(req.Params, &params); err == nil {
+			h.log.V(5).Info("acknowledged progress token creation", "token", params.Token)
+		}
+	}
+	// Return nil result with nil error to send a successful response
+	return nil, nil
+}
+
+// handleProgress processes $/progress notifications to track workspace import status.
+// It tracks active progress operations by their tokens. When all active progress
+// operations have completed (all begins have matching ends), it signals readiness.
+func (h *jdtlsProgressHandler) handleProgress(req *jsonrpc2.Request) (interface{}, error) {
+	if req.Params == nil {
+		return nil, nil
+	}
+
+	var params protocol.ProgressParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		h.log.V(5).Error(err, "failed to parse $/progress params")
+		return nil, nil
+	}
+
+	// Re-marshal the Value to inspect the kind field
+	valueBytes, err := json.Marshal(params.Value)
+	if err != nil {
+		h.log.V(5).Error(err, "failed to marshal progress value")
+		return nil, nil
+	}
+
+	var pv progressValue
+	if err := json.Unmarshal(valueBytes, &pv); err != nil {
+		h.log.V(5).Error(err, "failed to parse progress value kind")
+		return nil, nil
+	}
+
+	tokenKey := fmt.Sprintf("%v", params.Token)
+
+	switch pv.Kind {
+	case "begin":
+		var begin protocol.WorkDoneProgressBegin
+		if err := json.Unmarshal(valueBytes, &begin); err != nil {
+			h.log.V(5).Error(err, "failed to parse WorkDoneProgressBegin")
+			return nil, nil
+		}
+		h.mu.Lock()
+		h.activeProgress[tokenKey] = begin.Title
+		h.sawProgress = true
+		h.mu.Unlock()
+		h.log.Info("JDTLS progress started", "title", begin.Title, "token", tokenKey)
+
+	case "report":
+		var report protocol.WorkDoneProgressReport
+		if err := json.Unmarshal(valueBytes, &report); err == nil {
+			h.mu.Lock()
+			title := h.activeProgress[tokenKey]
+			h.mu.Unlock()
+			h.log.V(5).Info("JDTLS progress update", "title", title, "message", report.Message, "percentage", report.Percentage)
+		}
+
+	case "end":
+		var end protocol.WorkDoneProgressEnd
+		if err := json.Unmarshal(valueBytes, &end); err == nil {
+			h.mu.Lock()
+			title := h.activeProgress[tokenKey]
+			delete(h.activeProgress, tokenKey)
+			sawProgress := h.sawProgress
+			remaining := len(h.activeProgress)
+			h.mu.Unlock()
+
+			h.log.Info("JDTLS progress ended", "title", title, "message", end.Message, "remainingActive", remaining)
+
+			if sawProgress && remaining == 0 {
+				h.log.Info("all JDTLS initialization progress complete, workspace is ready")
+				h.signalReady()
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// handleLanguageStatus processes JDTLS-specific language/status notifications.
+// When JDTLS sends type "Started", the workspace is ready.
+// This serves as a secondary/fallback readiness signal alongside $/progress.
+func (h *jdtlsProgressHandler) handleLanguageStatus(req *jsonrpc2.Request) (interface{}, error) {
+	if req.Params == nil {
+		return nil, nil
+	}
+
+	var params languageStatusParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		h.log.V(5).Error(err, "failed to parse language/status params")
+		return nil, nil
+	}
+
+	h.log.V(3).Info("JDTLS language status", "type", params.Type, "message", params.Message)
+
+	if params.Type == "Started" {
+		h.log.Info("JDTLS reported ServiceReady via language/status")
+		h.signalReady()
+	}
+
+	return nil, nil
+}

--- a/external-providers/java-external-provider/pkg/java_external_provider/handler_test.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/handler_test.go
@@ -1,0 +1,250 @@
+package java
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	jsonrpc2 "github.com/konveyor/analyzer-lsp/jsonrpc2_v2"
+	"github.com/konveyor/analyzer-lsp/lsp/protocol"
+)
+
+func TestHandlerWorkDoneProgressCreate(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	// window/workDoneProgress/create is a request (has ID) that must return nil, nil
+	req, err := jsonrpc2.NewCall(jsonrpc2.StringID("1"), "window/workDoneProgress/create",
+		protocol.WorkDoneProgressCreateParams{Token: "test-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := h.Handle(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got: %v", result)
+	}
+}
+
+func TestHandlerProgressBeginAndEnd(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	ctx := context.Background()
+
+	// Send a begin notification
+	beginReq, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "import-token",
+		Value: protocol.WorkDoneProgressBegin{
+			Kind:  "begin",
+			Title: "Importing Maven project(s)",
+		},
+	})
+	h.Handle(ctx, beginReq)
+
+	// Channel should NOT be closed yet
+	select {
+	case <-ready:
+		t.Fatal("workspaceReady should not be closed after begin")
+	default:
+	}
+
+	// Send an end notification
+	endReq, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "import-token",
+		Value: protocol.WorkDoneProgressEnd{
+			Kind:    "end",
+			Message: "Finished",
+		},
+	})
+	h.Handle(ctx, endReq)
+
+	// Channel should now be closed
+	select {
+	case <-ready:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("workspaceReady should be closed after all progress ends")
+	}
+}
+
+func TestHandlerMultipleProgressTokens(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	ctx := context.Background()
+
+	// Begin two concurrent progress operations
+	begin1, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token-1",
+		Value: protocol.WorkDoneProgressBegin{Kind: "begin", Title: "Importing Maven project(s)"},
+	})
+	begin2, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token-2",
+		Value: protocol.WorkDoneProgressBegin{Kind: "begin", Title: "Resolving classpath"},
+	})
+	h.Handle(ctx, begin1)
+	h.Handle(ctx, begin2)
+
+	// End first token — should NOT signal ready yet
+	end1, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token-1",
+		Value: protocol.WorkDoneProgressEnd{Kind: "end", Message: "Done"},
+	})
+	h.Handle(ctx, end1)
+
+	select {
+	case <-ready:
+		t.Fatal("workspaceReady should not be closed while token-2 is still active")
+	default:
+	}
+
+	// End second token — should signal ready
+	end2, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token-2",
+		Value: protocol.WorkDoneProgressEnd{Kind: "end", Message: "Done"},
+	})
+	h.Handle(ctx, end2)
+
+	select {
+	case <-ready:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("workspaceReady should be closed after all progress ends")
+	}
+}
+
+func TestHandlerLanguageStatusReady(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	req, _ := jsonrpc2.NewNotification("language/status", languageStatusParams{
+		Type:    "Started",
+		Message: "ServiceReady",
+	})
+	h.Handle(context.Background(), req)
+
+	select {
+	case <-ready:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("workspaceReady should be closed after language/status Started")
+	}
+}
+
+func TestHandlerLanguageStatusNotReady(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	// "Message" type should NOT signal readiness
+	req, _ := jsonrpc2.NewNotification("language/status", languageStatusParams{
+		Type:    "Message",
+		Message: "Importing project...",
+	})
+	h.Handle(context.Background(), req)
+
+	select {
+	case <-ready:
+		t.Fatal("workspaceReady should not be closed for non-Started status")
+	default:
+		// expected
+	}
+}
+
+func TestHandlerUnknownMethodReturnsNotHandled(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	req, _ := jsonrpc2.NewNotification("textDocument/publishDiagnostics", nil)
+	_, err := h.Handle(context.Background(), req)
+	if err != jsonrpc2.ErrNotHandled {
+		t.Fatalf("expected ErrNotHandled for unknown method, got: %v", err)
+	}
+}
+
+func TestHandlerProgressReport(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	ctx := context.Background()
+
+	// Begin
+	begin, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token",
+		Value: protocol.WorkDoneProgressBegin{Kind: "begin", Title: "Importing"},
+	})
+	h.Handle(ctx, begin)
+
+	// Report — should not crash or signal ready
+	report, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token",
+		Value: protocol.WorkDoneProgressReport{Kind: "report", Message: "50%", Percentage: 50},
+	})
+	_, err := h.Handle(ctx, report)
+	if err != nil {
+		t.Fatalf("expected nil error for report, got: %v", err)
+	}
+
+	select {
+	case <-ready:
+		t.Fatal("workspaceReady should not be closed after report")
+	default:
+	}
+}
+
+func TestHandlerSignalReadyIdempotent(t *testing.T) {
+	log := testr.New(t)
+	ready := make(chan struct{})
+	h := newJDTLSProgressHandler(log, ready)
+
+	// Calling signalReady multiple times should not panic
+	h.signalReady()
+	h.signalReady()
+	h.signalReady()
+
+	select {
+	case <-ready:
+		// success
+	default:
+		t.Fatal("channel should be closed after signalReady")
+	}
+}
+
+func TestHandlerPreClosedChannel(t *testing.T) {
+	// Simulates the no-build-tool case where channel is pre-closed
+	log := testr.New(t)
+	ready := make(chan struct{})
+	close(ready)
+	h := newJDTLSProgressHandler(log, ready)
+
+	// Progress events should not panic even with pre-closed channel
+	begin, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token",
+		Value: protocol.WorkDoneProgressBegin{Kind: "begin", Title: "Importing"},
+	})
+	_, err := h.Handle(context.Background(), begin)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	end, _ := jsonrpc2.NewNotification("$/progress", protocol.ProgressParams{
+		Token: "token",
+		Value: protocol.WorkDoneProgressEnd{Kind: "end", Message: "Done"},
+	})
+	// This calls signalReady on an already-closed channel — should not panic
+	_, err = h.Handle(context.Background(), end)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -550,12 +550,6 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	// The workspaceReady channel is closed when JDTLS signals that workspace
 	// import (Maven/Gradle) is complete, either via $/progress or language/status.
 	workspaceReady := make(chan struct{})
-	if buildTool == nil {
-		// No Maven/Gradle build tool — there is no project import to wait for.
-		// Pre-close the channel so Prepare() returns immediately.
-		log.Info("no build tool detected, skipping workspace import wait")
-		close(workspaceReady)
-	}
 	progressHandler := newJDTLSProgressHandler(log, workspaceReady)
 
 	rpc, err := jsonrpc2.Dial(ctx, dialer, jsonrpc2.ConnectionOptions{

--- a/external-providers/java-external-provider/pkg/java_external_provider/provider.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/provider.go
@@ -417,6 +417,9 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	}
 
 	if config.RPC != nil {
+		// Pre-existing RPC connection — JDTLS is assumed to be already ready
+		alreadyReady := make(chan struct{})
+		close(alreadyReady)
 		return &javaServiceClient{
 			rpc:               config.RPC,
 			config:            config,
@@ -426,6 +429,7 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 			buildTool:         buildTool,
 			mvnIndexPath:      mavenOpenSourceIndex,
 			mvnSettingsFile:   mavenSettingsFile,
+			workspaceReady:    alreadyReady,
 		}, provider.InitConfig{}, nil
 	} else if lspServerPath == "" {
 		return nil, additionalBuiltinConfig, fmt.Errorf("invalid lspServerPath provided, unable to init java provider")
@@ -542,8 +546,20 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	// Create a shared input,ouput dialer
 	dialer := base.NewStdDialer(stdin, stdout)
 
+	// Set up workspace readiness tracking via JDTLS progress notifications.
+	// The workspaceReady channel is closed when JDTLS signals that workspace
+	// import (Maven/Gradle) is complete, either via $/progress or language/status.
+	workspaceReady := make(chan struct{})
+	if buildTool == nil {
+		// No Maven/Gradle build tool — there is no project import to wait for.
+		// Pre-close the channel so Prepare() returns immediately.
+		log.Info("no build tool detected, skipping workspace import wait")
+		close(workspaceReady)
+	}
+	progressHandler := newJDTLSProgressHandler(log, workspaceReady)
+
 	rpc, err := jsonrpc2.Dial(ctx, dialer, jsonrpc2.ConnectionOptions{
-		Handler: &base.DefaultHandler{},
+		Handler: base.NewChainHandler(&base.DefaultHandler{}, progressHandler),
 	})
 	if err != nil {
 		cancelFunc()
@@ -552,20 +568,21 @@ func (p *javaProvider) Init(ctx context.Context, log logr.Logger, config provide
 	}
 
 	svcClient := javaServiceClient{
-		rpc:                rpc,
-		cancelFunc:         cancelFunc,
-		config:             config,
-		cmd:                cmd,
-		bundles:            bundles,
-		workspace:          workspace,
-		log:                log,
-		globalSettings:     globalSettingsFile,
-		depsLocationCache:  make(map[string]int),
-		includedPaths:      provider.GetIncludedPathsFromConfig(config, false),
-		buildTool:          buildTool,
-		mvnIndexPath:       mavenOpenSourceIndex,
-		mvnSettingsFile:    mavenSettingsFile,
-		jdtlsProcessExited: &jdtlsProcessExited,
+		rpc:                 rpc,
+		cancelFunc:          cancelFunc,
+		config:              config,
+		cmd:                 cmd,
+		bundles:             bundles,
+		workspace:           workspace,
+		log:                 log,
+		globalSettings:      globalSettingsFile,
+		depsLocationCache:   make(map[string]int),
+		includedPaths:       provider.GetIncludedPathsFromConfig(config, false),
+		buildTool:           buildTool,
+		mvnIndexPath:        mavenOpenSourceIndex,
+		mvnSettingsFile:     mavenSettingsFile,
+		jdtlsProcessExited:  &jdtlsProcessExited,
+		workspaceReady:      workspaceReady,
 	}
 
 	svcClient.initialization(ctx)

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -25,22 +25,23 @@ import (
 )
 
 type javaServiceClient struct {
-	rpc                provider.RPCClient
-	cancelFunc         context.CancelFunc
-	config             provider.InitConfig
-	log                logr.Logger
-	cmd                *exec.Cmd
-	bundles            []string
-	workspace          string
-	globalSettings     string
-	includedPaths      []string
-	cleanExplodedBins  []string
-	activeRPCCalls     sync.WaitGroup
-	depsLocationCache  map[string]int
-	buildTool          bldtool.BuildTool
-	mvnIndexPath       string
-	mvnSettingsFile    string
-	jdtlsProcessExited *chan bool
+	rpc                 provider.RPCClient
+	cancelFunc          context.CancelFunc
+	config              provider.InitConfig
+	log                 logr.Logger
+	cmd                 *exec.Cmd
+	bundles             []string
+	workspace           string
+	globalSettings      string
+	includedPaths       []string
+	cleanExplodedBins   []string
+	activeRPCCalls      sync.WaitGroup
+	depsLocationCache   map[string]int
+	buildTool           bldtool.BuildTool
+	mvnIndexPath        string
+	mvnSettingsFile     string
+	jdtlsProcessExited  *chan bool
+	workspaceReady      chan struct{} // closed when JDTLS workspace import is complete
 }
 
 var _ provider.ServiceClient = &javaServiceClient{}
@@ -109,7 +110,14 @@ func (p *javaServiceClient) Evaluate(ctx context.Context, cap string, conditionI
 }
 
 func (p *javaServiceClient) Prepare(ctx context.Context, conditionsByCap []provider.ConditionsByCap) error {
-	return nil
+	p.log.Info("waiting for JDTLS workspace to be ready")
+	select {
+	case <-p.workspaceReady:
+		p.log.Info("JDTLS workspace is ready, proceeding with evaluation")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("context cancelled while waiting for JDTLS workspace import to complete: %w", ctx.Err())
+	}
 }
 
 func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, condCTX *provider.ProviderContext) ([]protocol.WorkspaceSymbol, error) {
@@ -422,7 +430,11 @@ func (p *javaServiceClient) initialization(ctx context.Context) {
 	//TODO(shawn-hurley): add ability to parse path to URI in a real supported way
 	params := &protocol.InitializeParams{}
 	params.RootURI = string(uri.File(absLocation))
-	params.Capabilities = protocol.ClientCapabilities{}
+	params.Capabilities = protocol.ClientCapabilities{
+		Window: &protocol.WindowClientCapabilities{
+			WorkDoneProgress: true,
+		},
+	}
 	params.ExtendedClientCapilities = map[string]any{
 		"classFileContentsSupport": true,
 	}


### PR DESCRIPTION
Add progress notification handling so the Java provider waits for JDTLS to finish importing Maven/Gradle projects before running rule evaluation. This prevents incorrect or incomplete results when JDTLS has not yet indexed the workspace.

- Extract JDTLS progress handler into handler.go with tests
- Track $/progress begin/end and language/status notifications
- Block in Prepare() until workspaceReady channel is closed
- Advertise WorkDoneProgress client capability to JDTLS
- Pre-close channel for no-build-tool and pre-existing RPC cases

Assisted-by: Claude (claude-opus-4-6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Java language service now waits for workspace import (Maven/Gradle) to complete during initialization, improving startup stability and preventing premature feature activation.
  * Progress reporting is tracked and aggregated so readiness is only signaled after all import progress completes; JDTLS "Started" status also triggers readiness.
  * Client initialize now explicitly enables work-done progress to support richer server progress interactions.

* **Tests**
  * End-to-end tests added to validate progress handling, readiness signaling, and robustness of repeated/early readiness events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->