### PR TITLE
:bug: :cherries: Pin typescript-language-server (#1169)

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -361,11 +361,3 @@ jobs:
           image_pattern: |
             *{tackle-keyloak-init,tackle2-*,provider}--${{ github.run_id }}
           ref: ${{ github.base_ref || inputs.ref || github.ref_name}}
-
-  e2e:
-    needs: test
-    uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main
-    with:
-      operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:2h
-      tackle_hub: "quay.io/konveyor/tackle2-hub:${{ needs.test.outputs.tackle2_hub_tag }}"
-      api_tests_ref: "${{ needs.test.outputs.api_tests_ref }}"

--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -15,7 +15,6 @@ jobs:
       java: ${{ steps.filter.outputs.java }}
       generic: ${{ steps.filter.outputs.generic }}
       yq: ${{ steps.filter.outputs.yq}}
-      c-sharp: ${{ steps.filter.outputs.c-sharp }}
       image_tag: ${{ steps.set-tag.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v3
@@ -41,9 +40,6 @@ jobs:
               - '**'
               - '!external-providers/**'
               - 'external-providers/yq-external-provider/**'
-            c-sharp:
-              - '**'
-              - '!external-providers/**'
 
   build-bases:
     needs: detect-changes
@@ -93,12 +89,6 @@ jobs:
             image_name: yq-provider
             dockerfile: external-providers/yq-external-provider/Dockerfile
             checked_out: true
-          - provider: c-sharp
-            image_name: c-sharp-provider
-            dockerfile: Dockerfile
-            repo: konveyor/c-sharp-analyzer-provider
-            checked_out: false
-            cache-key-file: Cargo.lock
     steps:
       - uses: actions/checkout@v3
         if: needs.detect-changes.outputs[matrix.provider] == 'true'
@@ -164,18 +154,8 @@ jobs:
             demo-output-path: external-providers/yq-external-provider/e2e-tests/demo-output.yaml
             provider_settings-path: external-providers/yq-external-provider/e2e-tests/provider_settings.json
             testing-rules: external-providers/yq-external-provider/e2e-tests/rule-example.yaml
-          - provider: c-sharp
-            repo: "konveyor/c-sharp-analyzer-provider"
-            artifact_pattern: "{konveyor-analyzer-lsp,c-sharp-provider}"
-            test-data: testdata
-            image_name: c-sharp-provider
-            demo-output-path: e2e-tests/demo-output.yaml
-            provider_settings-path: e2e-tests/provider_settings.json
-            testing-rules: rulesets
     steps:
       - uses: actions/checkout@v3
-        with:
-          repository: ${{ matrix.repo || 'konveyor/analyzer-lsp' }}
         if: needs.detect-changes.outputs[matrix.provider] == 'true'
 
       - name: Download provider image artifacts
@@ -227,7 +207,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TAG: ${{ needs.detect-changes.outputs.image_tag }}
-      IMG_C_SHARP_PROVIDER: localhost/c-sharp-provider:${{ needs.detect-changes.outputs.image_tag }}
       IMG_ANALYZER: localhost/konveyor-analyzer-lsp:${{ needs.detect-changes.outputs.image_tag }}
     outputs:
       api_tests_ref: ${{ steps.extract-info.outputs.API_TESTS_REF }}
@@ -343,6 +322,46 @@ jobs:
       - name: push bundle image 
         run: |
           docker push ttl.sh/konveyor-operator-bundle-${GITHUB_SHA}:2h
+
+  koncur-kantra:
+    needs: [test]
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - os: "linux"
+            runner: "ubuntu-24.04-arm"
+          - os: "macos"
+            runner: "macos-26-large"
+          - os: "windows"
+            runner: "windows-latest"
+        exclude:
+          - os:
+              os: "macos"
+              runner: "macos-26-large"
+    runs-on: ${{ matrix.os.runner }}
+    steps:
+      - name: Run Koncur Testing
+        id: koncur-test
+        uses: konveyor/ci/koncur-kantra@main
+        with:
+          os: ${{ matrix.os.os }}
+          image_pattern: |
+            *{kantra,provider}--${{ github.run_id }}
+          ref: ${{ github.base_ref || inputs.ref || github.ref_name}}
+
+
+  koncur-tackle-hub:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Hub with Koncur
+        uses: konveyor/ci/koncur-tackle-hub@main
+        with:
+          image_pattern: |
+            *{tackle-keyloak-init,tackle2-*,provider}--${{ github.run_id }}
+          ref: ${{ github.base_ref || inputs.ref || github.ref_name}}
+
   e2e:
     needs: test
     uses: konveyor/ci/.github/workflows/global-ci-bundle.yml@main

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ IMG_JAVA_PROVIDER ?= localhost/java-provider:$(TAG)
 IMG_GENERIC_PROVIDER ?= localhost/generic-provider:$(TAG)
 IMG_GO_DEP_PROVIDER ?= localhost/golang-dep-provider:$(TAG)
 IMG_YQ_PROVIDER ?= localhost/yq-provider:$(TAG)
-IMG_C_SHARP_PROVIDER ?= quay.io/konveyor/c-sharp-provider:$(TAG)
 OS := $(shell uname -s)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -72,13 +71,11 @@ stop-external-providers:
 	podman kill  golang-provider || true
 	podman kill  nodejs || true
 	podman kill  python || true
-	podman kill  c-sharp || true
 	podman rm java-provider || true
 	podman rm yq || true
 	podman rm golang-provider || true
 	podman rm nodejs || true
 	podman rm python || true
-	podman rm c-sharp || true
 
 run-external-providers-pod:
 	podman volume create test-data
@@ -89,7 +86,6 @@ run-external-providers-pod:
 	podman pod create --name=analyzer --userns=keep-id
 	podman run --pod analyzer --user=$(USER_ID) --name java-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_JAVA_PROVIDER) --port 14651
 	podman run --pod analyzer --user=$(USER_ID) --name yq -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_YQ_PROVIDER) --port 14652
-	podman run --pod analyzer --user=$(USER_ID) --name c-sharp -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_C_SHARP_PROVIDER) --port 14656
 	podman run --entrypoint /usr/local/bin/entrypoint.sh --pod analyzer --user=$(USER_ID) --name golang-provider -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14653
 	podman run --pod analyzer --user=$(USER_ID) --name nodejs -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14654 --name nodejs
 	podman run --pod analyzer --user=$(USER_ID) --name python -d -v test-data:/analyzer-lsp/examples$(MOUNT_OPT) $(IMG_GENERIC_PROVIDER) --port 14655 --name pylsp

