### PR TITLE
:sparkles: Surface isDependencyIncident

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -52,11 +52,10 @@ jobs:
 
   build-images:
     name: Build e2e Images
-    uses: konveyor/ci/.github/workflows/e2e-image-build.yaml@feature/262-refactor-generic-provider
+    uses: konveyor/ci/.github/workflows/e2e-image-build.yaml@main
     with:
       repo: ${{ github.repository }}
       ref: ${{ github.ref }}
-      ci_ref: 'feature/262-refactor-generic-provider'
 
   provider-tests:
     needs: [detect-changes, build-images]

--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -52,10 +52,11 @@ jobs:
 
   build-images:
     name: Build e2e Images
-    uses: konveyor/ci/.github/workflows/e2e-image-build.yaml@main
+    uses: konveyor/ci/.github/workflows/e2e-image-build.yaml@feature/262-refactor-generic-provider
     with:
       repo: ${{ github.repository }}
       ref: ${{ github.ref }}
+      ci_ref: 'feature/262-refactor-generic-provider'
 
   provider-tests:
     needs: [detect-changes, build-images]

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -521,7 +521,7 @@
         lineNumber: 4
         variables:
           matchingText: React
-          isDependencyIncident: false
+        isDependencyIncident: false
       effort: 1
     test-regex-pattern-00010:
       description: Test regex pattern for CSS/SCSS files

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -24,6 +24,7 @@
         variables:
           data: inclusionTestNode
           matchingJSON: Test this node
+        isDependencyIncident: false
       effort: 1
     builtin-inclusion-test-xml:
       description: |
@@ -34,6 +35,7 @@
       - uri: file:///analyzer-lsp/examples/builtin/inclusion_tests/dir-0/inclusion-test.xml
         message: Only incidents in dir-0/test.xml should be found
         lineNumber: 0
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/builtin/inclusion_tests/dir-0/inclusion-test.xml
         message: Only incidents in dir-0/test.xml should be found
         codeSnip: |2
@@ -47,6 +49,7 @@
           data: inclusionTestNode
           innerText: Test this node
           matchingXML: Test this node
+        isDependencyIncident: false
       effort: 1
     chain-pom-001:
       description: ""
@@ -60,6 +63,7 @@
           data: dependency
           innerText: "\n\t\t\t\tcom.fasterxml.jackson\n\t\t\t\tjackson-bom\n\t\t\t\t${jackson.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
           matchingXML: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
         codeSnip: "43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>"
@@ -68,6 +72,7 @@
           data: dependency
           innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
           matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
         codeSnip: "53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>"
@@ -76,6 +81,7 @@
           data: dependency
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-servlet-api\n\t\t\t${tomcat.version}\n\t\t\tprovided\n\t\t"
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
         codeSnip: "59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  "
@@ -84,6 +90,7 @@
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
           matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
         codeSnip: "63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>"
@@ -92,6 +99,7 @@
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
           matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId>
         codeSnip: "67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>"
@@ -100,6 +108,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework.data\n\t\t\tspring-data-jpa\n\t\t"
           matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>
         codeSnip: "72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>"
@@ -108,6 +117,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-jdbc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
         codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
@@ -116,6 +126,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-web\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
         codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
@@ -124,6 +135,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
         codeSnip: " 87  \t\t\t<artifactId>spring-webmvc</artifactId>\n 88  \t\t\t<version>${spring-framework.version}</version>\n 89  \t\t</dependency>\n 90  \t\t<dependency>\n 91  \t\t\t<groupId>org.springframework</groupId>\n 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>"
@@ -132,6 +144,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
           matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
         codeSnip: " 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>"
@@ -140,6 +153,7 @@
           data: dependency
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
         codeSnip: " 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>"
@@ -148,6 +162,7 @@
           data: dependency
           innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
           matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
         codeSnip: "103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>"
@@ -156,6 +171,7 @@
           data: dependency
           innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
           matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
         codeSnip: "108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>"
@@ -164,6 +180,7 @@
           data: dependency
           innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
           matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
         codeSnip: "113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>"
@@ -172,6 +189,7 @@
           data: dependency
           innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
           matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
         codeSnip: "118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>"
@@ -180,6 +198,7 @@
           data: dependency
           innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
           matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
         codeSnip: "124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>\n139  \t<build>\n140  \t\t<plugins>\n141  \t\t\t<plugin>\n142  \t\t\t\t<groupId>org.apache.maven.plugins</groupId>\n143  \t\t\t\t<artifactId>maven-compiler-plugin</artifactId>\n144  \t\t\t\t<version>${maven-compiler-plugin.version}</version>"
@@ -188,6 +207,7 @@
           data: dependency
           innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
           matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: <groupId>io.quarkus</groupId><artifactId>quarkus-universe-bom</artifactId><version>${quarkus.version}</version><type>pom</type><scope>import</scope>
         codeSnip: "19      <maven.compiler.target>11</maven.compiler.target>\n20      <quarkus.version>1.10.5.Final</quarkus.version>\n21      <compiler-plugin.version>3.8.1</compiler-plugin.version>\n22      <maven.compiler.parameters>true</maven.compiler.parameters>\n23    </properties>\n24  \n25    <dependencyManagement>\n26      <dependencies>\n27        <dependency>\n28          <groupId>io.quarkus</groupId>\n29          <artifactId>quarkus-universe-bom</artifactId>\n30          <version>${quarkus.version}</version>\n31          <type>pom</type>\n32          <scope>import</scope>\n33        </dependency>\n34      </dependencies>\n35    </dependencyManagement>\n36  \n37    <dependencies>\n38      <dependency>\n39        <groupId>io.javaoperatorsdk</groupId>"
@@ -196,6 +216,7 @@
           data: dependency
           innerText: "\n        io.quarkus\n        quarkus-universe-bom\n        ${quarkus.version}\n        pom\n        import\n      "
           matchingXML: <groupId>io.quarkus</groupId><artifactId>quarkus-universe-bom</artifactId><version>${quarkus.version}</version><type>pom</type><scope>import</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: <groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-quarkus-extension</artifactId><version>${project.version}</version>
         codeSnip: "30          <version>${quarkus.version}</version>\n31          <type>pom</type>\n32          <scope>import</scope>\n33        </dependency>\n34      </dependencies>\n35    </dependencyManagement>\n36  \n37    <dependencies>\n38      <dependency>\n39        <groupId>io.javaoperatorsdk</groupId>\n40        <artifactId>operator-framework-quarkus-extension</artifactId>\n41        <version>${project.version}</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>io.javaoperatorsdk</groupId>\n45        <artifactId>operator-framework-samples-common</artifactId>\n46        <version>${project.version}</version>\n47      </dependency>\n48    </dependencies>\n49  \n50    <build>"
