### PR TITLE
:bug: Update partial analysis on Windows

### DIFF
--- a/engine/scopes.go
+++ b/engine/scopes.go
@@ -101,12 +101,22 @@ func (i *includedPathScope) FilterResponse(response IncidentContext) bool {
 	if len(i.paths) == 0 {
 		return false
 	}
+	normalizedResponse := normalizePathForComparison(response.FileURI.Filename())
 	for _, path := range i.paths {
-		if string(response.FileURI) != "" && response.FileURI.Filename() == path {
+		if string(response.FileURI) != "" && normalizedResponse == normalizePathForComparison(path) {
 			return false
 		}
 	}
 	return true
+}
+
+// normalizePathForComparison converts a file path to a canonical form for
+// comparison.
+func normalizePathForComparison(path string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(filepath.ToSlash(path))
+	}
+	return path
 }
 
 func IncludedPathsScope(paths []string, log logr.Logger) Scope {

--- a/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
+++ b/external-providers/java-external-provider/pkg/java_external_provider/service_client.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -155,13 +156,17 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 	// Get filepath constraints from rule scope (e.g., chained conditions)
 	includedFilepaths, excludedFilepaths := condCTX.GetScopedFilepaths()
 
-	// Determine which filepaths to pass to the language server query
-	// Provider-level includes take precedence over rule-scope includes
+	// Determine which filepaths to pass to the language server query.
+	// On Windows, rule-scope paths are NOT sent to the JDT LS because its
+	// search scope creation (SampleDelegateCommandHandler.java) has path
+	// handling issues: case-sensitive segment comparison in makeRelativeTo and
+	// a findElement fallback that silently discards results. On Linux/macOS
+	// these work correctly so we keep the optimization.
 	var lspIncludedPaths []string
 	if len(p.includedPaths) > 0 {
 		lspIncludedPaths = p.includedPaths
 		log.V(8).Info("setting LSP search scope by provider-level filepaths", "paths", p.includedPaths)
-	} else if len(includedFilepaths) > 0 {
+	} else if len(includedFilepaths) > 0 && runtime.GOOS != "windows" {
 		lspIncludedPaths = includedFilepaths
 		log.V(8).Info("setting LSP search scope by rule-scope filepaths", "paths", includedFilepaths)
 	}
@@ -171,13 +176,9 @@ func (p *javaServiceClient) GetAllSymbols(ctx context.Context, c javaCondition, 
 	}
 
 	// Check if we need file-level filtering beyond what the language server provides
-	// The language server filters at package-level, we need file-level precision for:
-	// 1. Excluded paths (language server only handles included paths)
-	// 2. Condition-level filepaths (pattern matching and normalization)
-	// 3. Rule-scope included paths when provider-level paths were used for LSP query
-	hasAdditionalConstraints := len(excludedFilepaths) > 0 ||
-		len(c.Referenced.Filepaths) > 0 ||
-		(len(p.includedPaths) > 0 && len(includedFilepaths) > 0)
+	hasAdditionalConstraints := len(includedFilepaths) > 0 ||
+		len(excludedFilepaths) > 0 ||
+		len(c.Referenced.Filepaths) > 0
 
 	// Start file search in parallel with language server query (if needed)
 	type fileSearchResult struct {

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -596,6 +597,10 @@ func NormalizePathForComparison(path string) string {
 	// Remove common URI schemes (some systems emit file: instead of file://)
 	path = strings.TrimPrefix(path, "file://")
 	path = strings.TrimPrefix(path, "file:")
+
+	if decoded, err := url.PathUnescape(path); err == nil {
+		path = decoded
+	}
 
 	if len(path) >= 3 && path[0] == '/' &&
 		((path[1] >= 'A' && path[1] <= 'Z') || (path[1] >= 'a' && path[1] <= 'z')) &&


### PR DESCRIPTION
Resolves https://github.com/konveyor/editor-extensions/issues/1423 & https://github.com/konveyor/editor-extensions/issues/1430

Normalizes Windows paths before sending them to the jdtls for partial analyses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path matching on Windows to be case-insensitive and handle forward/backward slash inconsistencies
  * Enhanced Java language server file filtering accuracy on Windows
  * Added support for URL-encoded paths in normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->