### PR TITLE
:seedling: Add regression test for filePattern substring-matching default excludes

### DIFF
--- a/provider/lib_test.go
+++ b/provider/lib_test.go
@@ -513,6 +513,43 @@ func TestSearchFromIndex_AdditionalPathsWalkedFromFilesystem(t *testing.T) {
 	}
 }
 
+// TestFileSearcher_ExcludeDefaultDoesNotMatchPathSubstring is a regression test for
+// https://github.com/konveyor/analyzer-lsp/issues/1083 - a default exclude like ".git"
+// must only exclude a literal ".git" directory, not any path that merely contains the
+// substring "git" (e.g. a repo checked out under a directory named
+// "test-dir-with-git-in-name").
+func TestFileSearcher_ExcludeDefaultDoesNotMatchPathSubstring(t *testing.T) {
+	tempDir := t.TempDir()
+	basePath := filepath.Join(tempDir, "test-dir-with-git-in-name")
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		t.Fatalf("failed to create base path: %v", err)
+	}
+	testFile := filepath.Join(basePath, "test.jsx")
+	if err := os.WriteFile(testFile, []byte("import { Page } from '@patternfly/react-core';\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	log := testr.NewWithOptions(t, testr.Options{Verbosity: 10})
+	searcher := &FileSearcher{
+		BasePath: basePath,
+		ProviderConfigConstraints: IncludeExcludeConstraints{
+			ExcludePathsOrPatterns: GetExcludedDirsFromConfig(InitConfig{}),
+		},
+		Log: log,
+	}
+
+	got, err := searcher.Search(SearchCriteria{
+		Patterns: []string{`\.([jt])sx?$`},
+	})
+	if err != nil {
+		t.Fatalf("Search() unexpected error: %v", err)
+	}
+	if !slices.Contains(got, testFile) {
+		t.Errorf("Search() with default excludes should find %q even though the base path "+
+			"contains the substring %q, got: %v", testFile, "git", got)
+	}
+}
+
 func TestFileSearcher_Search(t *testing.T) {
 	testBasePath, err := filepath.Abs("./testdata/file-search")
 	if err != nil {


### PR DESCRIPTION
Motivation:
Report: https://github.com/konveyor/analyzer-lsp/issues/1083 describes
builtin.filecontent's filePattern finding zero files when the analyzed
repository's path contains a substring that matches a default exclude
directory, e.g. a directory named "test-dir-with-git-in-name" being
wrongly excluded because the default ".git" exclude was matched as an
unanchored regex against the substring "-git-".

The linked fix, https://github.com/konveyor/analyzer-lsp/pull/1084, was
closed unmerged: a maintainer noted the underlying matching logic had
already been changed independently while fixing unrelated Windows path
handling, in the merged pull requests
https://github.com/konveyor/analyzer-lsp/pull/1098 and
https://github.com/konveyor/analyzer-lsp/pull/1106. Those changes made
filterFilesByPathsOrPatterns in provider/lib.go match exclude/include
patterns against the file's path relative to BasePath (instead of its
absolute path) and anchor plain-literal patterns like ".git" as "^.git$"
before compiling them as regex.

This commit does not change any behavior - it adds the regression test
that was still missing, per the maintainer's own suggestion on the closed
pull request ("unless there are tests that still should be added").

Approach:
Added TestFileSearcher_ExcludeDefaultDoesNotMatchPathSubstring to
provider/lib_test.go. It reproduces the issue's exact scenario: a
FileSearcher rooted at a temp directory named
".../test-dir-with-git-in-name" containing one test.jsx file, with
ExcludePathsOrPatterns set to the real default excludes from
GetExcludedDirsFromConfig, searching with the filePattern from the
issue's repro rule. It asserts the file is still found.

Validation:
- Reproduced the reported bug directly: built ./cmd/analyzer from this
  branch and ran the exact bash repro script from the issue body against
  it. It passes on current main (violations found, not "unmatched").
  Re-running the same repro against provider/lib.go as of the commit
  referenced in the issue reproduces the reported failure (zero files
  found).
- Confirmed the new test is a real regression test, not a tautology: with
  provider/lib.go temporarily swapped for that pre-fix version, the new
  test fails (Search() returns no files); with the current, unmodified
  provider/lib.go it passes.
- `go build ./...` succeeds.
- `go test ./provider/... -count=1` passes, including the new test.
- `go test ./... -count=1` passes for the full repository.

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file discovery so default directory exclusions match complete path components, preventing valid files in directories with names containing excluded terms from being missed.

* **Tests**
  * Added regression coverage for searching JSX and TSX files in directories whose names include exclusion-related text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->