### PR TITLE
Fix CVE-2026-44660: Update ujson to 5.12.1

### DIFF
--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -18,6 +18,6 @@ requests==2.31.0
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
-ujson==5.8.0
+ujson==5.12.1
 urllib3==1.26.16
 websocket-client==1.6.3


### PR DESCRIPTION
## Summary
Fixes CVE-2026-44660 by updating ujson from 5.8.0 to 5.12.1.

## CVE Details
**CVE-2026-44660**: UltraJSON Memory leak leading to Denial of Service

When ujson.dump() writes to a file-like object and the write operation raises an exception, the serialized JSON string object is not decremented, leaking memory. Each failed write operation leaks the full size of the serialized payload. This vulnerability is fixed in 5.12.1.

## Changes
- Updated `examples/python/requirements.txt`: ujson==5.8.0 → ujson==5.12.1

## Affected Components
- mta-generic-external-provider-rhel9

## Jira Tickets
- Resolves: MTA-7054

## Test Plan
- [ ] Verify Python provider still functions correctly
- [ ] Confirm no regression in example tests

## Target Versions
- main (for backport to mta-8.1.4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned `ujson` dependency to version 5.12.1 in the Python example requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->