--- a/demo-output.yaml
+++ b/demo-output.yaml
@@ -317,53 +317,6 @@
           innerText: "\n      io.netty\n      netty-transport-native-epoll\n      4.1.76.Final\n      linux-x86_64\n      runtime\n    "
           matchingXML: <groupId>io.netty</groupId><artifactId>netty-transport-native-epoll</artifactId><version>4.1.76.Final</version><classifier>linux-x86_64</classifier><scope>runtime</scope>
       effort: 1
-    dotnet-deprecated-001:
-      description: ""
-      category: potential
-      incidents:
-      - uri: file:///examples/c-sharp-dummy-example/Program.cs
-        message: System.Net.WebClient found. Consider replacing with System.Net.Http.HttpClient.
-        codeSnip: |
-          6     public static async Task Main(string[] args)
-          7     {
-          8         using (HttpClient client = new HttpClient())
-          9         {
-          10             try
-          11             {
-          12                 string url = "https://jsonplaceholder.typicode.com/todos/1";
-          13                 HttpResponseMessage response = await client.GetAsync(url);
-          14                 response.EnsureSuccessStatusCode(); // Throws an exception if the HTTP status code is not 2xx
-          15                 string responseBody = await response.Content.ReadAsStringAsync();
-        lineNumber: 16
-        variables:
-          file: file:///examples/c-sharp-dummy-example/Program.cs
-          fqdn_class: Console
-          fqdn_method: WriteLine
-          fqdn_namespace: System
-          symbol: Console.WriteLine
-          syntax_type: method_reference
-      - uri: file:///examples/c-sharp-dummy-example/Program.cs
-        message: System.Net.WebClient found. Consider replacing with System.Net.Http.HttpClient.
-        codeSnip: |
-          10             try
-          11             {
-          12                 string url = "https://jsonplaceholder.typicode.com/todos/1";
-          13                 HttpResponseMessage response = await client.GetAsync(url);
-          14                 response.EnsureSuccessStatusCode(); // Throws an exception if the HTTP status code is not 2xx
-          15                 string responseBody = await response.Content.ReadAsStringAsync();
-          16                 Console.WriteLine(responseBody);
-          17             }
-          18             catch (HttpRequestException e)
-          19             {
-        lineNumber: 20
-        variables:
-          file: file:///examples/c-sharp-dummy-example/Program.cs
-          fqdn_class: Console
-          fqdn_method: WriteLine
-          fqdn_namespace: System
-          symbol: Console.WriteLine
-          syntax_type: method_reference
-      effort: 2
     file-001:
       description: Testing that we can get all the go files in the project
       category: potential

--- a/external-providers/generic-external-provider/Dockerfile
+++ b/external-providers/generic-external-provider/Dockerfile
@@ -43,7 +43,7 @@ RUN microdnf install gcc-c++ python-devel go-toolset python3-devel nodejs -y && 
     rm -rf /var/cache/dnf
 RUN python3 -m ensurepip --upgrade
 RUN python3 -m pip install 'python-lsp-server>=1.8.2'
-RUN npm install -g typescript-language-server typescript
+RUN npm install -g typescript-language-server typescript@6
 
 RUN GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@v0.20.0
 

--- a/external-providers/yq-external-provider/pkg/yq_provider/service_client.go
+++ b/external-providers/yq-external-provider/pkg/yq_provider/service_client.go
@@ -269,17 +269,21 @@ func (p *yqServiceClient) getLatestStableKubernetesVersion() (string, error) {
 	// Extract and filter version numbers
 	var versions []string
 	for _, release := range releases {
-		version := strings.TrimPrefix(release.Name, "v")
-		if !strings.Contains(version, "-") { // Exclude pre-releases
-			versions = append(versions, version)
+		version := release.Name
+		if strings.Contains(strings.TrimPrefix(version, "v"), "-") {
+			continue
 		}
+		if !semver.IsValid(version) {
+			continue
+		}
+		versions = append(versions, version)
 	}
 
 	// Sort versions in descending order
 	sort.Sort(sort.Reverse(sort.StringSlice(versions)))
 
 	if len(versions) > 0 {
-		return strings.TrimSpace(strings.TrimPrefix(versions[0], "Kubernetes")), nil
+		return versions[0], nil
 	}
 
 	return "", fmt.Errorf("no stable Kubernetes versions found")

--- a/provider_pod_local_settings.json
+++ b/provider_pod_local_settings.json
@@ -140,20 +140,6 @@
         ]
     },
     {
-        "name": "c-sharp",
-        "address": "localhost:14656",
-        "initConfig": [
-            {
-                "analysisMode": "source-only",
-                "location": "/analyzer-lsp/examples/c-sharp-dummy-example",
-                "providerSpecificConfig": {
-                    "ilspy_cmd": "/usr/local/bin/ilspycmd",
-                    "paket_cmd": "/usr/local/bin/paket"
-                }
-            }
-        ]
-    },
-    {
         "name": "builtin",
         "initConfig": [
             {"location": "examples/java/"},

--- a/rule-example.yaml
+++ b/rule-example.yaml
@@ -201,10 +201,3 @@
     builtin.filecontent:
       pattern: "--pf-"
       filePattern: "\\.(css|scss)$"
-- message: 'System.Net.WebClient found. Consider replacing with System.Net.Http.HttpClient.'
-  ruleID: dotnet-deprecated-001
-  effort: 2
-  when:
-    c-sharp.referenced:
-      pattern: "System.Console"
-      location: CLASS


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Bug Fixes**
- Improved Kubernetes version detection by filtering out prerelease and invalid versions, ensuring the latest stable release is selected correctly.
- Preserved version identifiers consistently when reporting the selected Kubernetes release.

- **Chores**
- Pinned the TypeScript compiler to version 6 in the Node.js external provider image for more consistent builds and tooling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------