### PR TITLE
:bug: Preserve escaped trailing quote when trimming filecontent patterns

### DIFF
--- a/provider/internal/builtin/service_client.go
+++ b/provider/internal/builtin/service_client.go
@@ -511,8 +511,13 @@ type fileSearchResult struct {
 }
 
 func (b *builtinServiceClient) performFileContentSearch(pattern string, locations []string) ([]fileSearchResult, error) {
-	// Trim quotes around the pattern to keep backwards compatibility
-	trimmedPattern := strings.Trim(pattern, "\"")
+	// Trim quotes around the pattern to keep backwards compatibility.
+	// Skip stripping a trailing quote that is escaped (\"): stripping it would leave
+	// a dangling backslash that fails to compile as a regex.
+	trimmedPattern := strings.TrimPrefix(pattern, "\"")
+	if !strings.HasSuffix(trimmedPattern, `\"`) {
+		trimmedPattern = strings.TrimSuffix(trimmedPattern, `"`)
+	}
 
 	// Check if the pattern needs multiline support
 	// Patterns need multiline support if they:


### PR DESCRIPTION
## Problem

The builtin `filecontent` provider strips surrounding quotes from patterns for
backwards compatibility using `strings.Trim(pattern, "\"")`. This also strips a
trailing quote that is part of an escaped quote (`\"`), leaving a dangling
backslash that is not a valid regex.

On Windows the provider compiles the trimmed pattern with Go's `regexp`, while
Linux/macOS run `grep -P` on the original, untrimmed pattern. So patterns ending
in `\"` fail **only on Windows** — e.g. rule
`spring-framework-5.x-to-6.0-security-00150` (pattern `\".*hasIpAddress\(.*\"`):

    could not compile provided regex pattern '\".*hasIpAddress\(.*\':
    error parsing regexp: illegal \ at end of pattern

## Fix

Switch to `TrimPrefix`/`TrimSuffix` and skip stripping the trailing quote when it
is escaped. This backports the guard already present on `release-0.10` and `main`
(#1090) to `release-0.9`.