@@ -204,6 +225,7 @@
           data: dependency
           innerText: "\n      io.javaoperatorsdk\n      operator-framework-quarkus-extension\n      ${project.version}\n    "
           matchingXML: <groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-quarkus-extension</artifactId><version>${project.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: <groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-samples-common</artifactId><version>${project.version}</version>
         codeSnip: "35    </dependencyManagement>\n36  \n37    <dependencies>\n38      <dependency>\n39        <groupId>io.javaoperatorsdk</groupId>\n40        <artifactId>operator-framework-quarkus-extension</artifactId>\n41        <version>${project.version}</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>io.javaoperatorsdk</groupId>\n45        <artifactId>operator-framework-samples-common</artifactId>\n46        <version>${project.version}</version>\n47      </dependency>\n48    </dependencies>\n49  \n50    <build>\n51      <plugins>\n52        <plugin>\n53          <groupId>org.apache.maven.plugins</groupId>\n54          <artifactId>maven-compiler-plugin</artifactId>\n55          <version>${compiler-plugin.version}</version>"
@@ -212,6 +234,7 @@
           data: dependency
           innerText: "\n      io.javaoperatorsdk\n      operator-framework-samples-common\n      ${project.version}\n    "
           matchingXML: <groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-samples-common</artifactId><version>${project.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/dummy/pom.xml
         message: |-
           <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
@@ -223,6 +246,7 @@
           matchingXML: |-
             <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
                              as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/pom.xml
         message: |-
           <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
@@ -234,6 +258,7 @@
           matchingXML: |-
             <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
                              as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
         codeSnip: "20    <properties>\n21      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n22      <maven.compiler.source>1.7</maven.compiler.source>\n23      <maven.compiler.target>1.7</maven.compiler.target>\n24      <javaee-api.version>7.0</javaee-api.version>\n25    </properties>\n26  \n27    <dependencies>\n28      <dependency>\n29        <groupId>junit</groupId>\n30        <artifactId>junit</artifactId>\n31        <version>4.11</version>\n32        <scope>test</scope>\n33      </dependency>\n34      <dependency>\n35        <groupId>io.fabric8</groupId>\n36        <artifactId>kubernetes-client</artifactId>\n37        <version>6.0.0</version>\n38      </dependency>\n39      <dependency>\n40        <groupId>io.fabric8</groupId>"
@@ -242,6 +267,7 @@
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
           matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
         codeSnip: "26  \n27    <dependencies>\n28      <dependency>\n29        <groupId>junit</groupId>\n30        <artifactId>junit</artifactId>\n31        <version>4.11</version>\n32        <scope>test</scope>\n33      </dependency>\n34      <dependency>\n35        <groupId>io.fabric8</groupId>\n36        <artifactId>kubernetes-client</artifactId>\n37        <version>6.0.0</version>\n38      </dependency>\n39      <dependency>\n40        <groupId>io.fabric8</groupId>\n41        <artifactId>kubernetes-client-api</artifactId>\n42        <version>6.0.0</version>\n43      </dependency>\n44      <dependency>\n45        <groupId>javax</groupId>\n46        <artifactId>javaee-api</artifactId>"
@@ -250,6 +276,7 @@
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
         codeSnip: |-
@@ -279,6 +306,7 @@
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>
         codeSnip: |-
@@ -308,6 +336,7 @@
           data: dependency
           innerText: "\n      javax\n      javaee-api\n      ${javaee-api.version}\n      provided\n    "
           matchingXML: <groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
         codeSnip: "43      </dependency>\n44      <dependency>\n45        <groupId>javax</groupId>\n46        <artifactId>javaee-api</artifactId>\n47        <version>${javaee-api.version}</version>\n48        <scope>provided</scope>\n49      </dependency>\n50      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->\n51      <dependency>\n52        <groupId>io.netty</groupId>\n53        <artifactId>netty-transport-native-epoll</artifactId>\n54        <version>4.1.76.Final</version>\n55        <classifier>linux-x86_64</classifier>\n56        <scope>runtime</scope>\n57      </dependency>\n58    </dependencies>\n59  \n60    <build>\n61      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n62        <plugins>\n63          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->"
@@ -316,6 +345,7 @@
           data: dependency
           innerText: "\n      io.netty\n      netty-transport-native-epoll\n      4.1.76.Final\n      linux-x86_64\n      runtime\n    "
           matchingXML: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
+        isDependencyIncident: false
       effort: 1
     dotnet-deprecated-001:
       description: ""
@@ -351,6 +381,7 @@
           fqdn_namespace: System
           symbol: Console.WriteLine
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/c-sharp-dummy-example/Program.cs
         message: System.Net.WebClient found. Consider replacing with System.Net.Http.HttpClient.
         codeSnip: |
@@ -377,6 +408,7 @@
           fqdn_namespace: System
           symbol: Console.WriteLine
           syntax_type: method_reference
+        isDependencyIncident: false
       effort: 2
     file-001:
       description: Testing that we can get all the go files in the project
@@ -387,8 +419,10 @@
       incidents:
       - uri: file:///analyzer-lsp/examples/golang/dummy/test_functions.go
         message: all go files
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/main.go
         message: all go files
+        isDependencyIncident: false
       links:
       - url: https://go.dev
         title: Golang
@@ -403,6 +437,7 @@
         lineNumber: 5
         variables:
           matchingText: FROM maven:3.8-openjdk-11 as build
+        isDependencyIncident: false
       effort: 1
     jboss-eap5-7-xml-02000:
       description: ""
@@ -414,6 +449,7 @@
           data: module
           innerText: "\n        jboss-example-service\n    "
           matchingXML: <service>jboss-example-service</service>
+        isDependencyIncident: false
       effort: 1
     lang-ref-001:
       description: ""
@@ -425,6 +461,7 @@
         lineNumber: 11
         variables:
           file: file:///analyzer-lsp/examples/golang/main.go
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/src/main/java/com/example/apps/App.java
         message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
         codeSnip: "\n 1  package com.example.apps;\n 2  \n 3  import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;\n 4  \n 5  public class App\n 6  {\n 7  \n 8  /**\n 9  * {@link CustomResourceDefinition}\n10  * @param args\n11  */\n12  public static void main( String[] args )\n13  {"
@@ -434,6 +471,7 @@
           kind: Module
           name: io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition
           package: com.example.apps
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/src/main/java/com/example/apps/App.java
         message: apiextensions/v1beta1/customresourcedefinitions is deprecated, apiextensions/v1/customresourcedefinitions should be used instead
         codeSnip: "\n 4  \n 5  public class App\n 6  {\n 7  \n 8  /**\n 9  * {@link CustomResourceDefinition}\n10  * @param args\n11  */\n12  public static void main( String[] args )\n13  {\n14  CustomResourceDefinition crd = new CustomResourceDefinition();\n15  System.out.println( crd );\n16  \n17  GenericClass<String> element = new GenericClass<String>(\"Hello world!\");\n18  element.get();\n19  }\n20  }"
@@ -443,6 +481,7 @@
           kind: Method
           name: main
           package: com.example.apps
+        isDependencyIncident: false
       effort: 1
     test-regex-pattern-00000:
       description: Test regex pattern for TypeScript/JavaScript files
@@ -454,30 +493,35 @@
         lineNumber: 1
         variables:
           matchingText: React
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/Component.tsx
         message: Found React reference using regex pattern
         codeSnip: " 1  import React from 'react';\n 2  \n 3  export const MyComponent: React.FC = () => {\n 4    return <div>Hello from TypeScript React</div>;\n 5  };\n"
         lineNumber: 3
         variables:
           matchingText: React
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/Component.tsx
         message: Found React reference using regex pattern
         codeSnip: " 1  import React from 'react';\n 2  \n 3  export const MyComponent: React.FC = () => {\n 4    return <div>Hello from TypeScript React</div>;\n 5  };\n"
         lineNumber: 4
         variables:
           matchingText: React
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/LegacyComponent.jsx
         message: Found React reference using regex pattern
         codeSnip: " 1  import React from 'react';\n 2  \n 3  export const LegacyComponent = () => {\n 4    return <div>Hello from JavaScript React</div>;\n 5  };\n"
         lineNumber: 1
         variables:
           matchingText: React
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/LegacyComponent.jsx
         message: Found React reference using regex pattern
         codeSnip: " 1  import React from 'react';\n 2  \n 3  export const LegacyComponent = () => {\n 4    return <div>Hello from JavaScript React</div>;\n 5  };\n"
         lineNumber: 4
         variables:
           matchingText: React
+          isDependencyIncident: false
       effort: 1
     test-regex-pattern-00010:
       description: Test regex pattern for CSS/SCSS files
@@ -493,6 +537,7 @@
         lineNumber: 2
         variables:
           matchingText: --pf-
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/styles.css
         message: Found PatternFly CSS variable using regex pattern
         codeSnip: |2
@@ -503,6 +548,7 @@
         lineNumber: 3
         variables:
           matchingText: --pf-
+        isDependencyIncident: false
       effort: 1
     test-tsx-support-00000:
       description: Test that .tsx files are scanned (builtin provider)
@@ -514,6 +560,7 @@
         lineNumber: 1
         variables:
           matchingText: import React
+        isDependencyIncident: false
       effort: 1
     xml-pom-001:
       description: ""
@@ -527,6 +574,7 @@
           data: dependency
           innerText: "\n\t\t\t\tcom.fasterxml.jackson\n\t\t\t\tjackson-bom\n\t\t\t\t${jackson.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
           matchingXML: <groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>'
         codeSnip: "43  \t\t<dependencies>\n44  \t\t\t<dependency>\n45  \t\t\t\t<groupId>com.fasterxml.jackson</groupId>\n46  \t\t\t\t<artifactId>jackson-bom</artifactId>\n47  \t\t\t\t<version>${jackson.version}</version>\n48  \t\t\t\t<scope>import</scope>\n49  \t\t\t\t<type>pom</type>\n50  \t\t\t</dependency>\n51  \t\t\t<dependency>\n52  \t\t\t\t<groupId>org.springframework.data</groupId>\n53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>"
@@ -535,6 +583,7 @@
           data: dependency
           innerText: "\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t"
           matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>'
         codeSnip: "53  \t\t\t\t<artifactId>spring-data-bom</artifactId>\n54  \t\t\t\t<version>${spring-data.version}</version>\n55  \t\t\t\t<scope>import</scope>\n56  \t\t\t\t<type>pom</type>\n57  \t\t\t</dependency>\n58  \t\t</dependencies>\n59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>"
@@ -543,6 +592,7 @@
           data: dependency
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-servlet-api\n\t\t\t${tomcat.version}\n\t\t\tprovided\n\t\t"
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>'
         codeSnip: "59  \t</dependencyManagement>\n60  \t<dependencies>\n61  \t\t<dependency>\n62  \t\t\t<groupId>org.apache.tomcat</groupId>\n63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  "
@@ -551,6 +601,7 @@
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t"
           matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>'
         codeSnip: "63  \t\t\t<artifactId>tomcat-servlet-api</artifactId>\n64  \t\t\t<version>${tomcat.version}</version>\n65  \t\t\t<scope>provided</scope>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>"
@@ -559,6 +610,7 @@
           data: dependency
           innerText: "\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t"
           matchingXML: <groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId>'
         codeSnip: "67  \t\t<dependency>\n68  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n69  \t\t\t<artifactId>jackson-core</artifactId>\n70  \t\t</dependency>\n71  \t\t<dependency>\n72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>"
@@ -567,6 +619,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework.data\n\t\t\tspring-data-jpa\n\t\t"
           matchingXML: <groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>'
         codeSnip: "72  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n73  \t\t\t<artifactId>jackson-databind</artifactId>\n74  \t\t</dependency>\n75  \t\t<dependency>\n76  \t\t\t<groupId>org.springframework.data</groupId>\n77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>"
@@ -575,6 +628,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-jdbc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>'
         codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
@@ -583,6 +637,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-web\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>'
         codeSnip: "77  \t\t\t<artifactId>spring-data-jpa</artifactId>\n78  \t\t</dependency>\n79  \n80  \t\t<dependency>\n81  \t\t\t<groupId>org.springframework</groupId>\n82  \t\t\t<artifactId>spring-jdbc</artifactId>\n83  \t\t\t<version>${spring-framework.version}</version>\n84  \t\t</dependency>\n85  \t\t<dependency>\n86  \t\t\t<groupId>org.springframework</groupId>\n87  \t\t\t<artifactId>spring-webmvc</artifactId>\n88  \t\t\t<version>${spring-framework.version}</version>\n89  \t\t</dependency>\n90  \t\t<dependency>\n91  \t\t\t<groupId>org.springframework</groupId>\n92  \t\t\t<artifactId>spring-web</artifactId>\n93  \t\t\t<version>${spring-framework.version}</version>\n94  \t\t</dependency>\n95  \t\t<dependency>\n96  \t\t\t<groupId>org.springframework.boot</groupId>\n97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
@@ -591,6 +646,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t"
           matchingXML: <groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>'
         codeSnip: " 87  \t\t\t<artifactId>spring-webmvc</artifactId>\n 88  \t\t\t<version>${spring-framework.version}</version>\n 89  \t\t</dependency>\n 90  \t\t<dependency>\n 91  \t\t\t<groupId>org.springframework</groupId>\n 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>"
@@ -599,6 +655,7 @@
           data: dependency
           innerText: "\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t"
           matchingXML: <groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>'
         codeSnip: " 92  \t\t\t<artifactId>spring-web</artifactId>\n 93  \t\t\t<version>${spring-framework.version}</version>\n 94  \t\t</dependency>\n 95  \t\t<dependency>\n 96  \t\t\t<groupId>org.springframework.boot</groupId>\n 97  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>"
@@ -607,6 +664,7 @@
           data: dependency
           innerText: "\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t"
           matchingXML: <groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>'
         codeSnip: " 98  \t\t\t<version>2.5.0</version>\n 99  \t\t</dependency>\n100  \t\t<dependency>\n101  \t\t\t<groupId>org.apache.tomcat</groupId>\n102  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>"
@@ -615,6 +673,7 @@
           data: dependency
           innerText: "\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t"
           matchingXML: <groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>'
         codeSnip: "103  \t\t\t<version>${tomcat.version}</version>\n104  \t\t\t<scope>runtime</scope>\n105  \t\t</dependency>\n106  \t\t<dependency>\n107  \t\t\t<groupId>org.hibernate</groupId>\n108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>"
@@ -623,6 +682,7 @@
           data: dependency
           innerText: "\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t"
           matchingXML: <groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>'
         codeSnip: "108  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n109  \t\t\t<version>${hibernate.version}</version>\n110  \t\t</dependency>\n111  \t\t<dependency>\n112  \t\t\t<groupId>org.hibernate.validator</groupId>\n113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>"
@@ -631,6 +691,7 @@
           data: dependency
           innerText: "\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t"
           matchingXML: <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>'
         codeSnip: "113  \t\t\t<artifactId>hibernate-validator</artifactId>\n114  \t\t\t<version>${hibernate-validator.version}</version>\n115  \t\t</dependency>\n116  \t\t<dependency>\n117  \t\t\t<groupId>ch.qos.logback</groupId>\n118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>"
@@ -639,6 +700,7 @@
           data: dependency
           innerText: "\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc8\n\t\t\t21.1.0.0\n\t\t"
           matchingXML: <groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc8</artifactId><version>21.1.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>'
         codeSnip: "118  \t\t\t<artifactId>logback-classic</artifactId>\n119  \t\t\t<version>1.1.7</version>\n120  \t\t</dependency>\n121  \t\t<dependency>\n122  \t\t\t<groupId>com.oracle.database.jdbc</groupId>\n123  \t\t\t<artifactId>ojdbc8</artifactId>\n124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>"
@@ -647,6 +709,7 @@
           data: dependency
           innerText: "\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t"
           matchingXML: <groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: POM XML dependencies - '<groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>'
         codeSnip: "124  \t\t\t<version>21.1.0.0</version>\n125  \t\t</dependency>\n126  \t\t<dependency>\n127  \t\t\t<groupId>org.postgresql</groupId>\n128  \t\t\t<artifactId>postgresql</artifactId>\n129  \t\t\t<version>42.2.23</version>\n130  \t\t</dependency>\n131  \t\t<!-- Corporate libraries -->\n132  \t\t<dependency>\n133  \t\t\t<groupId>io.konveyor.demo</groupId>\n134  \t\t\t<artifactId>config-utils</artifactId>\n135  \t\t\t<version>1.0.0</version>\n136  \t\t</dependency>\n137  \n138  \t</dependencies>\n139  \t<build>\n140  \t\t<plugins>\n141  \t\t\t<plugin>\n142  \t\t\t\t<groupId>org.apache.maven.plugins</groupId>\n143  \t\t\t\t<artifactId>maven-compiler-plugin</artifactId>\n144  \t\t\t\t<version>${maven-compiler-plugin.version}</version>"
@@ -655,6 +718,7 @@
           data: dependency
           innerText: "\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t"
           matchingXML: <groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: POM XML dependencies - '<groupId>io.quarkus</groupId><artifactId>quarkus-universe-bom</artifactId><version>${quarkus.version}</version><type>pom</type><scope>import</scope>'
         codeSnip: "19      <maven.compiler.target>11</maven.compiler.target>\n20      <quarkus.version>1.10.5.Final</quarkus.version>\n21      <compiler-plugin.version>3.8.1</compiler-plugin.version>\n22      <maven.compiler.parameters>true</maven.compiler.parameters>\n23    </properties>\n24  \n25    <dependencyManagement>\n26      <dependencies>\n27        <dependency>\n28          <groupId>io.quarkus</groupId>\n29          <artifactId>quarkus-universe-bom</artifactId>\n30          <version>${quarkus.version}</version>\n31          <type>pom</type>\n32          <scope>import</scope>\n33        </dependency>\n34      </dependencies>\n35    </dependencyManagement>\n36  \n37    <dependencies>\n38      <dependency>\n39        <groupId>io.javaoperatorsdk</groupId>"
@@ -663,6 +727,7 @@
           data: dependency
           innerText: "\n        io.quarkus\n        quarkus-universe-bom\n        ${quarkus.version}\n        pom\n        import\n      "
           matchingXML: <groupId>io.quarkus</groupId><artifactId>quarkus-universe-bom</artifactId><version>${quarkus.version}</version><type>pom</type><scope>import</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: POM XML dependencies - '<groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-quarkus-extension</artifactId><version>${project.version}</version>'
         codeSnip: "30          <version>${quarkus.version}</version>\n31          <type>pom</type>\n32          <scope>import</scope>\n33        </dependency>\n34      </dependencies>\n35    </dependencyManagement>\n36  \n37    <dependencies>\n38      <dependency>\n39        <groupId>io.javaoperatorsdk</groupId>\n40        <artifactId>operator-framework-quarkus-extension</artifactId>\n41        <version>${project.version}</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>io.javaoperatorsdk</groupId>\n45        <artifactId>operator-framework-samples-common</artifactId>\n46        <version>${project.version}</version>\n47      </dependency>\n48    </dependencies>\n49  \n50    <build>"
@@ -671,6 +736,7 @@
           data: dependency
           innerText: "\n      io.javaoperatorsdk\n      operator-framework-quarkus-extension\n      ${project.version}\n    "
           matchingXML: <groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-quarkus-extension</artifactId><version>${project.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: POM XML dependencies - '<groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-samples-common</artifactId><version>${project.version}</version>'
         codeSnip: "35    </dependencyManagement>\n36  \n37    <dependencies>\n38      <dependency>\n39        <groupId>io.javaoperatorsdk</groupId>\n40        <artifactId>operator-framework-quarkus-extension</artifactId>\n41        <version>${project.version}</version>\n42      </dependency>\n43      <dependency>\n44        <groupId>io.javaoperatorsdk</groupId>\n45        <artifactId>operator-framework-samples-common</artifactId>\n46        <version>${project.version}</version>\n47      </dependency>\n48    </dependencies>\n49  \n50    <build>\n51      <plugins>\n52        <plugin>\n53          <groupId>org.apache.maven.plugins</groupId>\n54          <artifactId>maven-compiler-plugin</artifactId>\n55          <version>${compiler-plugin.version}</version>"
@@ -679,6 +745,7 @@
           data: dependency
           innerText: "\n      io.javaoperatorsdk\n      operator-framework-samples-common\n      ${project.version}\n    "
           matchingXML: <groupId>io.javaoperatorsdk</groupId><artifactId>operator-framework-samples-common</artifactId><version>${project.version}</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/dummy/pom.xml
         message: |-
           POM XML dependencies - '<groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
@@ -690,6 +757,7 @@
           matchingXML: |-
             <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
                              as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/pom.xml
         message: |-
           POM XML dependencies - '<groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
@@ -701,6 +769,7 @@
           matchingXML: |-
             <groupId>javax</groupId><artifactId>javaee-api</artifactId><!-- This leads to https://github.com/konveyor/analyzer-lsp/issues/390
                              as the property cannot be resolved here but only in the parent POM --><version>${javaee-api.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>'
         codeSnip: "20    <properties>\n21      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n22      <maven.compiler.source>1.7</maven.compiler.source>\n23      <maven.compiler.target>1.7</maven.compiler.target>\n24      <javaee-api.version>7.0</javaee-api.version>\n25    </properties>\n26  \n27    <dependencies>\n28      <dependency>\n29        <groupId>junit</groupId>\n30        <artifactId>junit</artifactId>\n31        <version>4.11</version>\n32        <scope>test</scope>\n33      </dependency>\n34      <dependency>\n35        <groupId>io.fabric8</groupId>\n36        <artifactId>kubernetes-client</artifactId>\n37        <version>6.0.0</version>\n38      </dependency>\n39      <dependency>\n40        <groupId>io.fabric8</groupId>"
@@ -709,6 +778,7 @@
           data: dependency
           innerText: "\n      junit\n      junit\n      4.11\n      test\n    "
           matchingXML: <groupId>junit</groupId><artifactId>junit</artifactId><version>4.11</version><scope>test</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>'
         codeSnip: "26  \n27    <dependencies>\n28      <dependency>\n29        <groupId>junit</groupId>\n30        <artifactId>junit</artifactId>\n31        <version>4.11</version>\n32        <scope>test</scope>\n33      </dependency>\n34      <dependency>\n35        <groupId>io.fabric8</groupId>\n36        <artifactId>kubernetes-client</artifactId>\n37        <version>6.0.0</version>\n38      </dependency>\n39      <dependency>\n40        <groupId>io.fabric8</groupId>\n41        <artifactId>kubernetes-client-api</artifactId>\n42        <version>6.0.0</version>\n43      </dependency>\n44      <dependency>\n45        <groupId>javax</groupId>\n46        <artifactId>javaee-api</artifactId>"
@@ -717,6 +787,7 @@
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client</artifactId><version>6.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>'
         codeSnip: |-
@@ -746,6 +817,7 @@
           data: dependency
           innerText: "\n      io.fabric8\n      kubernetes-client-api\n      6.0.0\n    "
           matchingXML: <groupId>io.fabric8</groupId><artifactId>kubernetes-client-api</artifactId><version>6.0.0</version>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>'
         codeSnip: |-
@@ -775,6 +847,7 @@
           data: dependency
           innerText: "\n      javax\n      javaee-api\n      ${javaee-api.version}\n      provided\n    "
           matchingXML: <groupId>javax</groupId><artifactId>javaee-api</artifactId><version>${javaee-api.version}</version><scope>provided</scope>
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: POM XML dependencies - '<groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>'
         codeSnip: "43      </dependency>\n44      <dependency>\n45        <groupId>javax</groupId>\n46        <artifactId>javaee-api</artifactId>\n47        <version>${javaee-api.version}</version>\n48        <scope>provided</scope>\n49      </dependency>\n50      <!-- This currently leads to https://github.com/konveyor/analyzer-lsp/issues/392 -->\n51      <dependency>\n52        <groupId>io.netty</groupId>\n53        <artifactId>netty-transport-native-epoll</artifactId>\n54        <version>4.1.76.Final</version>\n55        <classifier>linux-x86_64</classifier>\n56        <scope>runtime</scope>\n57      </dependency>\n58    </dependencies>\n59  \n60    <build>\n61      <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->\n62        <plugins>\n63          <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->"
@@ -783,6 +856,7 @@
           data: dependency
           innerText: "\n      io.netty\n      netty-transport-native-epoll\n      4.1.76.Final\n      linux-x86_64\n      runtime\n    "
           matchingXML: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
+        isDependencyIncident: false
       effort: 1
     xml-test-key-match:
       description: Test code snippets when match is a key of a XML node
@@ -797,6 +871,7 @@
           innerText: |2+
 
           matchingXML: ""
+        isDependencyIncident: false
       effort: 1
   insights:
     multiple-actions-001:

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -884,6 +884,7 @@
         variables:
           tags:
           - Golang
+        isDependencyIncident: false
     tag-go-000:
       description: ""
       labels:
@@ -891,6 +892,7 @@
       incidents:
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: ""
+        isDependencyIncident: false
     tag-java-000:
       description: ""
       labels:
@@ -898,18 +900,25 @@
       incidents:
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/pom.xml
         message: ""
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/gradle-multi-project-example/gradle/wrapper/gradle-wrapper.jar
         message: ""
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/inclusion-tests/pom.xml
         message: ""
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/pom.xml
         message: ""
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/dummy/pom.xml
         message: ""
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/pom.xml
         message: ""
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: ""
+        isDependencyIncident: false
     tag-k8s-000:
       description: ""
       labels:
@@ -921,36 +930,42 @@
         lineNumber: 5
         variables:
           matchingText: require k8s.io/apiextensions-apiserver v0.24.4
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: ""
         codeSnip: " 9  \tgithub.com/gogo/protobuf v1.3.2 // indirect\n10  \tgithub.com/google/gofuzz v1.1.0 // indirect\n11  \tgithub.com/json-iterator/go v1.1.12 // indirect\n12  \tgithub.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect\n13  \tgithub.com/modern-go/reflect2 v1.0.2 // indirect\n14  \tgolang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect\n15  \tgolang.org/x/text v0.3.7 // indirect\n16  \tgopkg.in/inf.v0 v0.9.1 // indirect\n17  \tgopkg.in/yaml.v2 v2.4.0 // indirect\n18  \tk8s.io/apimachinery v0.24.4 // indirect\n19  \tk8s.io/klog/v2 v2.60.1 // indirect\n20  \tk8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect\n21  \tsigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect\n22  \tsigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect\n23  )\n"
         lineNumber: 18
         variables:
           matchingText: "\tk8s.io/apimachinery v0.24.4 // indirect"
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: ""
         codeSnip: "10  \tgithub.com/google/gofuzz v1.1.0 // indirect\n11  \tgithub.com/json-iterator/go v1.1.12 // indirect\n12  \tgithub.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect\n13  \tgithub.com/modern-go/reflect2 v1.0.2 // indirect\n14  \tgolang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect\n15  \tgolang.org/x/text v0.3.7 // indirect\n16  \tgopkg.in/inf.v0 v0.9.1 // indirect\n17  \tgopkg.in/yaml.v2 v2.4.0 // indirect\n18  \tk8s.io/apimachinery v0.24.4 // indirect\n19  \tk8s.io/klog/v2 v2.60.1 // indirect\n20  \tk8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect\n21  \tsigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect\n22  \tsigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect\n23  )\n"
         lineNumber: 19
         variables:
           matchingText: "\tk8s.io/klog/v2 v2.60.1 // indirect"
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: ""
         codeSnip: "11  \tgithub.com/json-iterator/go v1.1.12 // indirect\n12  \tgithub.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect\n13  \tgithub.com/modern-go/reflect2 v1.0.2 // indirect\n14  \tgolang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect\n15  \tgolang.org/x/text v0.3.7 // indirect\n16  \tgopkg.in/inf.v0 v0.9.1 // indirect\n17  \tgopkg.in/yaml.v2 v2.4.0 // indirect\n18  \tk8s.io/apimachinery v0.24.4 // indirect\n19  \tk8s.io/klog/v2 v2.60.1 // indirect\n20  \tk8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect\n21  \tsigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect\n22  \tsigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect\n23  )\n"
         lineNumber: 20
         variables:
           matchingText: "\tk8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect"
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: ""
         codeSnip: "12  \tgithub.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect\n13  \tgithub.com/modern-go/reflect2 v1.0.2 // indirect\n14  \tgolang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect\n15  \tgolang.org/x/text v0.3.7 // indirect\n16  \tgopkg.in/inf.v0 v0.9.1 // indirect\n17  \tgopkg.in/yaml.v2 v2.4.0 // indirect\n18  \tk8s.io/apimachinery v0.24.4 // indirect\n19  \tk8s.io/klog/v2 v2.60.1 // indirect\n20  \tk8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect\n21  \tsigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect\n22  \tsigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect\n23  )\n"
         lineNumber: 21
         variables:
           matchingText: "\tsigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect"
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: ""
         codeSnip: "13  \tgithub.com/modern-go/reflect2 v1.0.2 // indirect\n14  \tgolang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect\n15  \tgolang.org/x/text v0.3.7 // indirect\n16  \tgopkg.in/inf.v0 v0.9.1 // indirect\n17  \tgopkg.in/yaml.v2 v2.4.0 // indirect\n18  \tk8s.io/apimachinery v0.24.4 // indirect\n19  \tk8s.io/klog/v2 v2.60.1 // indirect\n20  \tk8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect\n21  \tsigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect\n22  \tsigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect\n23  )\n"
         lineNumber: 22
         variables:
           matchingText: "\tsigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect"
+        isDependencyIncident: false
     tag-license:
       description: ""
       labels:
@@ -977,42 +992,49 @@
         lineNumber: 4
         variables:
           matchingText: Apache
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/LICENSE
         message: ""
         codeSnip: " 1                                   Apache License\n 2                             Version 2.0, January 2004\n 3                          http://www.apache.org/licenses/\n 4  \n 5     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n 6  \n 7     1. Definitions.\n 8  \n 9        \"License\" shall mean the terms and conditions for use, reproduction,\n10        and distribution as defined by Sections 1 through 9 of this document.\n11  \n12        \"Licensor\" shall mean the copyright owner or entity authorized by"
         lineNumber: 1
         variables:
           matchingText: Apache
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/LICENSE
         message: ""
         codeSnip: "169        License. However, in accepting such obligations, You may act only\n170        on Your own behalf and on Your sole responsibility, not on behalf\n171        of any other Contributor, and only if You agree to indemnify,\n172        defend, and hold each Contributor harmless for any liability\n173        incurred by, or claims asserted against, such Contributor by reason\n174        of your accepting any such warranty or additional liability.\n175  \n176     END OF TERMS AND CONDITIONS\n177  \n178     APPENDIX: How to apply the Apache License to your work.\n179  \n180        To apply the Apache License to your work, attach the following\n181        boilerplate notice, with the fields enclosed by brackets \"[]\"\n182        replaced with your own identifying information. (Don't include\n183        the brackets!)  The text should be enclosed in the appropriate\n184        comment syntax for the file format. We also recommend that a\n185        file or class name and description of purpose be included on the\n186        same \"printed page\" as the copyright notice for easier\n187        identification within third-party archives.\n188  \n189     Copyright [yyyy] [name of copyright owner]"
         lineNumber: 178
         variables:
           matchingText: Apache
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/LICENSE
         message: ""
         codeSnip: "171        of any other Contributor, and only if You agree to indemnify,\n172        defend, and hold each Contributor harmless for any liability\n173        incurred by, or claims asserted against, such Contributor by reason\n174        of your accepting any such warranty or additional liability.\n175  \n176     END OF TERMS AND CONDITIONS\n177  \n178     APPENDIX: How to apply the Apache License to your work.\n179  \n180        To apply the Apache License to your work, attach the following\n181        boilerplate notice, with the fields enclosed by brackets \"[]\"\n182        replaced with your own identifying information. (Don't include\n183        the brackets!)  The text should be enclosed in the appropriate\n184        comment syntax for the file format. We also recommend that a\n185        file or class name and description of purpose be included on the\n186        same \"printed page\" as the copyright notice for easier\n187        identification within third-party archives.\n188  \n189     Copyright [yyyy] [name of copyright owner]\n190  \n191     Licensed under the Apache License, Version 2.0 (the \"License\");"
         lineNumber: 180
         variables:
           matchingText: Apache
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/LICENSE
         message: ""
         codeSnip: "182        replaced with your own identifying information. (Don't include\n183        the brackets!)  The text should be enclosed in the appropriate\n184        comment syntax for the file format. We also recommend that a\n185        file or class name and description of purpose be included on the\n186        same \"printed page\" as the copyright notice for easier\n187        identification within third-party archives.\n188  \n189     Copyright [yyyy] [name of copyright owner]\n190  \n191     Licensed under the Apache License, Version 2.0 (the \"License\");\n192     you may not use this file except in compliance with the License.\n193     You may obtain a copy of the License at\n194  \n195         http://www.apache.org/licenses/LICENSE-2.0\n196  \n197     Unless required by applicable law or agreed to in writing, software\n198     distributed under the License is distributed on an \"AS IS\" BASIS,\n199     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n200     See the License for the specific language governing permissions and\n201     limitations under the License.\n"
         lineNumber: 191
         variables:
           matchingText: Apache
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/META-INF/MANIFEST.MF
         message: ""
         codeSnip: " 1  Manifest-Version: 1.0\n 2  Archiver-Version: Plexus Archiver\n 3  Created-By: Apache Maven 3.6.3\n 4  Built-By: runner\n 5  Build-Jdk: 11.0.9\n 6  \n"
         lineNumber: 3
         variables:
           matchingText: Apache
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/beans.xml
         message: ""
         codeSnip: " 1  <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n 2  <!-- \n 3   * (C) Copyright IBM Corporation 2015.\n 4   *\n 5   * Licensed under the Apache License, Version 2.0 (the \"License\");\n 6   * you may not use this file except in compliance with the License.\n 7   * You may obtain a copy of the License at\n 8   *\n 9   * http://www.apache.org/licenses/LICENSE-2.0\n10   *\n11   * Unless required by applicable law or agreed to in writing, software\n12   * distributed under the License is distributed on an \"AS IS\" BASIS,\n13   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n14   * See the License for the specific language governing permissions and\n15   * limitations under the License.\n16  -->"
         lineNumber: 5
         variables:
           matchingText: Apache
+        isDependencyIncident: false
     tech-tag-001:
       description: ""
       category: potential
@@ -1024,12 +1046,14 @@
           tags:
           - Golang
           - Kubernetes
+        isDependencyIncident: false
       - uri: ""
         message: Tags [Java] found
         lineNumber: 0
         variables:
           tags:
           - Java
+        isDependencyIncident: false
   errors:
     error-rule-001: |-
       unable to get query info: yaml: unmarshal errors:

--- a/engine/conditions.go
+++ b/engine/conditions.go
@@ -49,12 +49,13 @@ type ConditionEntry struct {
 }
 
 type IncidentContext struct {
-	FileURI      uri.URI                `yaml:"fileURI"`
-	Effort       *int                   `yaml:"effort"`
-	LineNumber   *int                   `yaml:"lineNumber,omitempty"`
-	Variables    map[string]interface{} `yaml:"variables"`
-	Links        []konveyor.Link        `yaml:"externalLink"`
-	CodeLocation *Location              `yaml:"location,omitempty"`
+	FileURI              uri.URI                `yaml:"fileURI"`
+	Effort               *int                   `yaml:"effort"`
+	LineNumber           *int                   `yaml:"lineNumber,omitempty"`
+	Variables            map[string]interface{} `yaml:"variables"`
+	Links                []konveyor.Link        `yaml:"externalLink"`
+	CodeLocation         *Location              `yaml:"location,omitempty"`
+	IsDependencyIncident bool
 }
 
 type Location struct {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -644,7 +644,8 @@ func (r *ruleEngine) createViolation(ctx context.Context, conditionResponse Cond
 			LineNumber: m.LineNumber,
 			// This allows us to change m.Variables and it will be set
 			// because it is a pointer.
-			Variables: m.Variables,
+			Variables:            m.Variables,
+			IsDependencyIncident: m.IsDependencyIncident,
 		}
 		if m.LineNumber != nil {
 			lineNumber := *m.LineNumber

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1677,6 +1677,58 @@ func TestCreateViolation(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "dependency incident propagation",
+			setupFunc: func(t *testing.T) (*ruleEngine, ConditionResponse, Rule, func()) {
+				ruleEngine := CreateRuleEngine(ctx, 10, log).(*ruleEngine)
+				lineNum1, lineNum2 := 10, 20
+				msg := "Test violation"
+				conditionResponse := ConditionResponse{
+					Matched: true,
+					Incidents: []IncidentContext{
+						{
+							FileURI:              "file:///app/src/main/MyClass.java",
+							LineNumber:           &lineNum1,
+							Variables:            map[string]any{},
+							IsDependencyIncident: false, // application code
+						},
+						{
+							FileURI:              "konveyor-jdt://contents/org/springframework/core/SpringVersion.class?packageName=org.springframework.core.SpringVersion&source-range=true",
+							LineNumber:           &lineNum2,
+							Variables:            map[string]any{},
+							IsDependencyIncident: true, // dependency code
+						},
+					},
+				}
+				rule := Rule{
+					RuleMeta: RuleMeta{
+						RuleID: "test-rule",
+					},
+					Perform: Perform{
+						Message: Message{
+							Text: &msg,
+						},
+					},
+				}
+				return ruleEngine, conditionResponse, rule, func() { ruleEngine.Stop() }
+			},
+			checkFunc: func(t *testing.T, violation konveyor.Violation, err error) {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if len(violation.Incidents) != 2 {
+					t.Fatalf("Expected 2 incidents, got %d", len(violation.Incidents))
+				}
+				// First incident should NOT be marked as from dependency
+				if violation.Incidents[0].IsDependencyIncident {
+					t.Errorf("Expected first incident (app code) to have IsDependencyIncident=false, got true")
+				}
+				// Second incident SHOULD be marked as from dependency
+				if !violation.Incidents[1].IsDependencyIncident {
+					t.Errorf("Expected second incident (dependency code) to have IsDependencyIncident=true, got false")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/external-providers/go-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/go-external-provider/e2e-tests/demo-output.yaml
@@ -10,6 +10,7 @@
         lineNumber: 11
         variables:
           file: file:///analyzer-lsp/examples/golang/main.go
+        isDependencyIncident: false
       effort: 1
     golang-gomod-dependencies:
       description: ""
@@ -21,16 +22,19 @@
         variables:
           name: golang.org/x/text
           version: v0.3.7
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: dependency k8s.io/apimachinery with v0.24.4 is bad and you should feel bad for using it
         lineNumber: 0
         variables:
           name: k8s.io/apimachinery
           version: v0.24.4
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/golang/go.mod
         message: dependency sigs.k8s.io/structured-merge-diff/v4 with v4.2.1 is bad and you should feel bad for using it
         lineNumber: 0
         variables:
           name: sigs.k8s.io/structured-merge-diff/v4
           version: v4.2.1
+        isDependencyIncident: false
       effort: 1

--- a/external-providers/java-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/java-external-provider/e2e-tests/demo-output.yaml
@@ -19,6 +19,7 @@
           kind: Class
           name: Bean
           package: com.example.apps
+          isDependencyIncident: false
       effort: 1
     java-gradle-project:
       description: |
@@ -34,6 +35,7 @@
           kind: Module
           name: com.sun.net.httpserver.HttpExchange
           package: io.jeffchao.template.server
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/gradle-multi-project-example/template-server/src/main/java/io/jeffchao/template/server/Server.java
         message: Only incidents in gradle project should appear
         codeSnip: "\n14  String portString = System.getenv(\"PORT\");\n15  int port = portString == null ? 8080 : Integer.valueOf(portString);\n16  HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);\n17  server.createContext(\"/\", new MyHandler());\n18  server.setExecutor(null); // creates a default executor\n19  server.start();\n20  }\n21  \n22  static class MyHandler implements HttpHandler {\n23  @Override\n24  public void handle(HttpExchange t) throws IOException {\n25  String response = \"Hello from Gradle!\";\n26  t.sendResponseHeaders(200, response.length());\n27  OutputStream os = t.getResponseBody();\n28  os.write(response.getBytes());\n29  os.close();\n30  }\n31  }\n32  }"
@@ -43,6 +45,7 @@
           kind: Method
           name: handle
           package: io.jeffchao.template.server
+        isDependencyIncident: false
       effort: 3
     java-inclusion-test:
       description: |
@@ -59,6 +62,7 @@
           kind: Class
           name: FileReader
           package: io.konveyor.util
+        isDependencyIncident: false
       effort: 3
     java-pomxml-dependencies:
       description: ""
@@ -71,6 +75,7 @@
         variables:
           name: junit.junit
           version: "4.12"
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency junit.junit with 4.11 is bad and you should feel bad for using it
         codeSnip: "\n20  <properties>\n21  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n22  <maven.compiler.source>1.7</maven.compiler.source>\n23  <maven.compiler.target>1.7</maven.compiler.target>\n24  <javaee-api.version>7.0</javaee-api.version>\n25  </properties>\n26  \n27  <dependencies>\n28  <dependency>\n29  <groupId>junit</groupId>\n30  <artifactId>junit</artifactId>\n31  <version>4.11</version>\n32  <scope>test</scope>\n33  </dependency>\n34  <dependency>\n35  <groupId>io.fabric8</groupId>\n36  <artifactId>kubernetes-client</artifactId>\n37  <version>6.0.0</version>\n38  </dependency>\n39  <dependency>\n40  <groupId>io.fabric8</groupId>"
@@ -78,6 +83,7 @@
         variables:
           name: junit.junit
           version: "4.11"
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/pom.xml
         message: dependency io.fabric8.kubernetes-client with 6.0.0 is bad and you should feel bad for using it
         codeSnip: "\n26  \n27  <dependencies>\n28  <dependency>\n29  <groupId>junit</groupId>\n30  <artifactId>junit</artifactId>\n31  <version>4.11</version>\n32  <scope>test</scope>\n33  </dependency>\n34  <dependency>\n35  <groupId>io.fabric8</groupId>\n36  <artifactId>kubernetes-client</artifactId>\n37  <version>6.0.0</version>\n38  </dependency>\n39  <dependency>\n40  <groupId>io.fabric8</groupId>\n41  <artifactId>kubernetes-client-api</artifactId>\n42  <version>6.0.0</version>\n43  </dependency>\n44  <dependency>\n45  <groupId>javax</groupId>\n46  <artifactId>javaee-api</artifactId>"
@@ -85,6 +91,7 @@
         variables:
           name: io.fabric8.kubernetes-client
           version: 6.0.0
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-1:
       description: PACKAGE match with stars
@@ -99,6 +106,7 @@
           kind: Module
           name: org.springframework.web.servlet.view.tiles3
           package: com.example.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: PACKAGE match with stars
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")"
@@ -108,6 +116,7 @@
           kind: Module
           name: org.springframework.web.servlet.view.tiles3
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-2:
       description: Exact PACKAGE match
@@ -122,6 +131,7 @@
           kind: Module
           name: org.springframework.web.servlet
           package: io.konveyor.demo.ordermanagement
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: Exact PACKAGE match
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")\n17  public TilesConfigurer tilesConfigurer() {"
@@ -131,6 +141,7 @@
           kind: Module
           name: org.springframework.web.servlet
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-3:
       description: Exact PACKAGE match with wildcard at the end
@@ -145,6 +156,7 @@
           kind: Module
           name: org.springframework.web.servlet
           package: io.konveyor.demo.ordermanagement
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: Exact PACKAGE match with wildcard at the end
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  "
@@ -154,6 +166,7 @@
           kind: Module
           name: org.springframework.web.servlet.view.tiles3
           package: com.example.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: Exact PACKAGE match with wildcard at the end
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")"
@@ -163,6 +176,7 @@
           kind: Module
           name: org.springframework.web.servlet.view.tiles3
           package: com.example.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: Exact PACKAGE match with wildcard at the end
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")\n17  public TilesConfigurer tilesConfigurer() {"
@@ -172,6 +186,7 @@
           kind: Module
           name: org.springframework.web.servlet
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-4:
       description: Exact IMPORT match
@@ -186,6 +201,7 @@
           kind: Module
           name: org.springframework.web.servlet.ViewResolver
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-6:
       description: IMPORT match with asterisk at the end (without dot)
@@ -200,6 +216,7 @@
           kind: Module
           name: org.springframework.web.servlet.DispatcherServlet
           package: io.konveyor.demo.ordermanagement
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: IMPORT match with asterisk at the end (without dot)
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  "
@@ -209,6 +226,7 @@
           kind: Module
           name: org.springframework.web.servlet.view.tiles3.TilesConfigurer
           package: com.example.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: IMPORT match with asterisk at the end (without dot)
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")"
@@ -218,6 +236,7 @@
           kind: Module
           name: org.springframework.web.servlet.view.tiles3.TilesViewResolver
           package: com.example.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: IMPORT match with asterisk at the end (without dot)
         codeSnip: "\n 1  package com.example.config;\n 2  \n 3  import org.springframework.context.annotation.Bean;\n 4  import org.springframework.context.annotation.Configuration;\n 5  import org.springframework.web.servlet.view.tiles3.TilesConfigurer;\n 6  import org.springframework.web.servlet.view.tiles3.TilesViewResolver;\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")\n17  public TilesConfigurer tilesConfigurer() {"
@@ -227,6 +246,7 @@
           kind: Module
           name: org.springframework.web.servlet.ViewResolver
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-7:
       description: METHOD match with asterisk at the end
@@ -241,6 +261,7 @@
           kind: Method
           name: doStuffWithHomeService
           package: com.example.controller
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/service/HomeService.java
         message: METHOD match with asterisk at the end
         codeSnip: "\n 5  import org.springframework.core.AttributeAccessor;\n 6  \n 7  public class HomeService implements AttributeAccessor {\n 8  \n 9  private TypedEntity<B> typedEntity;\n10  \n11  public HomeService() {\n12  this.typedEntity = new TypedEntity<>(new B());\n13  }\n14  \n15  public void doStuff() {\n16  B b = new B();\n17  TypedEntity<B> typedEntity = new TypedEntity<>(b);\n18  }\n19  \n20  public <T extends B> String doThings(T input) {\n21  return \"Hello World!\";\n22  }\n23  \n24  @Override\n25  public void setAttribute(String name, Object value) {"
@@ -250,6 +271,7 @@
           kind: Method
           name: doStuff
           package: com.example.service
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/service/HomeService.java
         message: METHOD match with asterisk at the end
         codeSnip: "\n10  \n11  public HomeService() {\n12  this.typedEntity = new TypedEntity<>(new B());\n13  }\n14  \n15  public void doStuff() {\n16  B b = new B();\n17  TypedEntity<B> typedEntity = new TypedEntity<>(b);\n18  }\n19  \n20  public <T extends B> String doThings(T input) {\n21  return \"Hello World!\";\n22  }\n23  \n24  @Override\n25  public void setAttribute(String name, Object value) {\n26  \n27  }\n28  \n29  @Override\n30  public Object getAttribute(String name) {"
@@ -259,6 +281,7 @@
           kind: Method
           name: doThings
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-8:
       description: METHOD match with asterisk at the end and class name
@@ -273,6 +296,7 @@
           kind: Method
           name: doStuff
           package: com.example.service
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/service/HomeService.java
         message: METHOD match with asterisk at the end and class name
         codeSnip: "\n10  \n11  public HomeService() {\n12  this.typedEntity = new TypedEntity<>(new B());\n13  }\n14  \n15  public void doStuff() {\n16  B b = new B();\n17  TypedEntity<B> typedEntity = new TypedEntity<>(b);\n18  }\n19  \n20  public <T extends B> String doThings(T input) {\n21  return \"Hello World!\";\n22  }\n23  \n24  @Override\n25  public void setAttribute(String name, Object value) {\n26  \n27  }\n28  \n29  @Override\n30  public Object getAttribute(String name) {"
@@ -282,6 +306,7 @@
           kind: Method
           name: doThings
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-9:
       description: METHOD match with asterisk at the end and fully qualified class name
@@ -296,6 +321,7 @@
           kind: Method
           name: doStuff
           package: com.example.service
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/service/HomeService.java
         message: METHOD match with asterisk at the end and fully qualified class name
         codeSnip: "\n10  \n11  public HomeService() {\n12  this.typedEntity = new TypedEntity<>(new B());\n13  }\n14  \n15  public void doStuff() {\n16  B b = new B();\n17  TypedEntity<B> typedEntity = new TypedEntity<>(b);\n18  }\n19  \n20  public <T extends B> String doThings(T input) {\n21  return \"Hello World!\";\n22  }\n23  \n24  @Override\n25  public void setAttribute(String name, Object value) {\n26  \n27  }\n28  \n29  @Override\n30  public Object getAttribute(String name) {"
@@ -305,6 +331,7 @@
           kind: Method
           name: doThings
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-10:
       description: Exact METHOD match with fully qualified class name
@@ -319,6 +346,7 @@
           kind: Method
           name: doThings
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-11:
       description: Exact METHOD match with fully qualified class name and type parameters
@@ -333,6 +361,7 @@
           kind: Method
           name: doThings
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-12:
       description: Exact METHOD_CALL match with fully qualified class name
@@ -347,6 +376,7 @@
           kind: Method
           name: doStuffWithHomeService
           package: com.example.controller
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-13:
       description: METHOD_CALL match with asterisk and fully qualified class name
@@ -361,6 +391,7 @@
           kind: Method
           name: doStuffWithHomeService
           package: com.example.controller
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-14:
       description: METHOD_CALL match with asterisk for whole method name and fully qualified class name
@@ -375,6 +406,7 @@
           kind: Method
           name: doStuffWithHomeService
           package: com.example.controller
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-15:
       description: FIELD match with asterisk for name and fq type
@@ -389,6 +421,7 @@
           kind: Field
           name: typedEntity
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-16:
       description: Exact ANNOTATION match
@@ -403,6 +436,7 @@
           kind: Property
           name: Controller
           package: com.example.controller
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-17:
       description: CLASS asterisk match with annotated pattern
@@ -417,6 +451,7 @@
           kind: Class
           name: HomeController
           package: com.example.controller
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-18:
       description: METHOD asterisk match with annotated pattern
@@ -431,6 +466,7 @@
           kind: Method
           name: entityManagerFactory
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
         message: METHOD asterisk match with annotated pattern
         codeSnip: "\n32  final LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();\n33  em.setDataSource(dataSource());\n34  em.setPackagesToScan(\"io.konveyor.demo.ordermanagement.model\");\n35  em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());\n36  em.setJpaProperties(additionalProperties());\n37  \n38  return em;\n39  }\n40  \n41  @Bean\n42  public DataSource dataSource() {\n43  ApplicationConfiguration config = new ApplicationConfiguration();\n44  final DriverManagerDataSource dataSource = new DriverManagerDataSource();\n45  dataSource.setDriverClassName(config.getProperty(\"jdbc.driverClassName\"));\n46  dataSource.setUrl(config.getProperty(\"jdbc.url\"));\n47  dataSource.setUsername(config.getProperty(\"jdbc.user\"));\n48  dataSource.setPassword(config.getProperty(\"jdbc.password\"));\n49  \n50  return dataSource;\n51  }\n52  "
@@ -440,6 +476,7 @@
           kind: Method
           name: dataSource
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
         message: METHOD asterisk match with annotated pattern
         codeSnip: "\n44  final DriverManagerDataSource dataSource = new DriverManagerDataSource();\n45  dataSource.setDriverClassName(config.getProperty(\"jdbc.driverClassName\"));\n46  dataSource.setUrl(config.getProperty(\"jdbc.url\"));\n47  dataSource.setUsername(config.getProperty(\"jdbc.user\"));\n48  dataSource.setPassword(config.getProperty(\"jdbc.password\"));\n49  \n50  return dataSource;\n51  }\n52  \n53  @Bean\n54  public PlatformTransactionManager transactionManager() {\n55  final JpaTransactionManager transactionManager = new JpaTransactionManager();\n56  transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());\n57  return transactionManager;\n58  }\n59  \n60  @Bean\n61  public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {\n62  return new PersistenceExceptionTranslationPostProcessor();\n63  }\n64  "
@@ -449,6 +486,7 @@
           kind: Method
           name: transactionManager
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/customers-tomcat-legacy/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
         message: METHOD asterisk match with annotated pattern
         codeSnip: "\n51  }\n52  \n53  @Bean\n54  public PlatformTransactionManager transactionManager() {\n55  final JpaTransactionManager transactionManager = new JpaTransactionManager();\n56  transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());\n57  return transactionManager;\n58  }\n59  \n60  @Bean\n61  public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {\n62  return new PersistenceExceptionTranslationPostProcessor();\n63  }\n64  \n65  final Properties additionalProperties() {\n66  ApplicationConfiguration config = new ApplicationConfiguration();\n67  final Properties hibernateProperties = new Properties();\n68  hibernateProperties.setProperty(\"hibernate.hbm2ddl.auto\", config.getProperty(\"hibernate.hbm2ddl.auto\"));\n69  hibernateProperties.setProperty(\"hibernate.dialect\", config.getProperty(\"hibernate.dialect\"));\n70  hibernateProperties.setProperty(\"hibernate.cache.use_second_level_cache\", \"false\");\n71  "
@@ -458,6 +496,7 @@
           kind: Method
           name: exceptionTranslation
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: METHOD asterisk match with annotated pattern
         codeSnip: "\n 7  import org.springframework.web.servlet.ViewResolver;\n 8  \n 9  /**\n10  * Apache Tiles configuration for Spring MVC.\n11  * This class uses Spring 5's Tiles integration which has been removed in Spring 6.\n12  */\n13  @Configuration\n14  public class TilesConfig {\n15  \n16  @Bean(name = \"nameForThisBean\")\n17  public TilesConfigurer tilesConfigurer() {\n18  TilesConfigurer tilesConfigurer = new TilesConfigurer();\n19  tilesConfigurer.setDefinitions(\"/WEB-INF/tiles/tiles-definitions.xml\");\n20  tilesConfigurer.setCheckRefresh(true);\n21  return tilesConfigurer;\n22  }\n23  \n24  @Bean\n25  public ViewResolver tilesViewResolver() {\n26  TilesViewResolver viewResolver = new TilesViewResolver();\n27  viewResolver.setOrder(1);"
@@ -467,6 +506,7 @@
           kind: Method
           name: tilesConfigurer
           package: com.example.config
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/sample-tiles-app/src/main/java/com/example/config/TilesConfig.java
         message: METHOD asterisk match with annotated pattern
         codeSnip: "\n15  \n16  @Bean(name = \"nameForThisBean\")\n17  public TilesConfigurer tilesConfigurer() {\n18  TilesConfigurer tilesConfigurer = new TilesConfigurer();\n19  tilesConfigurer.setDefinitions(\"/WEB-INF/tiles/tiles-definitions.xml\");\n20  tilesConfigurer.setCheckRefresh(true);\n21  return tilesConfigurer;\n22  }\n23  \n24  @Bean\n25  public ViewResolver tilesViewResolver() {\n26  TilesViewResolver viewResolver = new TilesViewResolver();\n27  viewResolver.setOrder(1);\n28  return viewResolver;\n29  }\n30  }"
@@ -476,6 +516,7 @@
           kind: Method
           name: tilesViewResolver
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-19:
       description: METHOD match with annotated pattern
@@ -490,6 +531,7 @@
           kind: Method
           name: tilesConfigurer
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-20:
       description: METHOD match with annotated pattern
@@ -504,6 +546,7 @@
           kind: Method
           name: tilesConfigurer
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-21:
       description: METHOD match with annotated pattern with boolean element
@@ -518,6 +561,7 @@
           kind: Method
           name: tilesConfigurer
           package: com.example.config
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-22:
       description: METHOD match with annotated pattern with boolean element
@@ -532,6 +576,7 @@
           kind: Class
           name: TypedEntity
           package: com.example.model
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-111:
       description: METHOD match with asterisk in package name
@@ -546,6 +591,7 @@
           kind: Method
           name: doThings
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-151:
       description: FIELD match with asterisk for name and fq type
@@ -560,6 +606,7 @@
           kind: Field
           name: typedEntity
           package: com.example.service
+        isDependencyIncident: false
       effort: 1
     konveyor-java-pattern-test-211:
       description: ANNOTATION match with elements search and on-demand import of the annotation
@@ -574,6 +621,7 @@
           kind: Property
           name: GetMapping
           package: com.example.controller
+        isDependencyIncident: false
       effort: 1
     lang-ref-003:
       description: ""
@@ -588,6 +636,7 @@
           kind: Module
           name: io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition
           package: com.example.apps
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/src/main/java/com/example/apps/App.java
         message: java found apiextensions/v1/customresourcedefinitions found file:///analyzer-lsp/examples/java/example/src/main/java/com/example/apps/App.java:14
         codeSnip: "\n 4  \n 5  public class App\n 6  {\n 7  \n 8  /**\n 9  * {@link CustomResourceDefinition}\n10  * @param args\n11  */\n12  public static void main( String[] args )\n13  {\n14  CustomResourceDefinition crd = new CustomResourceDefinition();\n15  System.out.println( crd );\n16  \n17  GenericClass<String> element = new GenericClass<String>(\"Hello world!\");\n18  element.get();\n19  }\n20  }"
@@ -597,6 +646,7 @@
           kind: Method
           name: main
           package: com.example.apps
+        isDependencyIncident: false
       effort: 1
     lang-ref-004:
       description: ""
@@ -612,6 +662,7 @@
           kind: Method
           name: main
           package: com.example.apps
+          isDependencyIncident: false
       effort: 1
     maven-javax-to-jakarta-00002:
       description: Move to Jakarta EE Maven Artifacts - replace groupId javax.activation
@@ -646,6 +697,7 @@
         variables:
           name: javax.activation.activation
           version: "1.1"
+        isDependencyIncident: false
       effort: 1
     singleton-sessionbean-00001:
       description: ""
@@ -660,6 +712,7 @@
           kind: Property
           name: Singleton
           package: com.example.apps
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/src/main/java/com/example/apps/Bean.java
         message: condition entries should evaluate out of order
         codeSnip: "\n 1  package com.example.apps;\n 2  \n 3  import javax.ejb.SessionBean;\n 4  import javax.ejb.Singleton;\n 5  \n 6  @Singleton\n 7  public abstract class Bean implements SessionBean {\n 8  \n 9  }"
@@ -669,6 +722,7 @@
           kind: Class
           name: Bean
           package: com.example.apps
+        isDependencyIncident: false
       effort: 1
     singleton-sessionbean-00002:
       description: ""
@@ -683,6 +737,7 @@
           kind: Property
           name: Singleton
           package: com.example.apps
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java/example/src/main/java/com/example/apps/Bean.java
         message: condition entries should evaluate in order
         codeSnip: "\n 1  package com.example.apps;\n 2  \n 3  import javax.ejb.SessionBean;\n 4  import javax.ejb.Singleton;\n 5  \n 6  @Singleton\n 7  public abstract class Bean implements SessionBean {\n 8  \n 9  }"
@@ -692,6 +747,7 @@
           kind: Class
           name: Bean
           package: com.example.apps
+        isDependencyIncident: false
       effort: 1
   insights:
     field-rule-00001:
@@ -829,4 +885,4 @@
           name: operator
           package: io.javaoperatorsdk.operator.sample
   unmatched:
-  - konveyor-java-pattern-test-5
+    - konveyor-java-pattern-test-5

--- a/external-providers/java-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/java-external-provider/e2e-tests/demo-output.yaml
@@ -19,7 +19,7 @@
           kind: Class
           name: Bean
           package: com.example.apps
-          isDependencyIncident: false
+        isDependencyIncident: false
       effort: 1
     java-gradle-project:
       description: |
@@ -662,7 +662,7 @@
           kind: Method
           name: main
           package: com.example.apps
-          isDependencyIncident: false
+        isDependencyIncident: false
       effort: 1
     maven-javax-to-jakarta-00002:
       description: Move to Jakarta EE Maven Artifacts - replace groupId javax.activation
@@ -763,6 +763,7 @@
           kind: Field
           name: repository
           package: io.konveyor.demo.ordermanagement.service
+        isDependencyIncident: false
     field-rule-00002:
       description: Sample field declaration rule (field_declaration)
       category: mandatory
@@ -776,6 +777,7 @@
           kind: Field
           name: repository
           package: io.konveyor.demo.ordermanagement.service
+        isDependencyIncident: false
     java-annotation-inspection-01:
       description: |
         This rule looks for a given class annotated with a given annotation
@@ -790,6 +792,7 @@
           kind: Class
           name: PersistenceConfig
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
     java-annotation-inspection-02:
       description: |
         This rule looks for a given method annotated with a given annotation
@@ -804,6 +807,7 @@
           kind: Method
           name: entityManagerFactory
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
     java-annotation-inspection-03:
       description: |
         This rule looks for a given field annotated with a given annotation
@@ -818,6 +822,7 @@
           kind: Field
           name: customerService
           package: io.konveyor.demo.ordermanagement.controller
+        isDependencyIncident: false
     java-annotation-inspection-04:
       description: |
         This rule looks for a given annotation used with some given properties (elements)
@@ -832,6 +837,7 @@
           kind: Property
           name: GetMapping
           package: io.konveyor.demo.ordermanagement.controller
+        isDependencyIncident: false
     java-annotation-inspection-05:
       description: |
         This rule looks for a given annotation used with another annotation
@@ -846,6 +852,7 @@
           kind: Property
           name: Configuration
           package: io.konveyor.demo.ordermanagement.config
+        isDependencyIncident: false
     java-chaining-01:
       description: There should only be one instance of this rule
       category: mandatory
@@ -860,6 +867,7 @@
           kind: Class
           name: OrderManagementAppInitializer
           package: io.konveyor.demo.ordermanagement
+        isDependencyIncident: false
     java-downloaded-maven-artifact:
       description: |
         This rule tests the application downloaded from maven artifact
@@ -875,6 +883,7 @@
           kind: Module
           name: io.javaoperatorsdk.operator.Operator
           package: io.javaoperatorsdk.operator.sample
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/java-project/src/main/java/io/javaoperatorsdk/operator/sample/QuarkusOperator.java
         message: ""
         codeSnip: "\n 7  import io.quarkus.runtime.Quarkus;\n 8  import io.quarkus.runtime.QuarkusApplication;\n 9  import io.quarkus.runtime.annotations.QuarkusMain;\n10  import javax.inject.Inject;\n11  \n12  @QuarkusMain\n13  public class QuarkusOperator implements QuarkusApplication {\n14  @Inject\n15  KubernetesClient client;\n16  @Inject\n17  Operator operator;\n18  @Inject\n19  ConfigurationService configuration;\n20  @Inject\n21  CustomServiceController controller;\n22  \n23  public static void main(String... args) {\n24  Quarkus.run(QuarkusOperator.class, args);\n25  }\n26  \n27  public int run(String... args) throws Exception {"
@@ -884,5 +893,6 @@
           kind: Field
           name: operator
           package: io.javaoperatorsdk.operator.sample
+        isDependencyIncident: false
   unmatched:
-    - konveyor-java-pattern-test-5
+  - konveyor-java-pattern-test-5

--- a/external-providers/nodejs-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/nodejs-external-provider/e2e-tests/demo-output.yaml
@@ -10,18 +10,21 @@
         lineNumber: 6
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_a.ts
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/test_b.ts
         message: nodejs sample rule 001
         codeSnip: " 1  import { greeter } from './test_a';\n 2  \n 3  console.log(greeter.hello());\n"
         lineNumber: 1
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_b.ts
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/test_b.ts
         message: nodejs sample rule 001
         codeSnip: " 1  import { greeter } from './test_a';\n 2  \n 3  console.log(greeter.hello());\n"
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_b.ts
+        isDependencyIncident: false
       effort: 1
     node-sample-rule-002:
       description: Testing that the node provider works - function
@@ -33,18 +36,21 @@
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_a.ts
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/test_a.ts
         message: nodejs sample rule 002
         codeSnip: " 1  export interface Greeter {\n 2    name: string;\n 3    hello(): string;\n 4  }\n 5  \n 6  export const greeter: Greeter = {\n 7    name: \"Person1\",\n 8    hello() {\n 9      return `Hello, I'm ${this.name}`;\n10    },\n11  };\n"
         lineNumber: 8
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_a.ts
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/test_b.ts
         message: nodejs sample rule 002
         codeSnip: " 1  import { greeter } from './test_a';\n 2  \n 3  console.log(greeter.hello());\n"
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_b.ts
+        isDependencyIncident: false
       effort: 1
     node-sample-rule-003:
       description: Testing that the node module files are not matched
@@ -56,6 +62,7 @@
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nodejs/test_b.ts
+        isDependencyIncident: false
       effort: 1
     test-tsx-support-00010:
       description: Test that nodejs provider can find references in TypeScript/React files
@@ -67,16 +74,19 @@
         lineNumber: 1
         variables:
           file: file:///analyzer-lsp/examples/nodejs/Component.tsx
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/Component.tsx
         message: Found React reference using nodejs provider
         codeSnip: " 1  import React from 'react';\n 2  \n 3  export const MyComponent: React.FC = () => {\n 4    return <div>Hello from TypeScript React</div>;\n 5  };\n"
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nodejs/Component.tsx
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nodejs/LegacyComponent.jsx
         message: Found React reference using nodejs provider
         codeSnip: " 1  import React from 'react';\n 2  \n 3  export const LegacyComponent = () => {\n 4    return <div>Hello from JavaScript React</div>;\n 5  };\n"
         lineNumber: 1
         variables:
           file: file:///analyzer-lsp/examples/nodejs/LegacyComponent.jsx
+        isDependencyIncident: false
       effort: 1

--- a/external-providers/python-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/python-external-provider/e2e-tests/demo-output.yaml
@@ -10,6 +10,7 @@
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/python/file_a.py
+        isDependencyIncident: false
       effort: 1
     python-sample-rule-002:
       description: ""
@@ -21,6 +22,7 @@
         lineNumber: 6
         variables:
           file: file:///analyzer-lsp/examples/python/file_a.py
+        isDependencyIncident: false
       effort: 1
   unmatched:
-  - python-sample-rule-003
+    - python-sample-rule-003

--- a/external-providers/python-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/python-external-provider/e2e-tests/demo-output.yaml
@@ -25,4 +25,4 @@
         isDependencyIncident: false
       effort: 1
   unmatched:
-    - python-sample-rule-003
+  - python-sample-rule-003

--- a/external-providers/yq-external-provider/e2e-tests/demo-output.yaml
+++ b/external-providers/yq-external-provider/e2e-tests/demo-output.yaml
@@ -13,6 +13,7 @@
           kind: Deployment
           removed-in: v1.16.0
           replacement-API: apps/v1
+        isDependencyIncident: false
       effort: 2
     k8s-deprecated-api-002:
       description: Check for usage of deprecated Kubernetes API versions
@@ -27,4 +28,5 @@
           kind: ReplicaSet
           removed-in: v1.16.0
           replacement-API: apps/v1
+        isDependencyIncident: false
       effort: 2

--- a/output/v1/konveyor/violations.go
+++ b/output/v1/konveyor/violations.go
@@ -131,6 +131,10 @@ type Incident struct {
 	// Extras json.RawMessage
 	LineNumber *int                   `yaml:"lineNumber,omitempty" json:"lineNumber,omitempty"`
 	Variables  map[string]interface{} `yaml:"variables,omitempty" json:"variables,omitempty"`
+
+	// IsDependencyIncident indicates whether this incident was found in a dependency
+	// (as opposed to the application's own source code)
+	IsDependencyIncident bool `yaml:"isDependencyIncident" json:"isDependencyIncident"`
 }
 
 // Lexicographically compares two Incidents

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -623,11 +623,12 @@ func (p ProviderCondition) Evaluate(ctx context.Context, log logr.Logger, condCt
 			continue
 		}
 		i := engine.IncidentContext{
-			FileURI:    inc.FileURI,
-			Effort:     inc.Effort,
-			LineNumber: inc.LineNumber,
-			Variables:  inc.Variables,
-			Links:      p.Rule.Perform.Message.Links,
+			FileURI:              inc.FileURI,
+			Effort:               inc.Effort,
+			LineNumber:           inc.LineNumber,
+			Variables:            inc.Variables,
+			Links:                p.Rule.Perform.Message.Links,
+			IsDependencyIncident: inc.IsDependencyIncident,
 		}
 
 		if inc.CodeLocation != nil {


### PR DESCRIPTION
- The flag was already there, we just needed to take it to the surface.
- Tested with kantra on source and binary modes, it seems to be working fine.
- Fixes https://github.com/konveyor/kantra/issues/797
- For c-sharp provider test updates, see https://github.com/konveyor/c-sharp-analyzer-provider/pull/111

/ci test-with konveyor/c-sharp-analyzer-provider#111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Incidents in analysis reports are now classified to distinguish between those originating from application code and those from external dependencies, improving visibility into the source of identified issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->