### PR TITLE
:sparkles: Add GetCodeSnip for Python and Nodejs providers

### DIFF
--- a/external-providers/nodejs-external-provider/go.mod
+++ b/external-providers/nodejs-external-provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/analyzer-lsp/external-providers/nodejs-external-provider
 
-go 1.25
+go 1.25.8
 
 require (
 	github.com/bombsimon/logrusr/v3 v3.1.0

--- a/external-providers/nodejs-external-provider/main.go
+++ b/external-providers/nodejs-external-provider/main.go
@@ -17,7 +17,7 @@ var (
 	socket        = flag.String("socket", "", "Socket to be used")
 	logLevel      = flag.Int("log-level", 5, "Level to log")
 	lspServerName = flag.String("name", "nodejs", "LSP server name advertised to the analyzer")
-	contextLines  = flag.Int("contxtLines", 10, "lines of context for the code snippet")
+	contextLines  = flag.Int("contextLines", 10, "lines of context for the code snippet")
 	certFile      = flag.String("certFile", "", "Path to the cert file")
 	keyFile       = flag.String("keyFile", "", "Path to the key file")
 	secretKey     = flag.String("secretKey", "", "Secret Key value")

--- a/external-providers/nodejs-external-provider/main.go
+++ b/external-providers/nodejs-external-provider/main.go
@@ -17,6 +17,7 @@ var (
 	socket        = flag.String("socket", "", "Socket to be used")
 	logLevel      = flag.Int("log-level", 5, "Level to log")
 	lspServerName = flag.String("name", "nodejs", "LSP server name advertised to the analyzer")
+	contextLines  = flag.Int("contxtLines", 10, "lines of context for the code snippet")
 	certFile      = flag.String("certFile", "", "Path to the cert file")
 	keyFile       = flag.String("keyFile", "", "Path to the key file")
 	secretKey     = flag.String("secretKey", "", "Secret Key value")
@@ -31,7 +32,7 @@ func main() {
 	logrusLog.SetLevel(logrus.Level(*logLevel))
 	log := logrusr.New(logrusLog).WithName("nodejs-external-provider")
 
-	client := nodejsprov.NewNodejsProvider(*lspServerName, log, nil)
+	client := nodejsprov.NewNodejsProvider(*lspServerName, log, *contextLines, nil)
 
 	if *socket == "" && *port == 0 {
 		log.Error(fmt.Errorf("no serving location"), "port or socket must be set.")

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/provider.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/provider.go
@@ -12,6 +12,7 @@ import (
 type nodejsProvider struct {
 	capabilities []provider.Capability
 	progress     *progress.Progress
+	contextLines int
 }
 
 func (p *nodejsProvider) SetProgress(progress *progress.Progress) {
@@ -20,10 +21,11 @@ func (p *nodejsProvider) SetProgress(progress *progress.Progress) {
 
 // NewNodejsProvider constructs the gRPC-facing BaseClient for nodejs-external-provider.
 // lspServerName should match rule provider ids (typically "nodejs").
-func NewNodejsProvider(lspServerName string, log logr.Logger, progress *progress.Progress) provider.BaseClient {
+func NewNodejsProvider(lspServerName string, log logr.Logger, contextLines int, progress *progress.Progress) provider.BaseClient {
 	_ = lspServerName
 	p := &nodejsProvider{
-		progress: progress,
+		progress:     progress,
+		contextLines: contextLines,
 	}
 
 	builder := &NodeServiceClientBuilder{}

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/provider.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/provider.go
@@ -23,6 +23,9 @@ func (p *nodejsProvider) SetProgress(progress *progress.Progress) {
 // lspServerName should match rule provider ids (typically "nodejs").
 func NewNodejsProvider(lspServerName string, log logr.Logger, contextLines int, progress *progress.Progress) provider.BaseClient {
 	_ = lspServerName
+	if contextLines < 0 {
+		contextLines = 0
+	}
 	p := &nodejsProvider{
 		progress:     progress,
 		contextLines: contextLines,

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/provider_test.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/provider_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewNodejsProviderCapabilities(t *testing.T) {
 	log := logr.Discard()
-	p := nodejsext.NewNodejsProvider("nodejs", log, nil)
+	p := nodejsext.NewNodejsProvider("nodejs", log, 10, nil)
 	caps := p.Capabilities()
 	if len(caps) == 0 {
 		t.Fatalf("expected non-empty capabilities, got %d", len(caps))

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/service_client_integration_test.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/service_client_integration_test.go
@@ -42,7 +42,7 @@ func TestTypescriptLSInitAndEvaluate(t *testing.T) {
 	logrusLog.SetLevel(logrus.Level(5))
 	log := logrusr.New(logrusLog)
 
-	prov := nodejsext.NewNodejsProvider("nodejs", log, nil)
+	prov := nodejsext.NewNodejsProvider("nodejs", log, 10, nil)
 
 	repoRoot := testRepoRoot(t)
 	nodeDir := filepath.Join(repoRoot, "examples", "nodejs")

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/service_client_test.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/service_client_test.go
@@ -19,7 +19,7 @@ func TestNodejsServiceClientBuilderCapabilities(t *testing.T) {
 }
 
 func TestNodejsProviderInitErrorPath(t *testing.T) {
-	p := nodejsext.NewNodejsProvider("nodejs", logr.Discard(), nil)
+	p := nodejsext.NewNodejsProvider("nodejs", logr.Discard(), 10, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper.go
@@ -1,0 +1,44 @@
+package nodejs_external_provider
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/konveyor/analyzer-lsp/engine"
+	"go.lsp.dev/uri"
+)
+
+var _ engine.CodeSnip = &nodejsProvider{}
+
+func (p *nodejsProvider) GetCodeSnip(u uri.URI, loc engine.Location) (string, error) {
+	if !strings.HasPrefix(string(u), uri.FileScheme) {
+		return "", fmt.Errorf("invalid file uri, must use %s scheme", uri.FileScheme)
+	}
+	return p.scanFile(u.Filename(), loc)
+}
+
+func (p *nodejsProvider) scanFile(path string, loc engine.Location) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	lineNumber := 0
+	codeSnip := ""
+	paddingSize := len(strconv.Itoa(loc.EndPosition.Line + p.contextLines))
+	for scanner.Scan() {
+		if (lineNumber-p.contextLines) == loc.EndPosition.Line {
+			codeSnip = codeSnip + fmt.Sprintf("%*d  %v", paddingSize, lineNumber+1, scanner.Text())
+			break
+		}
+		if (lineNumber+p.contextLines) >= loc.StartPosition.Line {
+			codeSnip = codeSnip + fmt.Sprintf("%*d  %v\n", paddingSize, lineNumber+1, scanner.Text())
+		}
+		lineNumber++
+	}
+	return codeSnip, nil
+}

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper.go
@@ -14,7 +14,7 @@ import (
 var _ engine.CodeSnip = &nodejsProvider{}
 
 func (p *nodejsProvider) GetCodeSnip(u uri.URI, loc engine.Location) (string, error) {
-	if !strings.HasPrefix(string(u), uri.FileScheme) {
+	if !strings.HasPrefix(string(u), uri.FileScheme+"://") {
 		return "", fmt.Errorf("invalid file uri, must use %s scheme", uri.FileScheme)
 	}
 	return p.scanFile(u.Filename(), loc)

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper_test.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper_test.go
@@ -1,0 +1,52 @@
+package nodejs_external_provider_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	nodejsext "github.com/konveyor/analyzer-lsp/external-providers/nodejs-external-provider/pkg/nodejs_external_provider"
+	"github.com/konveyor/analyzer-lsp/engine"
+	"go.lsp.dev/uri"
+)
+
+func TestGetCodeSnip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.js")
+	content := "const fs = require('fs');\n\nconsole.log('hello');\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := nodejsext.NewNodejsProvider("nodejs", logr.Discard(), 10, nil)
+	snipper, ok := p.(engine.CodeSnip)
+	if !ok {
+		t.Fatal("nodejs provider does not implement engine.CodeSnip")
+	}
+
+	snip, err := snipper.GetCodeSnip(uri.File(path), engine.Location{
+		StartPosition: engine.Position{Line: 2},
+		EndPosition:   engine.Position{Line: 2},
+	})
+	if err != nil {
+		t.Fatalf("GetCodeSnip: %v", err)
+	}
+	want := " 1  const fs = require('fs');\n 2  \n 3  console.log('hello');\n"
+	if snip != want {
+		t.Errorf("GetCodeSnip = %q, want %q", snip, want)
+	}
+}
+
+func TestGetCodeSnipInvalidURI(t *testing.T) {
+	p := nodejsext.NewNodejsProvider("nodejs", logr.Discard(), 10, nil)
+	snipper, ok := p.(engine.CodeSnip)
+	if !ok {
+		t.Fatal("nodejs provider does not implement engine.CodeSnip")
+	}
+
+	_, err := snipper.GetCodeSnip("jdt://some/path", engine.Location{})
+	if err == nil {
+		t.Fatal("expected error for non-file URI")
+	}
+}

--- a/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper_test.go
+++ b/external-providers/nodejs-external-provider/pkg/nodejs_external_provider/snipper_test.go
@@ -49,4 +49,9 @@ func TestGetCodeSnipInvalidURI(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-file URI")
 	}
+
+	_, err = snipper.GetCodeSnip("filex://some/path", engine.Location{})
+	if err == nil {
+		t.Fatal("expected error for filex URI")
+	}
 }

--- a/external-providers/python-external-provider/go.mod
+++ b/external-providers/python-external-provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/analyzer-lsp/external-providers/python-external-provider
 
-go 1.25
+go 1.25.8
 
 require (
 	github.com/bombsimon/logrusr/v3 v3.1.0

--- a/external-providers/python-external-provider/main.go
+++ b/external-providers/python-external-provider/main.go
@@ -17,7 +17,7 @@ var (
 	socket        = flag.String("socket", "", "Socket to be used")
 	logLevel      = flag.Int("log-level", 5, "Level to log")
 	lspServerName = flag.String("name", "python", "LSP server name advertised to the analyzer")
-	contextLines  = flag.Int("contxtLines", 10, "lines of context for the code snippet")
+	contextLines  = flag.Int("contextLines", 10, "lines of context for the code snippet")
 	certFile      = flag.String("certFile", "", "Path to the cert file")
 	keyFile       = flag.String("keyFile", "", "Path to the key file")
 	secretKey     = flag.String("secretKey", "", "Secret Key value")

--- a/external-providers/python-external-provider/main.go
+++ b/external-providers/python-external-provider/main.go
@@ -17,6 +17,7 @@ var (
 	socket        = flag.String("socket", "", "Socket to be used")
 	logLevel      = flag.Int("log-level", 5, "Level to log")
 	lspServerName = flag.String("name", "python", "LSP server name advertised to the analyzer")
+	contextLines  = flag.Int("contxtLines", 10, "lines of context for the code snippet")
 	certFile      = flag.String("certFile", "", "Path to the cert file")
 	keyFile       = flag.String("keyFile", "", "Path to the key file")
 	secretKey     = flag.String("secretKey", "", "Secret Key value")
@@ -31,7 +32,7 @@ func main() {
 	logrusLog.SetLevel(logrus.Level(*logLevel))
 	log := logrusr.New(logrusLog).WithName("python-external-provider")
 
-	client := pythonprov.NewPythonProvider(*lspServerName, log, nil)
+	client := pythonprov.NewPythonProvider(*lspServerName, log, *contextLines, nil)
 
 	if *socket == "" && *port == 0 {
 		log.Error(fmt.Errorf("no serving location"), "port or socket must be set.")

--- a/external-providers/python-external-provider/pkg/python_external_provider/provider.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/provider.go
@@ -24,6 +24,9 @@ func (p *pythonProvider) SetProgress(progress *progress.Progress) {
 func NewPythonProvider(lspServerName string, log logr.Logger, contextLines int, progress *progress.Progress) provider.BaseClient {
 	_ = lspServerName
 	_ = log
+	if contextLines < 0 {
+		contextLines = 0
+	}
 	p := &pythonProvider{
 		progress:     progress,
 		contextLines: contextLines,

--- a/external-providers/python-external-provider/pkg/python_external_provider/provider.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/provider.go
@@ -12,6 +12,7 @@ import (
 type pythonProvider struct {
 	capabilities []provider.Capability
 	progress     *progress.Progress
+	contextLines int
 }
 
 func (p *pythonProvider) SetProgress(progress *progress.Progress) {
@@ -20,10 +21,12 @@ func (p *pythonProvider) SetProgress(progress *progress.Progress) {
 
 // NewPythonProvider constructs the gRPC-facing BaseClient for python-external-provider.
 // lspServerName should match rule provider ids (typically "python").
-func NewPythonProvider(lspServerName string, log logr.Logger, progress *progress.Progress) provider.BaseClient {
+func NewPythonProvider(lspServerName string, log logr.Logger, contextLines int, progress *progress.Progress) provider.BaseClient {
 	_ = lspServerName
+	_ = log
 	p := &pythonProvider{
-		progress: progress,
+		progress:     progress,
+		contextLines: contextLines,
 	}
 
 	builder := &PythonServiceClientBuilder{}

--- a/external-providers/python-external-provider/pkg/python_external_provider/provider_test.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/provider_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewPythonProviderCapabilities(t *testing.T) {
 	log := logr.Discard()
-	p := pythonext.NewPythonProvider("python", log, nil)
+	p := pythonext.NewPythonProvider("python", log, 10, nil)
 	caps := p.Capabilities()
 	if len(caps) == 0 {
 		t.Fatalf("expected non-empty capabilities, got %d", len(caps))

--- a/external-providers/python-external-provider/pkg/python_external_provider/service_client_integration_test.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/service_client_integration_test.go
@@ -42,7 +42,7 @@ func TestPylspInitAndEvaluate(t *testing.T) {
 	logrusLog.SetLevel(logrus.Level(5))
 	log := logrusr.New(logrusLog)
 
-	prov := pythonext.NewPythonProvider("python", log, nil)
+	prov := pythonext.NewPythonProvider("python", log, 10, nil)
 
 	repoRoot := testRepoRoot(t)
 	pyDir := filepath.Join(repoRoot, "examples", "python")

--- a/external-providers/python-external-provider/pkg/python_external_provider/service_client_test.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/service_client_test.go
@@ -19,7 +19,7 @@ func TestPythonServiceClientBuilderCapabilities(t *testing.T) {
 }
 
 func TestPythonProviderInitErrorPath(t *testing.T) {
-	p := pythonext.NewPythonProvider("python", logr.Discard(), nil)
+	p := pythonext.NewPythonProvider("python", logr.Discard(), 10, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/external-providers/python-external-provider/pkg/python_external_provider/snipper.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/snipper.go
@@ -1,0 +1,44 @@
+package python_external_provider
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/konveyor/analyzer-lsp/engine"
+	"go.lsp.dev/uri"
+)
+
+var _ engine.CodeSnip = &pythonProvider{}
+
+func (p *pythonProvider) GetCodeSnip(u uri.URI, loc engine.Location) (string, error) {
+	if !strings.HasPrefix(string(u), uri.FileScheme) {
+		return "", fmt.Errorf("invalid file uri, must use %s scheme", uri.FileScheme)
+	}
+	return p.scanFile(u.Filename(), loc)
+}
+
+func (p *pythonProvider) scanFile(path string, loc engine.Location) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	lineNumber := 0
+	codeSnip := ""
+	paddingSize := len(strconv.Itoa(loc.EndPosition.Line + p.contextLines))
+	for scanner.Scan() {
+		if (lineNumber-p.contextLines) == loc.EndPosition.Line {
+			codeSnip = codeSnip + fmt.Sprintf("%*d  %v", paddingSize, lineNumber+1, scanner.Text())
+			break
+		}
+		if (lineNumber+p.contextLines) >= loc.StartPosition.Line {
+			codeSnip = codeSnip + fmt.Sprintf("%*d  %v\n", paddingSize, lineNumber+1, scanner.Text())
+		}
+		lineNumber++
+	}
+	return codeSnip, nil
+}

--- a/external-providers/python-external-provider/pkg/python_external_provider/snipper.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/snipper.go
@@ -14,7 +14,7 @@ import (
 var _ engine.CodeSnip = &pythonProvider{}
 
 func (p *pythonProvider) GetCodeSnip(u uri.URI, loc engine.Location) (string, error) {
-	if !strings.HasPrefix(string(u), uri.FileScheme) {
+	if !strings.HasPrefix(string(u), uri.FileScheme+"://") {
 		return "", fmt.Errorf("invalid file uri, must use %s scheme", uri.FileScheme)
 	}
 	return p.scanFile(u.Filename(), loc)

--- a/external-providers/python-external-provider/pkg/python_external_provider/snipper_test.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/snipper_test.go
@@ -1,0 +1,52 @@
+package python_external_provider_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	pythonext "github.com/konveyor/analyzer-lsp/external-providers/python-external-provider/pkg/python_external_provider"
+	"github.com/konveyor/analyzer-lsp/engine"
+	"go.lsp.dev/uri"
+)
+
+func TestGetCodeSnip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.py")
+	content := "import os\n\nprint('hello')\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := pythonext.NewPythonProvider("python", logr.Discard(), 10, nil)
+	snipper, ok := p.(engine.CodeSnip)
+	if !ok {
+		t.Fatal("python provider does not implement engine.CodeSnip")
+	}
+
+	snip, err := snipper.GetCodeSnip(uri.File(path), engine.Location{
+		StartPosition: engine.Position{Line: 2},
+		EndPosition:   engine.Position{Line: 2},
+	})
+	if err != nil {
+		t.Fatalf("GetCodeSnip: %v", err)
+	}
+	want := " 1  import os\n 2  \n 3  print('hello')\n"
+	if snip != want {
+		t.Errorf("GetCodeSnip = %q, want %q", snip, want)
+	}
+}
+
+func TestGetCodeSnipInvalidURI(t *testing.T) {
+	p := pythonext.NewPythonProvider("python", logr.Discard(), 10, nil)
+	snipper, ok := p.(engine.CodeSnip)
+	if !ok {
+		t.Fatal("python provider does not implement engine.CodeSnip")
+	}
+
+	_, err := snipper.GetCodeSnip("jdt://some/path", engine.Location{})
+	if err == nil {
+		t.Fatal("expected error for non-file URI")
+	}
+}

--- a/external-providers/python-external-provider/pkg/python_external_provider/snipper_test.go
+++ b/external-providers/python-external-provider/pkg/python_external_provider/snipper_test.go
@@ -49,4 +49,9 @@ func TestGetCodeSnipInvalidURI(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-file URI")
 	}
+
+	_, err = snipper.GetCodeSnip("filex://some/path", engine.Location{})
+	if err == nil {
+		t.Fatal("expected error for filex URI")
+	}
 }


### PR DESCRIPTION
Fixes #1147 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable context lines (default: 10) via `--contextLines` to control surrounding code shown in snippets for both Node.js and Python providers.
  * Implemented code snippet generation for Node.js and Python providers (with file-URI validation).

* **Chores**
  * Updated Go toolchain directives to 1.25.8.

* **Tests**
  * Added unit tests for snippet output and invalid URI handling, plus updated provider initialization in existing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->