### PR TITLE
:bug: Update file uri replacement to support Wndows paths

### DIFF
--- a/external-providers/go-external-provider/pkg/go_external_provider/dependencies.go
+++ b/external-providers/go-external-provider/pkg/go_external_provider/dependencies.go
@@ -26,7 +26,7 @@ func getDependenciesDAG(workspaceFolder string) (map[uri.URI][]provider.DepDAGIt
 	// Remove file:// prefix if present
 	workspacePath := workspaceFolder
 	if strings.HasPrefix(workspaceFolder, "file://") {
-		workspacePath = workspaceFolder[7:]
+		workspacePath = uri.URI(workspaceFolder).Filename()
 	}
 
 	// If workspace folder is provided and has DEPENDENCY_PROVIDER_MODULE_DIR env var not set,


### PR DESCRIPTION
Part of https://github.com/konveyor/editor-extensions/issues/1427

On Windows, a file uri has 3 slashes `file:///`, the per-position replacement resulted in Windows paths looking like `/c:\...\...` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling for workspace configurations using URI-style paths to ensure accurate path interpretation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/analyzer-lsp/pull/1157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->