### PR TITLE
:bug: normalize CRLF line endings in Maven and Gradle dependency output

### DIFF
--- a/external-providers/java-external-provider/pkg/java_external_provider/bldtool/gradle.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/bldtool/gradle.go
@@ -187,7 +187,7 @@ func (g *gradleBuildTool) GetDependencies(ctx context.Context) (map[uri.URI][]pr
 		return nil, fmt.Errorf("error trying to get Gradle dependencies: %w - Gradle output: %s", err, string(output))
 	}
 
-	lines := strings.Split(string(output), "\n")
+	lines := strings.Split(strings.ReplaceAll(string(output), "\r\n", "\n"), "\n")
 	deps := g.parseGradleDependencyOutput(lines)
 
 	file := uri.File(g.hashFile)
@@ -230,7 +230,7 @@ func (g *gradleBuildTool) getGradleSubprojects(ctx context.Context) ([]string, e
 	subprojects := []string{}
 
 	gather := false
-	lines := strings.Split(string(output), "\n")
+	lines := strings.Split(strings.ReplaceAll(string(output), "\r\n", "\n"), "\n")
 	for _, line := range lines {
 		if npRegex.Find([]byte(line)) != nil {
 			return []string{}, nil

--- a/external-providers/java-external-provider/pkg/java_external_provider/bldtool/maven.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/bldtool/maven.go
@@ -160,7 +160,7 @@ func (m *mavenBuildTool) getDependenciesForMaven(ctx context.Context) (map[uri.U
 		return nil, fmt.Errorf("maven dependency:tree command failed with error %w, maven output: %s", err, string(mvnOutput))
 	}
 
-	lines := strings.Split(string(mvnOutput), "\n")
+	lines := strings.Split(strings.ReplaceAll(string(mvnOutput), "\r\n", "\n"), "\n")
 	submoduleTrees := m.extractSubmoduleTrees(lines)
 
 	var pomDeps []provider.DepDAGItem


### PR DESCRIPTION
On Windows, Maven and Gradle command output uses `\r\n` line endings.
The parsers split output on `\n`, leaving a trailing `\r` on each
line. This propagates into parsed dependency fields (Type, Version,
etc.), causing mismatches downstream.

Fixed by normalizing `\r\n` to `\n` before splitting in:
- `bldtool/maven.go` - `getDependenciesForMaven`
- `bldtool/gradle.go` - `GetDependencies` and `getGradleSubprojects`

Fixes #774