### PR TITLE
:bug: replace log.Fatalf with returned error in server.Start

### DIFF
--- a/provider/server.go
+++ b/provider/server.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -164,7 +163,7 @@ func (s *server) Start(ctx context.Context) error {
 	reflection.Register(gs)
 	s.Log.Info(fmt.Sprintf("server listening at %v", listen.Addr()))
 	if err := gs.Serve(listen); err != nil {
-		log.Fatalf("failed to serve: %v", err)
+		return fmt.Errorf("failed to serve: %v", err)
 	}
 	return nil
 }

--- a/provider/server.go
+++ b/provider/server.go
@@ -163,7 +163,7 @@ func (s *server) Start(ctx context.Context) error {
 	reflection.Register(gs)
 	s.Log.Info(fmt.Sprintf("server listening at %v", listen.Addr()))
 	if err := gs.Serve(listen); err != nil {
-		return fmt.Errorf("failed to serve: %v", err)
+		return fmt.Errorf("failed to serve: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
`server.Start()` calls `log.Fatalf` when `gs.Serve()` fails, which
kills the process and prevents callers from handling the error.

Replaced with `return fmt.Errorf(...)` so the error propagates
normally. Also removed the now-unused stdlib `log` import.

Fixes #937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for gRPC server startup: errors are now returned to the caller for proper handling instead of forcibly terminating the process.
  * Removed an unused import and cleaned up startup error flow to make server initialization more robust and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->